### PR TITLE
Fix allowing color codes in signs

### DIFF
--- a/patches/server/0052-Signs-allow-color-codes.patch
+++ b/patches/server/0052-Signs-allow-color-codes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Signs allow color codes
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 1360127549..e917b302af 100644
+index 136012754..e917b302a 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1247,6 +1247,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -17,28 +17,26 @@ index 1360127549..e917b302af 100644
          this.playerConnection.sendPacket(new PacketPlayOutOpenSignEditor(tileentitysign.getPosition()));
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 294ce7b086..1c98fb0c72 100644
+index 294ce7b08..11ad2830f 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2815,7 +2815,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2815,6 +2815,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      }
                  }
                  // Paper end
--                lines[i] = SharedConstants.filterAllowedChatCharacters(currentLine); // Paper - Replaced with anvil color stripping method to stop exploits that allow colored signs to be created.
-+                // Paper TODO(Proximyst): Add obfhelper when 1.16.4 runs
 +                // Purpur start
 +                if (worldserver.purpurConfig.signAllowColors) {
-+                    if (player.hasPermission("purpur.sign.color")) currentLine = currentLine.replaceAll("(?i)&([0-9a-fr])", "\u00a7$1");
-+                    if (player.hasPermission("purpur.sign.style")) currentLine = currentLine.replaceAll("(?i)&([l-or])", "\u00a7$1");
-+                    if (player.hasPermission("purpur.sign.magic")) currentLine = currentLine.replaceAll("(?i)&([kr])", "\u00a7$1");
++                    lines[i] = currentLine;
++                    if (player.hasPermission("purpur.sign.color")) lines[i] = lines[i].replaceAll("(?i)&([0-9a-fr])", "\u00a7$1");
++                    if (player.hasPermission("purpur.sign.style")) lines[i] = lines[i].replaceAll("(?i)&([l-or])", "\u00a7$1");
++                    if (player.hasPermission("purpur.sign.magic")) lines[i] = lines[i].replaceAll("(?i)&([kr])", "\u00a7$1");
 +                } else
 +                // Purpur end
-+                    lines[i] = SharedConstants.filterAllowedChatCharacters(currentLine); // Paper - Replaced with anvil color stripping method to stop exploits that allow colored signs to be created.
+                 lines[i] = SharedConstants.filterAllowedChatCharacters(currentLine); // Paper - Replaced with anvil color stripping method to stop exploits that allow colored signs to be created.
              }
              SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.server.getPlayer(this.player), lines);
-             this.server.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/server/TileEntitySign.java b/src/main/java/net/minecraft/server/TileEntitySign.java
-index 3167669702..852bb5db84 100644
+index 316766970..852bb5db8 100644
 --- a/src/main/java/net/minecraft/server/TileEntitySign.java
 +++ b/src/main/java/net/minecraft/server/TileEntitySign.java
 @@ -93,6 +93,18 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
@@ -61,7 +59,7 @@ index 3167669702..852bb5db84 100644
      @Override
      public PacketPlayOutTileEntityData getUpdatePacket() {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index f14e883133..bc5cba3074 100644
+index f14e88313..bc5cba307 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -109,8 +109,10 @@ public class PurpurWorldConfig {


### PR DESCRIPTION
Fixes sign text not being set properly (signs are blank, plugins give NPE on SignChangeEvent) when allow color codes in signs is enabled.