### PR TITLE
Fix client lag on advancement loading

### DIFF
--- a/patches/server/0130-PaperPR-Fix-client-lag-on-advancement-loading.patch
+++ b/patches/server/0130-PaperPR-Fix-client-lag-on-advancement-loading.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Sat, 31 Oct 2020 11:49:01 -0700
+Subject: [PATCH] PaperPR - Fix client lag on advancement loading
+
+When new advancements are added via the UnsafeValues#loadAdvancement
+API, it triggers a full datapack reload when this is not necessary. The
+advancement is already loaded directly into the advancement registry,
+and the point of saving the advancement to the Bukkit datapack seems to
+be for persistence. By removing the call to reload datapacks when an
+advancement is loaded, the client no longer completely freezes up when
+adding a new advancement.
+To ensure the client still receives the updated advancement data, we
+manually reload the advancement data for all players, which
+normally takes place as a part of the datapack reloading.
+
+diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+index c31f4040c..eaa1063ff 100644
+--- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
++++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+@@ -78,6 +78,7 @@ public class AdvancementDataPlayer {
+ 
+     }
+ 
++    public final void reload(AdvancementDataWorld advancementDataWorld) { this.a(advancementDataWorld); } // Paper - OBFHELPER
+     public void a(AdvancementDataWorld advancementdataworld) {
+         this.a();
+         this.data.clear();
+@@ -375,6 +376,7 @@ public class AdvancementDataPlayer {
+ 
+     }
+ 
++    public final void sendUpdateIfNeeded(EntityPlayer entityPlayer) { this.b(entityPlayer); } // Paper - OBFHELPER
+     public void b(EntityPlayer entityplayer) {
+         if (this.m || !this.i.isEmpty() || !this.j.isEmpty()) {
+             Map<MinecraftKey, AdvancementProgress> map = Maps.newHashMap();
+diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+index d33d24af6..0105382ee 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+@@ -230,4 +230,9 @@ public class PurpurConfig {
+     private static void tpsCatchup() {
+         tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
+     }
++
++    public static boolean fixClientAdvancementLag = false;
++    private static void fixClientAdvancementLag() {
++        fixClientAdvancementLag = getBoolean("settings.fix-client-lag-from-advancements-api", fixClientAdvancementLag);
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 63bfd1c70..aac30af6e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -282,7 +282,16 @@ public final class CraftMagicNumbers implements UnsafeValues {
+                     Bukkit.getLogger().log(Level.SEVERE, "Error saving advancement " + key, ex);
+                 }
+ 
+-                MinecraftServer.getServer().getPlayerList().reload();
++                // Paper start
++                if (net.pl3x.purpur.PurpurConfig.fixClientAdvancementLag) {
++                    MinecraftServer.getServer().getPlayerList().getPlayers().forEach(player -> {
++                        player.getAdvancementData().reload(MinecraftServer.getServer().getAdvancementData());
++                        player.getAdvancementData().sendUpdateIfNeeded(player);
++                    });
++                } else {
++                    MinecraftServer.getServer().getPlayerList().reload();
++                }
++                // Paper end
+ 
+                 return bukkit;
+             }


### PR DESCRIPTION
When new advancements are added via the UnsafeValues#loadAdvancement
API, it triggers a full datapack reload when this is not necessary. The
advancement is already loaded directly into the advancement registry,
and the point of saving the advancement to the Bukkit datapack seems to
be for persistence. By removing the call to reload datapacks when an
advancement is loaded, the client no longer completely freezes up when
adding a new advancement.

edit: I also opened this PR upstream, so don't merge for now