### PR TITLE
Breeding configuration patches

### DIFF
--- a/patches/server/0139-Add-adjustable-breeding-cooldown-to-config.patch
+++ b/patches/server/0139-Add-adjustable-breeding-cooldown-to-config.patch
@@ -1,0 +1,131 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: montlikadani <montlikada@gmail.com>
+Date: Fri, 13 Nov 2020 17:52:40 +0100
+Subject: [PATCH] Add adjustable breeding cooldown to config
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityAnimal.java b/src/main/java/net/minecraft/server/EntityAnimal.java
+index bba343542..0b3d0c84f 100644
+--- a/src/main/java/net/minecraft/server/EntityAnimal.java
++++ b/src/main/java/net/minecraft/server/EntityAnimal.java
+@@ -120,7 +120,10 @@ public abstract class EntityAnimal extends EntityAgeable {
+         if (this.k(itemstack)) {
+             int i = this.getAge();
+ 
+-            if (!this.world.isClientSide && i == 0 && this.eP()) {
++            // Purpur start
++            if (!this.world.isClientSide && i == 0 && this.eP()
++                    && (this.world.purpurConfig.animalBreedingCooldownSeconds == 0 || !this.world.hasBreedingCooldown(entityhuman.getUniqueID(), this.getClass()))) {
++                // Purpur end
+                 this.a(entityhuman, itemstack);
+                 this.g(entityhuman);
+                 return EnumInteractionResult.SUCCESS;
+@@ -212,6 +215,14 @@ public abstract class EntityAnimal extends EntityAgeable {
+             if (entityplayer == null && entityanimal.getBreedCause() != null) {
+                 entityplayer = entityanimal.getBreedCause();
+             }
++            // Purpur start
++            if (entityplayer != null && worldserver.purpurConfig.animalBreedingCooldownSeconds != 0) {
++                if (worldserver.hasBreedingCooldown(entityplayer.getUniqueID(), this.getClass())) {
++                    return;
++                }
++                worldserver.addBreedingCooldown(entityplayer.getUniqueID(), this.getClass());
++            }
++            // Purpur end
+             // CraftBukkit start - call EntityBreedEvent
+             int experience = this.getRandom().nextInt(7) + 1;
+             org.bukkit.event.entity.EntityBreedEvent entityBreedEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityBreedEvent(entityageable, this, entityanimal, entityplayer, this.breedItem, experience);
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 281bba56e..d12b396bd 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -104,6 +104,49 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+     private int tileTickPosition;
+     public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
+     public java.util.ArrayDeque<BlockRedstoneTorch.RedstoneUpdateInfo> redstoneUpdateInfos; // Paper - Move from Map in BlockRedstoneTorch to here
++    // Purpur start
++    private com.google.common.cache.Cache<BreedingCooldownPair, Object> playerBreedingCooldowns;
++
++    private com.google.common.cache.Cache<BreedingCooldownPair, Object> getNewBreedingCooldownCache() {
++        return com.google.common.cache.CacheBuilder.newBuilder()
++                .expireAfterWrite(this.purpurConfig.animalBreedingCooldownSeconds, java.util.concurrent.TimeUnit.SECONDS).build();
++    }
++
++    public void resetBreedingCooldowns() {
++        this.playerBreedingCooldowns = this.getNewBreedingCooldownCache();
++    }
++
++    boolean hasBreedingCooldown(java.util.UUID player, Class<? extends EntityAnimal> animalType) {
++        return this.playerBreedingCooldowns.getIfPresent(new BreedingCooldownPair(player, animalType)) != null;
++    }
++
++    void addBreedingCooldown(java.util.UUID player, Class<? extends EntityAnimal> animalType) {
++        this.playerBreedingCooldowns.put(new BreedingCooldownPair(player, animalType), new Object());
++    }
++
++    private static final class BreedingCooldownPair {
++        private final java.util.UUID playerUUID;
++        private final Class<? extends EntityAnimal> animalType;
++
++        public BreedingCooldownPair(java.util.UUID playerUUID, Class<? extends EntityAnimal> animalType) {
++            this.playerUUID = playerUUID;
++            this.animalType = animalType;
++        }
++
++        @Override
++        public boolean equals(Object o) {
++            if (this == o) return true;
++            if (o == null || getClass() != o.getClass()) return false;
++            BreedingCooldownPair that = (BreedingCooldownPair) o;
++            return playerUUID.equals(that.playerUUID) && animalType.equals(that.animalType);
++        }
++
++        @Override
++        public int hashCode() {
++            return java.util.Objects.hash(playerUUID, animalType);
++        }
++    }
++    // Purpur end
+ 
+     public CraftWorld getWorld() {
+         return this.world;
+@@ -157,6 +200,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+         this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig((((WorldDataServer)worlddatamutable).getName()), this.spigotConfig); // Paper
+         this.tuinityConfig = new com.tuinity.tuinity.config.TuinityConfig.WorldConfig(((WorldDataServer)worlddatamutable).getName()); // Tuinity - Server Config
+         this.purpurConfig = new net.pl3x.purpur.PurpurWorldConfig(((WorldDataServer) worlddatamutable).getName(), env); // Purpur
++        this.playerBreedingCooldowns = this.getNewBreedingCooldownCache(); // Purpur
+         this.chunkPacketBlockController = this.paperConfig.antiXray ? new ChunkPacketBlockControllerAntiXray(this, executor) : ChunkPacketBlockController.NO_OPERATION_INSTANCE; // Paper - Anti-Xray
+         this.generator = gen;
+         this.world = new CraftWorld((WorldServer) this, gen, env);
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index e080aa482..9eeedb6e7 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -204,6 +204,7 @@ public class PurpurWorldConfig {
+     public double tridentLoyaltyVoidReturnHeight = 0.0D;
+     public double voidDamageHeight = -64.0D;
+     public int raidCooldownSeconds = 0;
++    public int animalBreedingCooldownSeconds = 0;
+     private void miscGameplayMechanicsSettings() {
+         useBetterMending = getBoolean("gameplay-mechanics.use-better-mending", useBetterMending);
+         boatEjectPlayersOnLand = getBoolean("gameplay-mechanics.boat.eject-players-on-land", boatEjectPlayersOnLand);
+@@ -217,6 +218,7 @@ public class PurpurWorldConfig {
+         tridentLoyaltyVoidReturnHeight = getDouble("gameplay-mechanics.trident-loyalty-void-return-height", tridentLoyaltyVoidReturnHeight);
+         voidDamageHeight = getDouble("gameplay-mechanics.void-damage-height", voidDamageHeight);
+         raidCooldownSeconds = getInt("gameplay-mechanics.raid-cooldown-seconds", raidCooldownSeconds);
++        animalBreedingCooldownSeconds = getInt("gameplay-mechanics.animal-breeding-cooldown-seconds", animalBreedingCooldownSeconds);
+     }
+ 
+     public boolean catSpawning;
+diff --git a/src/main/java/net/pl3x/purpur/command/PurpurCommand.java b/src/main/java/net/pl3x/purpur/command/PurpurCommand.java
+index 4904be939..860d07cd6 100644
+--- a/src/main/java/net/pl3x/purpur/command/PurpurCommand.java
++++ b/src/main/java/net/pl3x/purpur/command/PurpurCommand.java
+@@ -49,6 +49,7 @@ public class PurpurCommand extends Command {
+             PurpurConfig.init((File) console.options.valueOf("purpur-settings"));
+             for (WorldServer world : console.getWorlds()) {
+                 world.purpurConfig.init();
++                world.resetBreedingCooldowns();
+             }
+             console.server.reloadCount++;
+ 

--- a/patches/server/0139-Add-adjustable-breeding-cooldown-to-config.patch
+++ b/patches/server/0139-Add-adjustable-breeding-cooldown-to-config.patch
@@ -5,27 +5,24 @@ Subject: [PATCH] Add adjustable breeding cooldown to config
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityAnimal.java b/src/main/java/net/minecraft/server/EntityAnimal.java
-index bba343542..0b3d0c84f 100644
+index bba343542..d9f9e2235 100644
 --- a/src/main/java/net/minecraft/server/EntityAnimal.java
 +++ b/src/main/java/net/minecraft/server/EntityAnimal.java
-@@ -120,7 +120,10 @@ public abstract class EntityAnimal extends EntityAgeable {
+@@ -120,7 +120,7 @@ public abstract class EntityAnimal extends EntityAgeable {
          if (this.k(itemstack)) {
              int i = this.getAge();
  
 -            if (!this.world.isClientSide && i == 0 && this.eP()) {
-+            // Purpur start
-+            if (!this.world.isClientSide && i == 0 && this.eP()
-+                    && (this.world.purpurConfig.animalBreedingCooldownSeconds == 0 || !this.world.hasBreedingCooldown(entityhuman.getUniqueID(), this.getClass()))) {
-+                // Purpur end
++            if (!this.world.isClientSide && i == 0 && this.eP() && (this.world.purpurConfig.animalBreedingCooldownSeconds <= 0 || !this.world.hasBreedingCooldown(entityhuman.getUniqueID(), this.getClass()))) { // Purpur
                  this.a(entityhuman, itemstack);
                  this.g(entityhuman);
                  return EnumInteractionResult.SUCCESS;
-@@ -212,6 +215,14 @@ public abstract class EntityAnimal extends EntityAgeable {
+@@ -212,6 +212,14 @@ public abstract class EntityAnimal extends EntityAgeable {
              if (entityplayer == null && entityanimal.getBreedCause() != null) {
                  entityplayer = entityanimal.getBreedCause();
              }
 +            // Purpur start
-+            if (entityplayer != null && worldserver.purpurConfig.animalBreedingCooldownSeconds != 0) {
++            if (entityplayer != null && worldserver.purpurConfig.animalBreedingCooldownSeconds > 0) {
 +                if (worldserver.hasBreedingCooldown(entityplayer.getUniqueID(), this.getClass())) {
 +                    return;
 +                }
@@ -36,10 +33,10 @@ index bba343542..0b3d0c84f 100644
              int experience = this.getRandom().nextInt(7) + 1;
              org.bukkit.event.entity.EntityBreedEvent entityBreedEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityBreedEvent(entityageable, this, entityanimal, entityplayer, this.breedItem, experience);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 281bba56e..d12b396bd 100644
+index 281bba56e..5adc630bb 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -104,6 +104,49 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -104,6 +104,48 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
      private int tileTickPosition;
      public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
      public java.util.ArrayDeque<BlockRedstoneTorch.RedstoneUpdateInfo> redstoneUpdateInfos; // Paper - Move from Map in BlockRedstoneTorch to here
@@ -47,8 +44,7 @@ index 281bba56e..d12b396bd 100644
 +    private com.google.common.cache.Cache<BreedingCooldownPair, Object> playerBreedingCooldowns;
 +
 +    private com.google.common.cache.Cache<BreedingCooldownPair, Object> getNewBreedingCooldownCache() {
-+        return com.google.common.cache.CacheBuilder.newBuilder()
-+                .expireAfterWrite(this.purpurConfig.animalBreedingCooldownSeconds, java.util.concurrent.TimeUnit.SECONDS).build();
++        return com.google.common.cache.CacheBuilder.newBuilder().expireAfterWrite(this.purpurConfig.animalBreedingCooldownSeconds, java.util.concurrent.TimeUnit.SECONDS).build();
 +    }
 +
 +    public void resetBreedingCooldowns() {
@@ -89,7 +85,7 @@ index 281bba56e..d12b396bd 100644
  
      public CraftWorld getWorld() {
          return this.world;
-@@ -157,6 +200,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -157,6 +199,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig((((WorldDataServer)worlddatamutable).getName()), this.spigotConfig); // Paper
          this.tuinityConfig = new com.tuinity.tuinity.config.TuinityConfig.WorldConfig(((WorldDataServer)worlddatamutable).getName()); // Tuinity - Server Config
          this.purpurConfig = new net.pl3x.purpur.PurpurWorldConfig(((WorldDataServer) worlddatamutable).getName(), env); // Purpur

--- a/patches/server/0140-Make-animal-breeding-times-configurable.patch
+++ b/patches/server/0140-Make-animal-breeding-times-configurable.patch
@@ -1,0 +1,639 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Sun, 15 Nov 2020 02:18:15 -0800
+Subject: [PATCH] Make animal breeding times configurable
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityAnimal.java b/src/main/java/net/minecraft/server/EntityAnimal.java
+index 0b3d0c84f..e0402475c 100644
+--- a/src/main/java/net/minecraft/server/EntityAnimal.java
++++ b/src/main/java/net/minecraft/server/EntityAnimal.java
+@@ -13,6 +13,7 @@ public abstract class EntityAnimal extends EntityAgeable {
+     public int loveTicks;
+     public UUID breedCause;
+     public ItemStack breedItem; // CraftBukkit - Add breedItem variable
++    abstract int getPurpurBreedTime(); // Purpur
+ 
+     protected EntityAnimal(EntityTypes<? extends EntityAnimal> entitytypes, World world) {
+         super(entitytypes, world);
+@@ -237,8 +238,10 @@ public abstract class EntityAnimal extends EntityAgeable {
+                 CriterionTriggers.o.a(entityplayer, this, entityanimal, entityageable);
+             }
+ 
+-            this.setAgeRaw(6000);
+-            entityanimal.setAgeRaw(6000);
++            // Purpur start
++            this.setAgeRaw(this.getPurpurBreedTime());
++            entityanimal.setAgeRaw(entityanimal.getPurpurBreedTime());
++            // Purpur end
+             this.resetLove();
+             entityanimal.resetLove();
+             entityageable.setBaby(true);
+diff --git a/src/main/java/net/minecraft/server/EntityBee.java b/src/main/java/net/minecraft/server/EntityBee.java
+index d8354ec4d..ded4e10f5 100644
+--- a/src/main/java/net/minecraft/server/EntityBee.java
++++ b/src/main/java/net/minecraft/server/EntityBee.java
+@@ -100,6 +100,11 @@ public class EntityBee extends EntityAnimal implements IEntityAngerable, EntityB
+             setMot(mot.a(0.9D));
+         }
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.beeBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityCat.java b/src/main/java/net/minecraft/server/EntityCat.java
+index 05929d5c5..a6ce4ca27 100644
+--- a/src/main/java/net/minecraft/server/EntityCat.java
++++ b/src/main/java/net/minecraft/server/EntityCat.java
+@@ -58,6 +58,11 @@ public class EntityCat extends EntityTameableAnimal {
+         setSleepingWithOwner(false);
+         setHeadDown(false);
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.catBreedingTicks;
++    }
+     // Purpur end
+ 
+     public MinecraftKey eU() {
+diff --git a/src/main/java/net/minecraft/server/EntityChicken.java b/src/main/java/net/minecraft/server/EntityChicken.java
+index a16ecd7ed..26f783349 100644
+--- a/src/main/java/net/minecraft/server/EntityChicken.java
++++ b/src/main/java/net/minecraft/server/EntityChicken.java
+@@ -36,6 +36,11 @@ public class EntityChicken extends EntityAnimal {
+             }
+         }
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.chickenBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityCow.java b/src/main/java/net/minecraft/server/EntityCow.java
+index 1219b0aa9..63497ca02 100644
+--- a/src/main/java/net/minecraft/server/EntityCow.java
++++ b/src/main/java/net/minecraft/server/EntityCow.java
+@@ -21,6 +21,11 @@ public class EntityCow extends EntityAnimal {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.cowRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.cowBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityFox.java b/src/main/java/net/minecraft/server/EntityFox.java
+index f5defe471..e87f5aeb9 100644
+--- a/src/main/java/net/minecraft/server/EntityFox.java
++++ b/src/main/java/net/minecraft/server/EntityFox.java
+@@ -86,6 +86,11 @@ public class EntityFox extends EntityAnimal {
+         super.onDismount(entityhuman);
+         setCanPickupLoot(true);
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.foxBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityHoglin.java b/src/main/java/net/minecraft/server/EntityHoglin.java
+index 548ff4449..a1578aade 100644
+--- a/src/main/java/net/minecraft/server/EntityHoglin.java
++++ b/src/main/java/net/minecraft/server/EntityHoglin.java
+@@ -30,6 +30,11 @@ public class EntityHoglin extends EntityAnimal implements IMonster, IOglin {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.hoglinRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.hoglinBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityHorse.java b/src/main/java/net/minecraft/server/EntityHorse.java
+index 0415a4d1f..b19995f96 100644
+--- a/src/main/java/net/minecraft/server/EntityHorse.java
++++ b/src/main/java/net/minecraft/server/EntityHorse.java
+@@ -17,6 +17,11 @@ public class EntityHorse extends EntityHorseAbstract {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.horseRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.horseBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityHorseDonkey.java b/src/main/java/net/minecraft/server/EntityHorseDonkey.java
+index cb8aee569..f6421bb45 100644
+--- a/src/main/java/net/minecraft/server/EntityHorseDonkey.java
++++ b/src/main/java/net/minecraft/server/EntityHorseDonkey.java
+@@ -13,6 +13,11 @@ public class EntityHorseDonkey extends EntityHorseChestedAbstract {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.donkeyRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.donkeyBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityHorseMule.java b/src/main/java/net/minecraft/server/EntityHorseMule.java
+index 243aeb736..30cbc505d 100644
+--- a/src/main/java/net/minecraft/server/EntityHorseMule.java
++++ b/src/main/java/net/minecraft/server/EntityHorseMule.java
+@@ -13,6 +13,11 @@ public class EntityHorseMule extends EntityHorseChestedAbstract {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.muleRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.muleBreedingTicks;
++    }
+     // Purpur end
+     @Override
+     protected SoundEffect getSoundAmbient() {
+diff --git a/src/main/java/net/minecraft/server/EntityHorseSkeleton.java b/src/main/java/net/minecraft/server/EntityHorseSkeleton.java
+index e2c6a5807..408db52ca 100644
+--- a/src/main/java/net/minecraft/server/EntityHorseSkeleton.java
++++ b/src/main/java/net/minecraft/server/EntityHorseSkeleton.java
+@@ -22,6 +22,11 @@ public class EntityHorseSkeleton extends EntityHorseAbstract {
+     public boolean isTamed() {
+         return true;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return 6000;
++    }
+     // Purpur end
+ 
+     public static AttributeProvider.Builder eL() {
+diff --git a/src/main/java/net/minecraft/server/EntityHorseZombie.java b/src/main/java/net/minecraft/server/EntityHorseZombie.java
+index 559ba5097..2121a6c97 100644
+--- a/src/main/java/net/minecraft/server/EntityHorseZombie.java
++++ b/src/main/java/net/minecraft/server/EntityHorseZombie.java
+@@ -18,6 +18,11 @@ public class EntityHorseZombie extends EntityHorseAbstract {
+     public boolean isTamed() {
+         return true;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return 6000;
++    }
+     // Purpur end
+ 
+     public static AttributeProvider.Builder eL() {
+diff --git a/src/main/java/net/minecraft/server/EntityLlama.java b/src/main/java/net/minecraft/server/EntityLlama.java
+index 109927786..3bc6e6df9 100644
+--- a/src/main/java/net/minecraft/server/EntityLlama.java
++++ b/src/main/java/net/minecraft/server/EntityLlama.java
+@@ -57,6 +57,11 @@ public class EntityLlama extends EntityHorseChestedAbstract implements IRangedEn
+     public boolean hasSaddle() {
+         return super.hasSaddle() || (isTamed() && getColor() != null);
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.llamaBreedingTicks;
++    }
+     // Purpur end
+ 
+     public void setStrength(int i) {
+diff --git a/src/main/java/net/minecraft/server/EntityMushroomCow.java b/src/main/java/net/minecraft/server/EntityMushroomCow.java
+index 7966b34f8..eb1f95d8b 100644
+--- a/src/main/java/net/minecraft/server/EntityMushroomCow.java
++++ b/src/main/java/net/minecraft/server/EntityMushroomCow.java
+@@ -30,6 +30,11 @@ public class EntityMushroomCow extends EntityCow implements IShearable {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.mooshroomRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.mooshroomBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityOcelot.java b/src/main/java/net/minecraft/server/EntityOcelot.java
+index 2f8275cd6..a5be10dfb 100644
+--- a/src/main/java/net/minecraft/server/EntityOcelot.java
++++ b/src/main/java/net/minecraft/server/EntityOcelot.java
+@@ -26,6 +26,11 @@ public class EntityOcelot extends EntityAnimal {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.ocelotRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.ocelotBreedingTicks;
++    }
+     // Purpur end
+ 
+     private boolean isTrusting() {
+diff --git a/src/main/java/net/minecraft/server/EntityPanda.java b/src/main/java/net/minecraft/server/EntityPanda.java
+index eafae5516..c70180fdd 100644
+--- a/src/main/java/net/minecraft/server/EntityPanda.java
++++ b/src/main/java/net/minecraft/server/EntityPanda.java
+@@ -65,6 +65,11 @@ public class EntityPanda extends EntityAnimal {
+         this.setEating(false);
+         this.setLayingOnBack(false);
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.pandaBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityParrot.java b/src/main/java/net/minecraft/server/EntityParrot.java
+index 66c1d666c..f229488c8 100644
+--- a/src/main/java/net/minecraft/server/EntityParrot.java
++++ b/src/main/java/net/minecraft/server/EntityParrot.java
+@@ -115,6 +115,11 @@ public class EntityParrot extends EntityPerchable implements EntityBird {
+             setMot(mot.a(0.9D));
+         }
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return 6000;
++    }
+     // Purpur end
+ 
+     @Nullable
+diff --git a/src/main/java/net/minecraft/server/EntityPig.java b/src/main/java/net/minecraft/server/EntityPig.java
+index dade0bb29..7172e8cab 100644
+--- a/src/main/java/net/minecraft/server/EntityPig.java
++++ b/src/main/java/net/minecraft/server/EntityPig.java
+@@ -29,6 +29,11 @@ public class EntityPig extends EntityAnimal implements ISteerable, ISaddleable {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.pigRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.pigBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityPolarBear.java b/src/main/java/net/minecraft/server/EntityPolarBear.java
+index 3d649843f..40395dd7e 100644
+--- a/src/main/java/net/minecraft/server/EntityPolarBear.java
++++ b/src/main/java/net/minecraft/server/EntityPolarBear.java
+@@ -67,6 +67,11 @@ public class EntityPolarBear extends EntityAnimal implements IEntityAngerable {
+             return this.isInLove() && polarbear.isInLove();
+         }
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.polarBearBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityRabbit.java b/src/main/java/net/minecraft/server/EntityRabbit.java
+index b766a27e9..654cd036a 100644
+--- a/src/main/java/net/minecraft/server/EntityRabbit.java
++++ b/src/main/java/net/minecraft/server/EntityRabbit.java
+@@ -30,6 +30,11 @@ public class EntityRabbit extends EntityAnimal {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.rabbitRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.rabbitBreedingTicks;
++    }
+     // Purpur end
+ 
+     // CraftBukkit start - code from constructor
+diff --git a/src/main/java/net/minecraft/server/EntitySheep.java b/src/main/java/net/minecraft/server/EntitySheep.java
+index a151d4295..32130c068 100644
+--- a/src/main/java/net/minecraft/server/EntitySheep.java
++++ b/src/main/java/net/minecraft/server/EntitySheep.java
+@@ -66,6 +66,11 @@ public class EntitySheep extends EntityAnimal implements IShearable {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.sheepRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.sheepBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityStrider.java b/src/main/java/net/minecraft/server/EntityStrider.java
+index 172867f50..9ab1b5af6 100644
+--- a/src/main/java/net/minecraft/server/EntityStrider.java
++++ b/src/main/java/net/minecraft/server/EntityStrider.java
+@@ -38,6 +38,11 @@ public class EntityStrider extends EntityAnimal implements ISteerable, ISaddleab
+     public boolean isRidableInWater() {
+         return world.purpurConfig.striderRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.striderBreedingTicks;
++    }
+     // Purpur end
+ 
+     public static boolean c(EntityTypes<EntityStrider> entitytypes, GeneratorAccess generatoraccess, EnumMobSpawn enummobspawn, BlockPosition blockposition, Random random) {
+diff --git a/src/main/java/net/minecraft/server/EntityTurtle.java b/src/main/java/net/minecraft/server/EntityTurtle.java
+index 2b34e6cf3..067f7f28b 100644
+--- a/src/main/java/net/minecraft/server/EntityTurtle.java
++++ b/src/main/java/net/minecraft/server/EntityTurtle.java
+@@ -37,6 +37,11 @@ public class EntityTurtle extends EntityAnimal {
+     public boolean isRidableInWater() {
+         return world.purpurConfig.turtleRidableInWater;
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.turtleBreedingTicks;
++    }
+     // Purpur end
+ 
+     public void setHomePos(BlockPosition blockposition) {
+diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
+index 9ae716859..6c25f667e 100644
+--- a/src/main/java/net/minecraft/server/EntityWolf.java
++++ b/src/main/java/net/minecraft/server/EntityWolf.java
+@@ -48,6 +48,11 @@ public class EntityWolf extends EntityTameableAnimal implements IEntityAngerable
+         super.onMount(entityhuman);
+         setSitting(false);
+     }
++
++    @Override
++    int getPurpurBreedTime() {
++        return this.world.purpurConfig.wolfBreedingTicks;
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 9eeedb6e7..25654a81a 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -425,10 +425,12 @@ public class PurpurWorldConfig {
+     public boolean beeRidable = false;
+     public boolean beeRidableInWater = false;
+     public double beeMaxY = 256D;
++    public int beeBreedingTicks = 6000;
+     private void beeSettings() {
+         beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
+         beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
+         beeMaxY = getDouble("mobs.bee.ridable-max-y", beeMaxY);
++        beeBreedingTicks = getInt("mobs.bee.breeding-delay-ticks", beeBreedingTicks);
+     }
+ 
+     public boolean blazeRidable = false;
+@@ -445,12 +447,14 @@ public class PurpurWorldConfig {
+     public int catSpawnDelay = 1200;
+     public int catSpawnSwampHutScanRange = 16;
+     public int catSpawnVillageScanRange = 48;
++    public int catBreedingTicks = 6000;
+     private void catSettings() {
+         catRidable = getBoolean("mobs.cat.ridable", catRidable);
+         catRidableInWater = getBoolean("mobs.cat.ridable-in-water", catRidableInWater);
+         catSpawnDelay = getInt("mobs.cat.spawn-delay", catSpawnDelay);
+         catSpawnSwampHutScanRange = getInt("mobs.cat.scan-range-for-other-cats.swamp-hut", catSpawnSwampHutScanRange);
+         catSpawnVillageScanRange = getInt("mobs.cat.scan-range-for-other-cats.village", catSpawnVillageScanRange);
++        catBreedingTicks = getInt("mobs.cat.breeding-delay-ticks", catBreedingTicks);
+     }
+ 
+     public boolean caveSpiderRidable = false;
+@@ -463,10 +467,12 @@ public class PurpurWorldConfig {
+     public boolean chickenRidable = false;
+     public boolean chickenRidableInWater = false;
+     public boolean chickenRetaliate = false;
++    public int chickenBreedingTicks = 6000;
+     private void chickenSettings() {
+         chickenRidable = getBoolean("mobs.chicken.ridable", chickenRidable);
+         chickenRidableInWater = getBoolean("mobs.chicken.ridable-in-water", chickenRidableInWater);
+         chickenRetaliate = getBoolean("mobs.chicken.retaliate", chickenRetaliate);
++        chickenBreedingTicks = getInt("mobs.chicken.breeding-delay-ticks", chickenBreedingTicks);
+     }
+ 
+     public boolean codRidable = false;
+@@ -477,10 +483,12 @@ public class PurpurWorldConfig {
+     public boolean cowRidable = false;
+     public boolean cowRidableInWater = false;
+     public int cowFeedMushrooms = 0;
++    public int cowBreedingTicks = 6000;
+     private void cowSettings() {
+         cowRidable = getBoolean("mobs.cow.ridable", cowRidable);
+         cowRidableInWater = getBoolean("mobs.cow.ridable-in-water", cowRidableInWater);
+         cowFeedMushrooms = getInt("mobs.cow.feed-mushrooms-for-mooshroom", cowFeedMushrooms);
++        cowBreedingTicks = getInt("mobs.cow.breeding-delay-ticks", cowBreedingTicks);
+     }
+ 
+     public boolean creeperRidable = false;
+@@ -508,8 +516,10 @@ public class PurpurWorldConfig {
+     }
+ 
+     public boolean donkeyRidableInWater = false;
++    public int donkeyBreedingTicks = 6000;
+     private void donkeySettings() {
+         donkeyRidableInWater = getBoolean("mobs.donkey.ridable-in-water", donkeyRidableInWater);
++        donkeyBreedingTicks = getInt("mobs.donkey.breeding-delay-ticks", donkeyBreedingTicks);
+     }
+ 
+     public boolean drownedRidable = false;
+@@ -571,10 +581,12 @@ public class PurpurWorldConfig {
+     public boolean foxRidable = false;
+     public boolean foxRidableInWater = false;
+     public boolean foxTypeChangesWithTulips = false;
++    public int foxBreedingTicks = 6000;
+     private void foxSettings() {
+         foxRidable = getBoolean("mobs.fox.ridable", foxRidable);
+         foxRidableInWater = getBoolean("mobs.fox.ridable-in-water", foxRidableInWater);
+         foxTypeChangesWithTulips = getBoolean("mobs.fox.tulips-change-type", foxTypeChangesWithTulips);
++        foxBreedingTicks = getInt("mobs.fox.breeding-delay-ticks", foxBreedingTicks);
+     }
+ 
+     public boolean ghastRidable = false;
+@@ -614,14 +626,18 @@ public class PurpurWorldConfig {
+ 
+     public boolean hoglinRidable = false;
+     public boolean hoglinRidableInWater = false;
++    public int hoglinBreedingTicks = 6000;
+     private void hoglinSettings() {
+         hoglinRidable = getBoolean("mobs.hoglin.ridable", hoglinRidable);
+         hoglinRidableInWater = getBoolean("mobs.hoglin.ridable-in-water", hoglinRidableInWater);
++        hoglinBreedingTicks = getInt("mobs.hoglin.breeding-delay-ticks", hoglinBreedingTicks);
+     }
+ 
+     public boolean horseRidableInWater = false;
++    public int horseBreedingTicks = 6000;
+     private void horseSettings() {
+         horseRidableInWater = getBoolean("mobs.horse.ridable-in-water", horseRidableInWater);
++        horseBreedingTicks = getInt("mobs.horse.breeding-delay-ticks", horseBreedingTicks);
+     }
+ 
+     public boolean huskRidable = false;
+@@ -661,9 +677,11 @@ public class PurpurWorldConfig {
+ 
+     public boolean llamaRidable = false;
+     public boolean llamaRidableInWater = false;
++    public int llamaBreedingTicks = 6000;
+     private void llamaSettings() {
+         llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
+         llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
++        llamaBreedingTicks = getInt("mobs.llama.breeding-delay-ticks", llamaBreedingTicks);
+     }
+ 
+     public boolean llamaTraderRidable = false;
+@@ -682,28 +700,36 @@ public class PurpurWorldConfig {
+ 
+     public boolean mooshroomRidable = false;
+     public boolean mooshroomRidableInWater = false;
++    public int mooshroomBreedingTicks = 6000;
+     private void mooshroomSettings() {
+         mooshroomRidable = getBoolean("mobs.mooshroom.ridable", mooshroomRidable);
+         mooshroomRidableInWater = getBoolean("mobs.mooshroom.ridable-in-water", mooshroomRidableInWater);
++        mooshroomBreedingTicks = getInt("mobs.mooshroom.breeding-delay-ticks", mooshroomBreedingTicks);
+     }
+ 
+     public boolean muleRidableInWater = false;
++    public int muleBreedingTicks = 6000;
+     private void muleSettings() {
+         muleRidableInWater = getBoolean("mobs.mule.ridable-in-water", muleRidableInWater);
++        muleBreedingTicks = getInt("mobs.mule.breeding-delay-ticks", muleBreedingTicks);
+     }
+ 
+     public boolean ocelotRidable = false;
+     public boolean ocelotRidableInWater = false;
++    public int ocelotBreedingTicks = 6000;
+     private void ocelotSettings() {
+         ocelotRidable = getBoolean("mobs.ocelot.ridable", ocelotRidable);
+         ocelotRidableInWater = getBoolean("mobs.ocelot.ridable-in-water", ocelotRidableInWater);
++        ocelotBreedingTicks = getInt("mobs.ocelot.breeding-delay-ticks", ocelotBreedingTicks);
+     }
+ 
+     public boolean pandaRidable = false;
+     public boolean pandaRidableInWater = false;
++    public int pandaBreedingTicks = 6000;
+     private void pandaSettings() {
+         pandaRidable = getBoolean("mobs.panda.ridable", pandaRidable);
+         pandaRidableInWater = getBoolean("mobs.panda.ridable-in-water", pandaRidableInWater);
++        pandaBreedingTicks = getInt("mobs.panda.breeding-delay-ticks", pandaBreedingTicks);
+     }
+ 
+     public boolean parrotRidable = false;
+@@ -767,10 +793,12 @@ public class PurpurWorldConfig {
+     public boolean pigRidable = false;
+     public boolean pigRidableInWater = false;
+     public boolean pigGiveSaddleBack = false;
++    public int pigBreedingTicks = 6000;
+     private void pigSettings() {
+         pigRidable = getBoolean("mobs.pig.ridable", pigRidable);
+         pigRidableInWater = getBoolean("mobs.pig.ridable-in-water", pigRidableInWater);
+         pigGiveSaddleBack = getBoolean("mobs.pig.give-saddle-back", pigGiveSaddleBack);
++        pigBreedingTicks = getInt("mobs.pig.breeding-delay-ticks", pigBreedingTicks);
+     }
+ 
+     public boolean piglinRidable = false;
+@@ -798,12 +826,14 @@ public class PurpurWorldConfig {
+     public boolean polarBearRidableInWater = false;
+     public String polarBearBreedableItemString = "";
+     public Item polarBearBreedableItem = null;
++    public int polarBearBreedingTicks = 6000;
+     private void polarBearSettings() {
+         polarBearRidable = getBoolean("mobs.polar_bear.ridable", polarBearRidable);
+         polarBearRidableInWater = getBoolean("mobs.polar_bear.ridable-in-water", polarBearRidableInWater);
+         polarBearBreedableItemString = getString("mobs.polar_bear.breedable-item", polarBearBreedableItemString);
+         Item item = IRegistry.ITEM.get(new MinecraftKey(polarBearBreedableItemString));
+         if (item != Items.AIR) polarBearBreedableItem = item;
++        polarBearBreedingTicks = getInt("mobs.polar_bear.breeding-delay-ticks", polarBearBreedingTicks);
+     }
+ 
+     public boolean pufferfishRidable = false;
+@@ -815,11 +845,13 @@ public class PurpurWorldConfig {
+     public boolean rabbitRidableInWater = false;
+     public double rabbitNaturalToast = 0.0D;
+     public double rabbitNaturalKiller = 0.0D;
++    public int rabbitBreedingTicks = 6000;
+     private void rabbitSettings() {
+         rabbitRidable = getBoolean("mobs.rabbit.ridable", rabbitRidable);
+         rabbitRidableInWater = getBoolean("mobs.rabbit.ridable-in-water", rabbitRidableInWater);
+         rabbitNaturalToast = getDouble("mobs.rabbit.spawn-toast-chance", rabbitNaturalToast);
+         rabbitNaturalKiller = getDouble("mobs.rabbit.spawn-killer-rabbit-chance", rabbitNaturalKiller);
++        rabbitBreedingTicks = getInt("mobs.rabbit.breeding-delay-ticks", rabbitBreedingTicks);
+     }
+ 
+     public boolean ravagerRidable = false;
+@@ -836,9 +868,11 @@ public class PurpurWorldConfig {
+ 
+     public boolean sheepRidable = false;
+     public boolean sheepRidableInWater = false;
++    public int sheepBreedingTicks = 6000;
+     private void sheepSettings() {
+         sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
+         sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
++        sheepBreedingTicks = getInt("mobs.sheep.breeding-delay-ticks", sheepBreedingTicks);
+     }
+ 
+     public boolean shulkerRidable = false;
+@@ -916,9 +950,11 @@ public class PurpurWorldConfig {
+ 
+     public boolean striderRidable = false;
+     public boolean striderRidableInWater = false;
++    public int striderBreedingTicks = 6000;
+     private void striderSettings() {
+         striderRidable = getBoolean("mobs.strider.ridable", striderRidable);
+         striderRidableInWater = getBoolean("mobs.strider.ridable-in-water", striderRidableInWater);
++        striderBreedingTicks = getInt("mobs.strider.breeding-delay-ticks", striderBreedingTicks);
+     }
+ 
+     public boolean tropicalFishRidable = false;
+@@ -928,9 +964,11 @@ public class PurpurWorldConfig {
+ 
+     public boolean turtleRidable = false;
+     public boolean turtleRidableInWater = false;
++    public int turtleBreedingTicks = 6000;
+     private void turtleSettings() {
+         turtleRidable = getBoolean("mobs.turtle.ridable", turtleRidable);
+         turtleRidableInWater = getBoolean("mobs.turtle.ridable-in-water", turtleRidableInWater);
++        turtleBreedingTicks = getInt("mobs.turtle.breeding-delay-ticks", turtleBreedingTicks);
+     }
+ 
+     public boolean vexRidable = false;
+@@ -1018,9 +1056,11 @@ public class PurpurWorldConfig {
+ 
+     public boolean wolfRidable = false;
+     public boolean wolfRidableInWater = false;
++    public int wolfBreedingTicks = 6000;
+     private void wolfSettings() {
+         wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
+         wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
++        wolfBreedingTicks = getInt("mobs.wolf.breeding-delay-ticks", wolfBreedingTicks);
+     }
+ 
+     public boolean zoglinRidable = false;

--- a/patches/server/0140-Make-animal-breeding-times-configurable.patch
+++ b/patches/server/0140-Make-animal-breeding-times-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make animal breeding times configurable
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityAnimal.java b/src/main/java/net/minecraft/server/EntityAnimal.java
-index 0b3d0c84f..e0402475c 100644
+index d9f9e2235..dd6725deb 100644
 --- a/src/main/java/net/minecraft/server/EntityAnimal.java
 +++ b/src/main/java/net/minecraft/server/EntityAnimal.java
 @@ -13,6 +13,7 @@ public abstract class EntityAnimal extends EntityAgeable {
@@ -16,7 +16,7 @@ index 0b3d0c84f..e0402475c 100644
  
      protected EntityAnimal(EntityTypes<? extends EntityAnimal> entitytypes, World world) {
          super(entitytypes, world);
-@@ -237,8 +238,10 @@ public abstract class EntityAnimal extends EntityAgeable {
+@@ -234,8 +235,10 @@ public abstract class EntityAnimal extends EntityAgeable {
                  CriterionTriggers.o.a(entityplayer, this, entityanimal, entityageable);
              }
  


### PR DESCRIPTION
This PR includes two patches (willing to split it up if requested)
- My updated version of the patch from #92
  - Made the cooldowns per animal type
  - Store the cooldowns per world instead of per entity (because the config option is per world)
  - If the player has a cooldown for an animal type, don't let them put that animal into love mode/don't consume the breeding item
- Make-animal-breeding-times-configurable.patch
  - Makes the waiting time for breeding animals configurable per animal type, instead of always the vanilla 5 minutes.
  - Note: currently the config includes some animals which are technically not breedable, because I simply added a config for all entity types that are `Animals`. This is easily fixable by making the code for the config a bit more verbose.
    ![img](https://i.imgur.com/PQiStgV.png)

Also related: #85 