### PR TITLE
Add adjustable breeding cooldown to config

### DIFF
--- a/patches/server/0139-Add-adjustable-breeding-cooldown-to-config.patch
+++ b/patches/server/0139-Add-adjustable-breeding-cooldown-to-config.patch
@@ -5,27 +5,21 @@ Subject: [PATCH] Add adjustable breeding cooldown to config
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityAnimal.java b/src/main/java/net/minecraft/server/EntityAnimal.java
-index bba343542..153fbcc3c 100644
+index bba343542..895a31dd5 100644
 --- a/src/main/java/net/minecraft/server/EntityAnimal.java
 +++ b/src/main/java/net/minecraft/server/EntityAnimal.java
-@@ -212,6 +212,23 @@ public abstract class EntityAnimal extends EntityAgeable {
+@@ -212,6 +212,17 @@ public abstract class EntityAnimal extends EntityAgeable {
              if (entityplayer == null && entityanimal.getBreedCause() != null) {
                  entityplayer = entityanimal.getBreedCause();
              }
 +            // Purpur start
-+            if (entityplayer != null && entityageable.canBreed()) {
-+                if (playerBreedCooldowns.getOrDefault(entityplayer.getUniqueID(), 0L) > System.currentTimeMillis()) {
++            if (entityplayer != null && worldserver.purpurConfig.breedCooldownSeconds > 0) {
++                long now = System.currentTimeMillis();
++                Long cooldown = playerBreedCooldowns.get(entityplayer.getUniqueID());
++                if (cooldown != null && cooldown > now) {
 +                    return;
 +                }
-+                playerBreedCooldowns.remove(entityplayer.getUniqueID());
-+
-+                int breedSec = worldserver.purpurConfig.breedCooldownSeconds;
-+                if (breedSec != 0) {
-+                    java.util.Calendar cal = java.util.Calendar.getInstance();
-+                    cal.setTime(new java.util.Date());
-+                    cal.set(java.util.Calendar.SECOND, cal.get(java.util.Calendar.SECOND) + breedSec);
-+                    playerBreedCooldowns.put(entityplayer.getUniqueID(), cal.getTimeInMillis());
-+                }
++                playerBreedCooldowns.put(entityplayer.getUniqueID(), now + (worldserver.purpurConfig.breedCooldownSeconds * 1000));
 +            }
 +            // Purpur end
 +

--- a/patches/server/0139-Add-adjustable-breeding-cooldown-to-config.patch
+++ b/patches/server/0139-Add-adjustable-breeding-cooldown-to-config.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: montlikadani <montlikada@gmail.com>
+Date: Fri, 13 Nov 2020 17:52:40 +0100
+Subject: [PATCH] Add adjustable breeding cooldown to config
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityAnimal.java b/src/main/java/net/minecraft/server/EntityAnimal.java
+index bba343542..153fbcc3c 100644
+--- a/src/main/java/net/minecraft/server/EntityAnimal.java
++++ b/src/main/java/net/minecraft/server/EntityAnimal.java
+@@ -212,6 +212,23 @@ public abstract class EntityAnimal extends EntityAgeable {
+             if (entityplayer == null && entityanimal.getBreedCause() != null) {
+                 entityplayer = entityanimal.getBreedCause();
+             }
++            // Purpur start
++            if (entityplayer != null && entityageable.canBreed()) {
++                if (playerBreedCooldowns.getOrDefault(entityplayer.getUniqueID(), 0L) > System.currentTimeMillis()) {
++                    return;
++                }
++                playerBreedCooldowns.remove(entityplayer.getUniqueID());
++
++                int breedSec = worldserver.purpurConfig.breedCooldownSeconds;
++                if (breedSec != 0) {
++                    java.util.Calendar cal = java.util.Calendar.getInstance();
++                    cal.setTime(new java.util.Date());
++                    cal.set(java.util.Calendar.SECOND, cal.get(java.util.Calendar.SECOND) + breedSec);
++                    playerBreedCooldowns.put(entityplayer.getUniqueID(), cal.getTimeInMillis());
++                }
++            }
++            // Purpur end
++
+             // CraftBukkit start - call EntityBreedEvent
+             int experience = this.getRandom().nextInt(7) + 1;
+             org.bukkit.event.entity.EntityBreedEvent entityBreedEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityBreedEvent(entityageable, this, entityanimal, entityplayer, this.breedItem, experience);
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index c33909e20..afe52c0b4 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -61,6 +61,7 @@ public abstract class EntityLiving extends Entity {
+     private final AttributeMapBase attributeMap;
+     public CombatTracker combatTracker = new CombatTracker(this);
+     public final Map<MobEffectList, MobEffect> effects = Maps.newHashMap();
++    public final Map<UUID, Long> playerBreedCooldowns = Maps.newHashMap(); // Purpur
+     private final NonNullList<ItemStack> bn;
+     private final NonNullList<ItemStack> bo;
+     public boolean ai;
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index e080aa482..cecf5c4cb 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -204,6 +204,7 @@ public class PurpurWorldConfig {
+     public double tridentLoyaltyVoidReturnHeight = 0.0D;
+     public double voidDamageHeight = -64.0D;
+     public int raidCooldownSeconds = 0;
++    public int breedCooldownSeconds = 0;
+     private void miscGameplayMechanicsSettings() {
+         useBetterMending = getBoolean("gameplay-mechanics.use-better-mending", useBetterMending);
+         boatEjectPlayersOnLand = getBoolean("gameplay-mechanics.boat.eject-players-on-land", boatEjectPlayersOnLand);
+@@ -217,6 +218,7 @@ public class PurpurWorldConfig {
+         tridentLoyaltyVoidReturnHeight = getDouble("gameplay-mechanics.trident-loyalty-void-return-height", tridentLoyaltyVoidReturnHeight);
+         voidDamageHeight = getDouble("gameplay-mechanics.void-damage-height", voidDamageHeight);
+         raidCooldownSeconds = getInt("gameplay-mechanics.raid-cooldown-seconds", raidCooldownSeconds);
++        breedCooldownSeconds = getInt("gameplay-mechanics.breed-cooldown-seconds", breedCooldownSeconds);
+     }
+ 
+     public boolean catSpawning;


### PR DESCRIPTION
This patch literally not the best implementation, because the cooldown is implemented with NBTs, but if we want this, we should extend the EntityAnimal to PersistentBase. I'm unsure we can do this way. Also this option is not per-mob handled, it is for global, but for each player.

Related #85 