### PR TITLE
Despawn rate for llama spit

### DIFF
--- a/patches/server/0127-Despawn-rate-config-options-per-projectile-type.patch
+++ b/patches/server/0127-Despawn-rate-config-options-per-projectile-type.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Despawn rate config options per projectile type
 Default values of -1 respect vanilla behaviour.
 
 diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
-index b0218959a..cecaa6e70 100644
+index b0218959a0..cecaa6e70e 100644
 --- a/src/main/java/net/minecraft/server/EntityArrow.java
 +++ b/src/main/java/net/minecraft/server/EntityArrow.java
 @@ -23,7 +23,7 @@ public abstract class EntityArrow extends IProjectile {
@@ -48,7 +48,7 @@ index b0218959a..cecaa6e70 100644
  
      private void A() {
 diff --git a/src/main/java/net/minecraft/server/EntityDragonFireball.java b/src/main/java/net/minecraft/server/EntityDragonFireball.java
-index 27032abad..9d2d5be5e 100644
+index 27032abad4..9d2d5be5ee 100644
 --- a/src/main/java/net/minecraft/server/EntityDragonFireball.java
 +++ b/src/main/java/net/minecraft/server/EntityDragonFireball.java
 @@ -75,4 +75,11 @@ public class EntityDragonFireball extends EntityFireball {
@@ -64,7 +64,7 @@ index 27032abad..9d2d5be5e 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityEgg.java b/src/main/java/net/minecraft/server/EntityEgg.java
-index edce89169..4951abdfa 100644
+index edce89169b..4951abdfa1 100644
 --- a/src/main/java/net/minecraft/server/EntityEgg.java
 +++ b/src/main/java/net/minecraft/server/EntityEgg.java
 @@ -87,4 +87,11 @@ public class EntityEgg extends EntityProjectileThrowable {
@@ -80,7 +80,7 @@ index edce89169..4951abdfa 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityEnderPearl.java b/src/main/java/net/minecraft/server/EntityEnderPearl.java
-index 63b4a449b..e8650c1bf 100644
+index 63b4a449b5..e8650c1bfa 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderPearl.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderPearl.java
 @@ -106,4 +106,11 @@ public class EntityEnderPearl extends EntityProjectileThrowable {
@@ -96,7 +96,7 @@ index 63b4a449b..e8650c1bf 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityFireworks.java b/src/main/java/net/minecraft/server/EntityFireworks.java
-index 36729e478..a9418cbe3 100644
+index 36729e4783..a9418cbe36 100644
 --- a/src/main/java/net/minecraft/server/EntityFireworks.java
 +++ b/src/main/java/net/minecraft/server/EntityFireworks.java
 @@ -296,4 +296,11 @@ public class EntityFireworks extends IProjectile {
@@ -112,7 +112,7 @@ index 36729e478..a9418cbe3 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
-index b6cace72a..248429023 100644
+index b6cace72ab..2484290238 100644
 --- a/src/main/java/net/minecraft/server/EntityFishingHook.java
 +++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
 @@ -554,4 +554,11 @@ public class EntityFishingHook extends IProjectile {
@@ -128,7 +128,7 @@ index b6cace72a..248429023 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityLargeFireball.java b/src/main/java/net/minecraft/server/EntityLargeFireball.java
-index b4b0dfbc7..d12de20cf 100644
+index b4b0dfbc70..d12de20cf4 100644
 --- a/src/main/java/net/minecraft/server/EntityLargeFireball.java
 +++ b/src/main/java/net/minecraft/server/EntityLargeFireball.java
 @@ -66,4 +66,11 @@ public class EntityLargeFireball extends EntityFireballFireball {
@@ -143,8 +143,24 @@ index b4b0dfbc7..d12de20cf 100644
 +    }
 +    // Purpur end
  }
+diff --git a/src/main/java/net/minecraft/server/EntityLlamaSpit.java b/src/main/java/net/minecraft/server/EntityLlamaSpit.java
+index 29d1db053c..77925e9e16 100644
+--- a/src/main/java/net/minecraft/server/EntityLlamaSpit.java
++++ b/src/main/java/net/minecraft/server/EntityLlamaSpit.java
+@@ -71,4 +71,11 @@ public class EntityLlamaSpit extends IProjectile {
+     public Packet<?> P() {
+         return new PacketPlayOutSpawnEntity(this);
+     }
++
++    // Purpur start
++    @Override
++    protected int getPurpurDespawnRate() {
++        return this.world.purpurConfig.llamaSpitDespawnRate;
++    }
++    // Purpur end
+ }
 diff --git a/src/main/java/net/minecraft/server/EntityPotion.java b/src/main/java/net/minecraft/server/EntityPotion.java
-index c7416602c..b189e2d8e 100644
+index c7416602c1..b189e2d8e9 100644
 --- a/src/main/java/net/minecraft/server/EntityPotion.java
 +++ b/src/main/java/net/minecraft/server/EntityPotion.java
 @@ -240,4 +240,11 @@ public class EntityPotion extends EntityProjectileThrowable {
@@ -160,7 +176,7 @@ index c7416602c..b189e2d8e 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityShulkerBullet.java b/src/main/java/net/minecraft/server/EntityShulkerBullet.java
-index 226b34643..b482dce83 100644
+index 226b346436..b482dce83b 100644
 --- a/src/main/java/net/minecraft/server/EntityShulkerBullet.java
 +++ b/src/main/java/net/minecraft/server/EntityShulkerBullet.java
 @@ -313,4 +313,11 @@ public class EntityShulkerBullet extends IProjectile {
@@ -176,7 +192,7 @@ index 226b34643..b482dce83 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntitySmallFireball.java b/src/main/java/net/minecraft/server/EntitySmallFireball.java
-index 92efb2953..f884e4cf7 100644
+index 92efb29534..f884e4cf7a 100644
 --- a/src/main/java/net/minecraft/server/EntitySmallFireball.java
 +++ b/src/main/java/net/minecraft/server/EntitySmallFireball.java
 @@ -88,4 +88,11 @@ public class EntitySmallFireball extends EntityFireballFireball {
@@ -192,7 +208,7 @@ index 92efb2953..f884e4cf7 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntitySnowball.java b/src/main/java/net/minecraft/server/EntitySnowball.java
-index e44249f59..34a5f481e 100644
+index e44249f59b..34a5f481e6 100644
 --- a/src/main/java/net/minecraft/server/EntitySnowball.java
 +++ b/src/main/java/net/minecraft/server/EntitySnowball.java
 @@ -14,6 +14,12 @@ public class EntitySnowball extends EntityProjectileThrowable {
@@ -209,7 +225,7 @@ index e44249f59..34a5f481e 100644
      protected Item getDefaultItem() {
          return Items.SNOWBALL;
 diff --git a/src/main/java/net/minecraft/server/EntityThrownExpBottle.java b/src/main/java/net/minecraft/server/EntityThrownExpBottle.java
-index 2d3ca8c42..1d32518bd 100644
+index 2d3ca8c424..1d32518bd7 100644
 --- a/src/main/java/net/minecraft/server/EntityThrownExpBottle.java
 +++ b/src/main/java/net/minecraft/server/EntityThrownExpBottle.java
 @@ -51,4 +51,11 @@ public class EntityThrownExpBottle extends EntityProjectileThrowable {
@@ -225,7 +241,7 @@ index 2d3ca8c42..1d32518bd 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityWitherSkull.java b/src/main/java/net/minecraft/server/EntityWitherSkull.java
-index 2c02e114c..4a97a7517 100644
+index 2c02e114cc..4a97a7517d 100644
 --- a/src/main/java/net/minecraft/server/EntityWitherSkull.java
 +++ b/src/main/java/net/minecraft/server/EntityWitherSkull.java
 @@ -116,4 +116,11 @@ public class EntityWitherSkull extends EntityFireball {
@@ -241,7 +257,7 @@ index 2c02e114c..4a97a7517 100644
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/IProjectile.java b/src/main/java/net/minecraft/server/IProjectile.java
-index 9a17eb606..f0b898289 100644
+index 9a17eb6066..f0b8982893 100644
 --- a/src/main/java/net/minecraft/server/IProjectile.java
 +++ b/src/main/java/net/minecraft/server/IProjectile.java
 @@ -13,6 +13,7 @@ public abstract class IProjectile extends Entity {
@@ -284,10 +300,10 @@ index 9a17eb606..f0b898289 100644
  
      public boolean checkIfLeftOwner() { return this.h(); } // Purpur - OBFHELPER
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 423593ae6..ab7105851 100644
+index 423593ae66..67b8996671 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-@@ -145,6 +145,33 @@ public class PurpurWorldConfig {
+@@ -145,6 +145,35 @@ public class PurpurWorldConfig {
          idleTimeoutUpdateTabList = getBoolean("gameplay-mechanics.player.idle-timeout.update-tab-list", idleTimeoutUpdateTabList);
      }
  
@@ -298,6 +314,7 @@ index 423593ae6..ab7105851 100644
 +    public int fireworkDespawnRate = -1;
 +    public int fishingHookDespawnRate = -1;
 +    public int largeFireballDespawnRate = -1;
++    public int llamaSpitDespawnRate = -1;
 +    public int potionDespawnRate = -1;
 +    public int shulkerBulletDespawnRate = -1;
 +    public int smallFireballDespawnRate = -1;
@@ -311,6 +328,7 @@ index 423593ae6..ab7105851 100644
 +        fireworkDespawnRate = getInt("gameplay-mechanics.projectile-despawn-rates.firework_rocket", fireworkDespawnRate);
 +        fishingHookDespawnRate = getInt("gameplay-mechanics.projectile-despawn-rates.fishing_bobber", fishingHookDespawnRate);
 +        largeFireballDespawnRate = getInt("gameplay-mechanics.projectile-despawn-rates.fireball", largeFireballDespawnRate);
++        llamaSpitDespawnRate = getInt("gameplay-mechanics.projectile-despawn-rates.llama_spit", llamaSpitDespawnRate);
 +        potionDespawnRate = getInt("gameplay-mechanics.projectile-despawn-rates.potion", potionDespawnRate);
 +        shulkerBulletDespawnRate = getInt("gameplay-mechanics.projectile-despawn-rates.shulker_bullet", shulkerBulletDespawnRate);
 +        smallFireballDespawnRate = getInt("gameplay-mechanics.projectile-despawn-rates.small_fireball", smallFireballDespawnRate);


### PR DESCRIPTION
I originally left llama spit out as they tend to despawn right away anyways, but making getPurpurDespawnRate abstract means  we have to implement it. Fixes #68 