### PR TITLE
Persistent display names for items with entity forms

### DIFF
--- a/patches/server/0143-Apply-display-names-from-item-forms-of-entities-to-e.patch
+++ b/patches/server/0143-Apply-display-names-from-item-forms-of-entities-to-e.patch
@@ -1,0 +1,228 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Tue, 17 Nov 2020 03:23:48 -0800
+Subject: [PATCH] Apply display names from item forms of entities to entities
+ and vice versa
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
+index 0b1985901..f6f90fc17 100644
+--- a/src/main/java/net/minecraft/server/EntityArmorStand.java
++++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
+@@ -546,7 +546,13 @@ public class EntityArmorStand extends EntityLiving {
+     }
+ 
+     private void f(DamageSource damagesource) {
+-        drops.add(org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(new ItemStack(Items.ARMOR_STAND))); // CraftBukkit - add to drops
++        // Purpur start
++        final ItemStack armorStand = new ItemStack(Items.ARMOR_STAND);
++        if (this.world.purpurConfig.persistentDroppableEntityDisplayNames && this.hasCustomName()) {
++            armorStand.setName(this.getCustomName());
++        }
++        drops.add(org.bukkit.craftbukkit.inventory.CraftItemStack.asBukkitCopy(armorStand)); // CraftBukkit - add to drops
++        // Purpur end
+         this.g(damagesource);
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/EntityBoat.java b/src/main/java/net/minecraft/server/EntityBoat.java
+index 939a5fb88..fc3b0c1da 100644
+--- a/src/main/java/net/minecraft/server/EntityBoat.java
++++ b/src/main/java/net/minecraft/server/EntityBoat.java
+@@ -155,7 +155,13 @@ public class EntityBoat extends Entity {
+                 }
+                 // CraftBukkit end
+                 if (!flag && this.world.getGameRules().getBoolean(GameRules.DO_ENTITY_DROPS)) {
+-                    this.a((IMaterial) this.g());
++                    // Purpur start
++                    final ItemStack boat = new ItemStack(this.getMaterialForType());
++                    if (this.world.purpurConfig.persistentDroppableEntityDisplayNames && this.hasCustomName()) {
++                        boat.setName(this.getCustomName());
++                    }
++                    this.dropItem(boat);
++                    // Purpur end
+                 }
+ 
+                 this.die();
+@@ -216,6 +222,7 @@ public class EntityBoat extends Entity {
+ 
+     }
+ 
++    public Item getMaterialForType() { return this.g(); } // Purpur - OBFHELPER
+     public Item g() {
+         switch (this.getType()) {
+             case OAK:
+diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
+index 695283245..9214b2a3c 100644
+--- a/src/main/java/net/minecraft/server/EntityInsentient.java
++++ b/src/main/java/net/minecraft/server/EntityInsentient.java
+@@ -1366,7 +1366,13 @@ public abstract class EntityInsentient extends EntityLiving {
+             this.by = null;
+             if (!this.world.isClientSide && flag1) {
+                 this.forceDrops = true; // CraftBukkit
+-                this.a((IMaterial) Items.LEAD);
++                // Purpur start
++                final ItemStack lead = new ItemStack(Items.LEAD);
++                if (this.world.purpurConfig.persistentDroppableEntityDisplayNames && this.hasCustomName()) {
++                    lead.setName(this.getCustomName());
++                }
++                this.dropItem(lead);
++                // Purpur end
+                 this.forceDrops = false; // CraftBukkit
+             }
+ 
+@@ -1442,7 +1448,13 @@ public abstract class EntityInsentient extends EntityLiving {
+             }
+ 
+             if (this.ticksLived > 100) {
+-                this.a((IMaterial) Items.LEAD);
++                // Purpur start
++                final ItemStack lead = new ItemStack(Items.LEAD);
++                if (this.world.purpurConfig.persistentDroppableEntityDisplayNames && this.hasCustomName()) {
++                    lead.setName(this.getCustomName());
++                }
++                this.dropItem(lead);
++                // Purpur end
+                 this.by = null;
+             }
+         }
+diff --git a/src/main/java/net/minecraft/server/EntityItemFrame.java b/src/main/java/net/minecraft/server/EntityItemFrame.java
+index 16c8f2cdf..19460d885 100644
+--- a/src/main/java/net/minecraft/server/EntityItemFrame.java
++++ b/src/main/java/net/minecraft/server/EntityItemFrame.java
+@@ -199,7 +199,13 @@ public class EntityItemFrame extends EntityHanging {
+                 }
+ 
+                 if (flag) {
+-                    this.a((IMaterial) Items.ITEM_FRAME);
++                    // Purpur start
++                    final ItemStack itemFrame = new ItemStack(Items.ITEM_FRAME);
++                    if (this.world.purpurConfig.persistentDroppableEntityDisplayNames && this.hasCustomName()) {
++                        itemFrame.setName(this.getCustomName());
++                    }
++                    this.dropItem(itemFrame);
++                    // Purpur end
+                 }
+ 
+                 if (!itemstack.isEmpty()) {
+diff --git a/src/main/java/net/minecraft/server/EntityPainting.java b/src/main/java/net/minecraft/server/EntityPainting.java
+index 4b7cd7c59..d01fc8b11 100644
+--- a/src/main/java/net/minecraft/server/EntityPainting.java
++++ b/src/main/java/net/minecraft/server/EntityPainting.java
+@@ -92,7 +92,13 @@ public class EntityPainting extends EntityHanging {
+                 }
+             }
+ 
+-            this.a((IMaterial) Items.PAINTING);
++            // Purpur start
++            final ItemStack painting = new ItemStack(Items.PAINTING);
++            if (this.world.purpurConfig.persistentDroppableEntityDisplayNames && this.hasCustomName()) {
++                painting.setName(this.getCustomName());
++            }
++            this.dropItem(painting);
++            // Purpur end
+         }
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/ItemArmorStand.java b/src/main/java/net/minecraft/server/ItemArmorStand.java
+index c9a5d3b58..315faee9e 100644
+--- a/src/main/java/net/minecraft/server/ItemArmorStand.java
++++ b/src/main/java/net/minecraft/server/ItemArmorStand.java
+@@ -43,6 +43,14 @@ public class ItemArmorStand extends Item {
+                         return EnumInteractionResult.FAIL;
+                     }
+                     // CraftBukkit end
++                    // Purpur start
++                    if (itemactioncontext.getWorld().purpurConfig.persistentDroppableEntityDisplayNames && itemactioncontext.getItemStack().hasName()) {
++                        entityarmorstand.setCustomName(itemactioncontext.getItemStack().getName());
++                        if (itemactioncontext.getWorld().purpurConfig.armorstandSetNameVisible) {
++                            entityarmorstand.setCustomNameVisible(true);
++                        }
++                    }
++                    // Purpur end
+                     worldserver.addAllEntities(entityarmorstand); // Paper - moved down
+                     world.playSound((EntityHuman) null, entityarmorstand.locX(), entityarmorstand.locY(), entityarmorstand.locZ(), SoundEffects.ENTITY_ARMOR_STAND_PLACE, SoundCategory.BLOCKS, 0.75F, 0.8F);
+                 }
+diff --git a/src/main/java/net/minecraft/server/ItemBoat.java b/src/main/java/net/minecraft/server/ItemBoat.java
+index 0580ce55e..6183da7ad 100644
+--- a/src/main/java/net/minecraft/server/ItemBoat.java
++++ b/src/main/java/net/minecraft/server/ItemBoat.java
+@@ -52,6 +52,11 @@ public class ItemBoat extends Item {
+ 
+                 entityboat.setType(this.b);
+                 entityboat.yaw = entityhuman.yaw;
++                // Purpur start
++                if (world.purpurConfig.persistentDroppableEntityDisplayNames && itemstack.hasName()) {
++                    entityboat.setCustomName(itemstack.getName());
++                }
++                // Purpur end
+                 if (!world.getCubes(entityboat, entityboat.getBoundingBox().g(-0.1D))) {
+                     return InteractionResultWrapper.fail(itemstack);
+                 } else {
+diff --git a/src/main/java/net/minecraft/server/ItemHanging.java b/src/main/java/net/minecraft/server/ItemHanging.java
+index a3eaeeda8..f2f800087 100644
+--- a/src/main/java/net/minecraft/server/ItemHanging.java
++++ b/src/main/java/net/minecraft/server/ItemHanging.java
+@@ -26,7 +26,7 @@ public class ItemHanging extends Item {
+             return EnumInteractionResult.FAIL;
+         } else {
+             World world = itemactioncontext.getWorld();
+-            Object object;
++            Entity object; // Purpur
+ 
+             if (this.a == EntityTypes.PAINTING) {
+                 object = new EntityPainting(world, blockposition1, enumdirection);
+@@ -42,6 +42,11 @@ public class ItemHanging extends Item {
+ 
+             if (nbttagcompound != null) {
+                 EntityTypes.a(world, entityhuman, (Entity) object, nbttagcompound);
++                // Purpur start
++                if (itemactioncontext.getWorld().purpurConfig.persistentDroppableEntityDisplayNames && itemactioncontext.getItemStack().hasName()) {
++                    object.setCustomName(itemactioncontext.getItemStack().getName());
++                }
++                // Purpur end
+             }
+ 
+             if (((EntityHanging) object).survives()) {
+diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
+index 40f553e39..7161eba52 100644
+--- a/src/main/java/net/minecraft/server/ItemStack.java
++++ b/src/main/java/net/minecraft/server/ItemStack.java
+@@ -738,6 +738,7 @@ public final class ItemStack {
+         return this.getItem().h(this);
+     }
+ 
++    public ItemStack setName(@Nullable IChatBaseComponent component) { return this.a(component); } // Purpur - OBFHELPER
+     public ItemStack a(@Nullable IChatBaseComponent ichatbasecomponent) {
+         NBTTagCompound nbttagcompound = this.a("display");
+ 
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index f72197d70..48e8e2e34 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -83,8 +83,10 @@ public class PurpurWorldConfig {
+         return PurpurConfig.config.getString("world-settings." + worldName + "." + path, PurpurConfig.config.getString("world-settings.default." + path));
+     }
+ 
++    public boolean armorstandSetNameVisible = false;
+     public float armorstandStepHeight = 0.0F;
+     private void armorstandSettings() {
++        armorstandSetNameVisible = getBoolean("gameplay-mechanics.armorstand.set-name-visible-when-placing-with-custom-name", armorstandSetNameVisible);
+         armorstandStepHeight = (float) getDouble("gameplay-mechanics.armorstand.step-height", armorstandStepHeight);
+     }
+ 
+@@ -201,6 +203,7 @@ public class PurpurWorldConfig {
+     public boolean milkCuresBadOmen = true;
+     public boolean saveProjectilesToDisk = true;
+     public boolean persistentTileEntityDisplayNames = false;
++    public boolean persistentDroppableEntityDisplayNames = false;
+     public double tridentLoyaltyVoidReturnHeight = 0.0D;
+     public double voidDamageHeight = -64.0D;
+     public int raidCooldownSeconds = 0;
+@@ -215,6 +218,7 @@ public class PurpurWorldConfig {
+         milkCuresBadOmen = getBoolean("gameplay-mechanics.milk-cures-bad-omen", milkCuresBadOmen);
+         saveProjectilesToDisk = getBoolean("gameplay-mechanics.save-projectiles-to-disk", saveProjectilesToDisk);
+         persistentTileEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-tileentity-display-names-and-lore", persistentTileEntityDisplayNames);
++        persistentDroppableEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-droppable-entity-display-names", persistentDroppableEntityDisplayNames);
+         tridentLoyaltyVoidReturnHeight = getDouble("gameplay-mechanics.trident-loyalty-void-return-height", tridentLoyaltyVoidReturnHeight);
+         voidDamageHeight = getDouble("gameplay-mechanics.void-damage-height", voidDamageHeight);
+         raidCooldownSeconds = getInt("gameplay-mechanics.raid-cooldown-seconds", raidCooldownSeconds);

--- a/patches/server/0144-Set-name-visible-when-using-a-Name-Tag-on-an-Armor-S.patch
+++ b/patches/server/0144-Set-name-visible-when-using-a-Name-Tag-on-an-Armor-S.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Tue, 17 Nov 2020 13:12:09 -0800
+Subject: [PATCH] Set name visible when using a Name Tag on an Armor Stand
+
+
+diff --git a/src/main/java/net/minecraft/server/ItemNameTag.java b/src/main/java/net/minecraft/server/ItemNameTag.java
+index 01163ce38..a7efce973 100644
+--- a/src/main/java/net/minecraft/server/ItemNameTag.java
++++ b/src/main/java/net/minecraft/server/ItemNameTag.java
+@@ -11,6 +11,11 @@ public class ItemNameTag extends Item {
+         if (itemstack.hasName() && !(entityliving instanceof EntityHuman)) {
+             if (!entityhuman.world.isClientSide && entityliving.isAlive()) {
+                 entityliving.setCustomName(itemstack.getName());
++                // Purpur start
++                if (entityhuman.world.purpurConfig.armorstandFixNametags && entityliving instanceof EntityArmorStand) {
++                    entityliving.setCustomNameVisible(true);
++                }
++                // Purpur end
+                 if (entityliving instanceof EntityInsentient) {
+                     ((EntityInsentient) entityliving).setPersistent();
+                 }
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 48e8e2e34..fad502179 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -84,9 +84,11 @@ public class PurpurWorldConfig {
+     }
+ 
+     public boolean armorstandSetNameVisible = false;
++    public boolean armorstandFixNametags = false;
+     public float armorstandStepHeight = 0.0F;
+     private void armorstandSettings() {
+         armorstandSetNameVisible = getBoolean("gameplay-mechanics.armorstand.set-name-visible-when-placing-with-custom-name", armorstandSetNameVisible);
++        armorstandFixNametags = getBoolean("gameplay-mechanics.armorstand.fix-nametags", armorstandFixNametags);
+         armorstandStepHeight = (float) getDouble("gameplay-mechanics.armorstand.step-height", armorstandStepHeight);
+     }
+ 


### PR DESCRIPTION
- Apply display names from item forms of entities to entities and vice versa
  - Default false config option
  - Uses the same logic vanilla does for minecarts to persist custom names for other types of items with entity forms.
  - Also adds a default false option which makes it so when an armor stand is placed with a custom name, it's custom name is set to be visible.
- Set name visible when using a Name Tag on an Armor Stand
  - Armor stands can be nametagged in vanilla, consuming the nametag and naming the armor stand, but the name will not be visible.
  - Default false config option