### PR TITLE
Create PR Build

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,41 @@
+name: PR Build
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        java: [11, 8]
+
+    steps:
+    - uses: actions/checkout@v2.1.0
+
+    - name: Get PR info
+      run: echo ::set-env name=PR::$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1.3.0
+      with:
+        java-version: ${{ matrix.java }}
+
+    - uses: actions/cache@v1.1.2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-maven-
+
+    - name: Patch Purpur
+      run: |
+        git config --global user.email "purpur-pr@example.com"
+        git config --global user.name "Pupur PR"
+        git submodule update --init --recursive
+        ./purpur jar
+        
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Purpur-PR${{ env.PR }}-JDK${{ matrix.java }}
+        path: purpurclip.jar


### PR DESCRIPTION
Using GitHub actions, create an action that runs when a new pr is submitted or new commits are added. This is useful for when someone is building and it errors on their machine only, they will be able to test and other people will be able to receive the jar that came from the changes. This closes #81.