### PR TITLE
Customizable WitherBoss Health and Healing

### DIFF
--- a/patches/server/0134-Customizable-WitherBoss-Health-and-Healing.patch
+++ b/patches/server/0134-Customizable-WitherBoss-Health-and-Healing.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Thu, 20 Aug 2020 17:38:12 -0700
+Subject: [PATCH] Customizable WitherBoss Health and Healing
+
+Adds the ability to customize the health of the Wither Boss, as well as the amount that it heals, and how often in the PurpurWorldConfig.
+
+diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
+index 1511212cb..78a5449d1 100644
+--- a/src/main/java/net/minecraft/server/EntityWither.java
++++ b/src/main/java/net/minecraft/server/EntityWither.java
+@@ -36,6 +36,11 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
+     public EntityWither(EntityTypes<? extends EntityWither> entitytypes, World world) {
+         super(entitytypes, world);
+         this.bossBattle = (BossBattleServer) (new BossBattleServer(this.getScoreboardDisplayName(), BossBattle.BarColor.PURPLE, BossBattle.BarStyle.PROGRESS)).setDarkenSky(true);
++        // Purpur start
++        if (world != null) {
++            this.getAttributeInstance(GenericAttributes.MAX_HEALTH).setValue(world.purpurConfig.witherBossMaxHealth);
++        }
++        // Purpur end
+         this.setHealth(this.getMaxHealth());
+         this.getNavigation().d(true);
+         this.f = 50;
+@@ -230,7 +235,7 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
+ 
+             this.setInvul(i);
+             if (this.ticksLived % 10 == 0) {
+-                this.heal(10.0F, EntityRegainHealthEvent.RegainReason.WITHER_SPAWN); // CraftBukkit
++                this.heal(this.getMaxHealth() / 33, EntityRegainHealthEvent.RegainReason.WITHER_SPAWN); // CraftBukkit // Purpur - use max health for healing instead of a constant
+             }
+ 
+         } else {
+@@ -339,9 +344,11 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
+                 }
+             }
+ 
+-            if (this.ticksLived % 20 == 0) {
+-                this.heal(1.0F, EntityRegainHealthEvent.RegainReason.REGEN); // CraftBukkit
++            // Purpur start - customizable heal rate and amount
++            if (this.ticksLived % world.purpurConfig.witherBossHealthRegenDelay == 0) {
++                this.heal(world.purpurConfig.witherBossHealthRegenAmount, EntityRegainHealthEvent.RegainReason.REGEN); // CraftBukkit
+             }
++            // Purpur end
+ 
+             this.bossBattle.setProgress(this.getHealth() / this.getMaxHealth());
+         }
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index d19c6d13c..aaf1735e6 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -887,6 +887,15 @@ public class PurpurWorldConfig {
+         witherSkeletonTakesWitherDamage = getBoolean("mobs.wither_skeleton.takes-wither-damage", witherSkeletonTakesWitherDamage);
+     }
+ 
++    public double witherBossMaxHealth = 300.0D;
++    public float witherBossHealthRegenAmount = 1.0f;
++    public int witherBossHealthRegenDelay = 20;
++    private void witherSettings() {
++        witherBossMaxHealth = getDouble("mobs.wither_boss.max-health", witherBossMaxHealth);
++        witherBossHealthRegenAmount = (float) getDouble("mobs.wither_boss.health-regen-amount", witherBossHealthRegenAmount);
++        witherBossHealthRegenDelay = getInt("mobs.wither_boss.health-regen-delay", witherBossHealthRegenDelay);
++    }
++
+     public boolean wolfRidable = false;
+     public boolean wolfRidableInWater = false;
+     private void wolfSettings() {


### PR DESCRIPTION
Adds the ability to customize the health of the Wither Boss, as well as the amount that it heals, and how often in the PurpurWorldConfig.