### PR TITLE
Add config for allowing Endermen to despawn even while holding a block

### DIFF
--- a/patches/server/0144-Add-config-for-allowing-Endermen-to-despawn-even-whi.patch
+++ b/patches/server/0144-Add-config-for-allowing-Endermen-to-despawn-even-whi.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Sun, 22 Nov 2020 22:17:53 -0800
+Subject: [PATCH] Add config for allowing Endermen to despawn even while
+ holding a block
+
+This should help to reduce the amount of dirt, gravel, grass, and etc.
+that Endermen like to randomly place all over the world.
+
+diff --git a/src/main/java/net/minecraft/server/EntityEnderman.java b/src/main/java/net/minecraft/server/EntityEnderman.java
+index 995849212c..acb2b3ed04 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderman.java
++++ b/src/main/java/net/minecraft/server/EntityEnderman.java
+@@ -372,7 +372,7 @@ public class EntityEnderman extends EntityMonster implements IEntityAngerable {
+ 
+     @Override
+     public boolean isSpecialPersistence() {
+-        return super.isSpecialPersistence() || this.getCarried() != null;
++        return super.isSpecialPersistence() || (!this.world.purpurConfig.endermanDespawnEvenWithBlock && this.getCarried() != null); // Purpur
+     }
+ 
+     static class PathfinderGoalEndermanPickupBlock extends PathfinderGoal {
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 9dd8d694c4..ff1afb3539 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -585,10 +585,12 @@ public class PurpurWorldConfig {
+     public boolean endermanRidable = false;
+     public boolean endermanRidableInWater = false;
+     public boolean endermanAllowGriefing = true;
++    public boolean endermanDespawnEvenWithBlock = false;
+     private void endermanSettings() {
+         endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
+         endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
+         endermanAllowGriefing = getBoolean("mobs.enderman.allow-griefing", endermanAllowGriefing);
++        endermanDespawnEvenWithBlock = getBoolean("mobs.enderman.can-despawn-with-held-block", endermanDespawnEvenWithBlock);
+     }
+ 
+     public boolean endermiteRidable = false;


### PR DESCRIPTION
Endermen that are holding blocks are unable to despawn, which causes worlds to become littered with randomly placed gravel, dirt, grass and etc.

This patch should reduce the amount of random blocks placed by endermen, without completely removing the mechanic.