### PR TITLE
Add option to disable zombies pathfinding to villagers only when lagging

### DIFF
--- a/patches/api/0031-Add-option-to-disable-zombie-aggressiveness-towards-.patch
+++ b/patches/api/0031-Add-option-to-disable-zombie-aggressiveness-towards-.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nitricspace <nitricspace@users.noreply.github.com>
+Date: Wed, 23 Sep 2020 22:14:38 +0100
+Subject: [PATCH] Add option to disable zombie aggressiveness towards villagers
+ when lagging
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
+index 83c51bb5..b77aff57 100644
+--- a/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
++++ b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
+@@ -209,5 +209,7 @@ public interface VanillaGoal<T extends Mob> extends Goal<T> {
+     // Purpur start
+     GoalKey<Phantom> FIND_CRYSTAL_GOAL = GoalKey.of(Phantom.class, NamespacedKey.minecraft("find_crystal_goal"));
+     GoalKey<Phantom> ORBIT_CRYSTAL_GOAL = GoalKey.of(Phantom.class, NamespacedKey.minecraft("orbit_crystal_goal"));
++    GoalKey<Drowned> DROWNED_ATTACK_VILLAGER = GoalKey.of(Drowned.class, NamespacedKey.minecraft("drowned_attack_villager"));
++    GoalKey<Zombie> ZOMBIE_ATTACK_VILLAGER = GoalKey.of(Zombie.class, NamespacedKey.minecraft("zombie_attack_villager"));
+     // Purpur end
+ }

--- a/patches/server/0130-Add-option-to-disable-zombie-aggressiveness-towards-.patch
+++ b/patches/server/0130-Add-option-to-disable-zombie-aggressiveness-towards-.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: nitricspace <nitricspace@users.noreply.github.com>
+Date: Mon, 21 Sep 2020 23:19:43 +0100
+Subject: [PATCH] Add option to disable zombie aggressiveness towards villagers
+ when lagging
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
+index 89b56de75..ded483ace 100644
+--- a/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
++++ b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
+@@ -131,6 +131,10 @@ public class MobGoalHelper {
+         deobfuscationMap.put("wither_a", "wither_do_nothing");
+         deobfuscationMap.put("wolf_a", "wolf_avoid_entity");
+         deobfuscationMap.put("zombie_a", "zombie_attack_turtle_egg");
++        // Purpur start
++        deobfuscationMap.put("zombie_1", "zombie_attack_villager");
++        deobfuscationMap.put("drowned_1", "drowned_attack_villager");
++        // Purpur end
+ 
+         ignored.add("selector_1");
+         ignored.add("selector_2");
+diff --git a/src/main/java/net/minecraft/server/EntityDrowned.java b/src/main/java/net/minecraft/server/EntityDrowned.java
+index 8aa53c617..1b75a2ff5 100644
+--- a/src/main/java/net/minecraft/server/EntityDrowned.java
++++ b/src/main/java/net/minecraft/server/EntityDrowned.java
+@@ -58,7 +58,16 @@ public class EntityDrowned extends EntityZombie implements IRangedEntity {
+         this.goalSelector.a(7, new PathfinderGoalRandomStroll(this, 1.0D));
+         this.targetSelector.a(1, (new PathfinderGoalHurtByTarget(this, new Class[]{EntityDrowned.class})).a(EntityPigZombie.class));
+         this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, 10, true, false, this::i));
+-        if ( world.spigotConfig.zombieAggressiveTowardsVillager ) this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, false)); // Paper
++        if ( world.spigotConfig.zombieAggressiveTowardsVillager ) this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<EntityVillagerAbstract>(this, EntityVillagerAbstract.class, false) { // Spigot  // Purpur start
++            @Override
++            public boolean a() {
++                return (world.purpurConfig.zombieAggressiveTowardsVillagerWhenLagging || !world.getMinecraftServer().server.isLagging()) && super.a();
++            }
++            @Override
++            public boolean b() {
++                return (world.purpurConfig.zombieAggressiveTowardsVillagerWhenLagging || !world.getMinecraftServer().server.isLagging()) && super.b();
++            }
++        }); // Purpur end
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+         this.targetSelector.a(5, new PathfinderGoalNearestAttackableTarget<>(this, EntityTurtle.class, 10, true, false, EntityTurtle.bo));
+     }
+diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
+index d08747c66..bcb5ddcaa 100644
+--- a/src/main/java/net/minecraft/server/EntityZombie.java
++++ b/src/main/java/net/minecraft/server/EntityZombie.java
+@@ -11,7 +11,7 @@ import java.util.function.Predicate;
+ import javax.annotation.Nullable;
+ 
+ // CraftBukkit start
+-import org.bukkit.craftbukkit.event.CraftEventFactory;
++import org.bukkit.entity.LivingEntity;
+ import org.bukkit.entity.Zombie;
+ import org.bukkit.event.entity.CreatureSpawnEvent;
+ import org.bukkit.event.entity.EntityCombustByEntityEvent;
+@@ -85,7 +85,16 @@ public class EntityZombie extends EntityMonster {
+         this.goalSelector.a(7, new PathfinderGoalRandomStrollLand(this, 1.0D));
+         this.targetSelector.a(1, (new PathfinderGoalHurtByTarget(this, new Class[0])).a(EntityPigZombie.class));
+         this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true));
+-        if ( world.spigotConfig.zombieAggressiveTowardsVillager ) this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, false)); // Spigot
++        if ( world.spigotConfig.zombieAggressiveTowardsVillager ) this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<EntityVillagerAbstract>(this, EntityVillagerAbstract.class, false) { // Spigot // Purpur start
++            @Override
++            public boolean a() {
++                return (world.purpurConfig.zombieAggressiveTowardsVillagerWhenLagging || !world.getMinecraftServer().server.isLagging()) && super.a();
++            }
++            @Override
++            public boolean b() {
++                return (world.purpurConfig.zombieAggressiveTowardsVillagerWhenLagging || !world.getMinecraftServer().server.isLagging()) && super.b();
++            }
++        }); // Purpur end
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+         this.targetSelector.a(5, new PathfinderGoalNearestAttackableTarget<>(this, EntityTurtle.class, 10, true, false, EntityTurtle.bo));
+     }
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 67b899667..d0fe5f751 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -998,12 +998,14 @@ public class PurpurWorldConfig {
+     public boolean zombieJockeyOnlyBaby = true;
+     public double zombieJockeyChance = 0.05D;
+     public boolean zombieJockeyTryExistingChickens = true;
++    public boolean zombieAggressiveTowardsVillagerWhenLagging = true;
+     private void zombieSettings() {
+         zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
+         zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
+         zombieJockeyOnlyBaby = getBoolean("mobs.zombie.jockey.only-babies", zombieJockeyOnlyBaby);
+         zombieJockeyChance = getDouble("mobs.zombie.jockey.chance", zombieJockeyChance);
+         zombieJockeyTryExistingChickens = getBoolean("mobs.zombie.jockey.try-existing-chickens", zombieJockeyTryExistingChickens);
++        zombieAggressiveTowardsVillagerWhenLagging = getBoolean("mobs.zombie.aggressive-towards-villager-when-lagging", zombieAggressiveTowardsVillagerWhenLagging);
+     }
+ 
+     public boolean zombieHorseCanSwim = false;


### PR DESCRIPTION
I found disabling this feature reduced the impact of zombies on my server by 10-15%, but I do have a lot of zombies and villagers. However, it does break some vanilla gameplay such as the zombification of villagers. This patch uses Purpur's lagging threshold in the same way as the villager brainticks patch to remove the impact on gameplay while the server isn't lagging.

I imagine this could be useful for other survival servers with lots of these entities, it has been really beneficial for my server.