### PR TITLE
Hide Purpur's configurable seeds in timings reports

### DIFF
--- a/patches/server/0120-Hide-Purpurs-configurable-seeds-in-timings.patch
+++ b/patches/server/0120-Hide-Purpurs-configurable-seeds-in-timings.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nitricspace <nitricspace@users.noreply.github.com>
+Date: Sat, 1 Aug 2020 21:37:20 +0100
+Subject: [PATCH] Hide Purpurs configurable seeds in timings
+
+
+diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+index cd524cabc..2e75ad1a7 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+@@ -1,5 +1,6 @@
+ package net.pl3x.purpur;
+ 
++import co.aikar.timings.TimingsManager;
+ import com.google.common.base.Throwables;
+ import net.minecraft.server.MinecraftServer;
+ import net.pl3x.purpur.command.PurpurCommand;
+@@ -147,6 +148,9 @@ public class PurpurConfig {
+     private static void seedSettings() {
+         dungeonSeed = getInt("settings.seed.dungeon", dungeonSeed);
+         endSpikeSeed = getInt("settings.seed.end-spike", endSpikeSeed);
++        TimingsManager.hiddenConfigs.add("settings.seed");
++        TimingsManager.hiddenConfigs.add("settings.seed.dungeon");
++        TimingsManager.hiddenConfigs.add("settings.seed.end-spike");
+     }
+ 
+     public static String serverModName = "Purpur";


### PR DESCRIPTION
This adds Purpur's seed settings to Aikar's set of values to be hidden from timings. Seems to make sense not to expose these as all other generator seeds are hidden, although end spikes aren't a concern there is a possibility knowing Purpur's dungeon seed could be abused from what I can tell.