### PR TITLE
Fix the raid cooldown patch

### DIFF
--- a/patches/server/0127-Raid-cooldown-setting.patch
+++ b/patches/server/0127-Raid-cooldown-setting.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: jmp <jasonpenilla2@me.com>
-Date: Sun, 23 Aug 2020 17:26:39 -0700
+Date: Thu, 27 Aug 2020 13:48:52 -0700
 Subject: [PATCH] Raid cooldown setting
 
 
 diff --git a/src/main/java/net/minecraft/server/PersistentRaid.java b/src/main/java/net/minecraft/server/PersistentRaid.java
-index b46b20cae..89be52ca1 100644
+index b46b20cae8..e7aee30555 100644
 --- a/src/main/java/net/minecraft/server/PersistentRaid.java
 +++ b/src/main/java/net/minecraft/server/PersistentRaid.java
 @@ -9,6 +9,7 @@ import javax.annotation.Nullable;
@@ -34,24 +34,25 @@ index b46b20cae..89be52ca1 100644
          Iterator iterator = this.raids.values().iterator();
  
          while (iterator.hasNext()) {
-@@ -67,6 +79,15 @@ public class PersistentRaid extends PersistentBase {
-             if (!dimensionmanager.hasRaids()) {
-                 return null;
-             } else {
-+                // Purpur start
-+                if (b.purpurConfig.raidCooldownSeconds != 0) {
-+                    if (!playerCooldowns.containsKey(entityplayer.getUniqueID())) {
+@@ -110,10 +122,15 @@ public class PersistentRaid extends PersistentBase {
+ 
+                 if (flag) {
+                     // CraftBukkit start
+-                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callRaidTriggerEvent(raid, entityplayer)) {
++                    if ((b.purpurConfig.raidCooldownSeconds != 0 && playerCooldowns.containsKey(entityplayer.getUniqueID())) || !org.bukkit.craftbukkit.event.CraftEventFactory.callRaidTriggerEvent(raid, entityplayer)) { // Purpur
+                         entityplayer.removeEffect(MobEffects.BAD_OMEN);
+                         return null;
+                     }
++                    // Purpur start
++                    if (b.purpurConfig.raidCooldownSeconds != 0) {
 +                        playerCooldowns.put(entityplayer.getUniqueID(), b.purpurConfig.raidCooldownSeconds);
-+                    } else {
-+                        return null;
 +                    }
-+                }
-+                // Purpur end
-                 BlockPosition blockposition = entityplayer.getChunkCoordinates();
-                 List<VillagePlaceRecord> list = (List) this.b.y().c(VillagePlaceType.b, blockposition, 64, VillagePlace.Occupancy.IS_OCCUPIED).collect(Collectors.toList());
-                 int i = 0;
++                    // Purpur end
+ 
+                     if (!this.raids.containsKey(raid.getId())) {
+                         this.raids.put(raid.getId(), raid);
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 755a46ee8..54e460ca8 100644
+index 755a46ee8b..54e460ca8e 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -155,6 +155,7 @@ public class PurpurWorldConfig {


### PR DESCRIPTION
This changes the raid cooldown patch to consume the player's bad omen if they attempt to start another raid while the cooldown is still active. This makes it so raid farms will break from this patch instead of just being slowed down.