### PR TITLE
[ci-skip] Update readme with downloads API info

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,24 @@ Join us on [Discord](https://discord.gg/mtAAnkk)
 ## Downloads
 [![Download from Jenkins CI](https://img.shields.io/jenkins/build?jobUrl=https%3A%2F%2Fci.pl3x.net%2Fjob%2FPurpur&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB0AAAAgCAYAAADud3N8AAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw1AUhU9TpUUrHewg4pChOlkQFXHUKhShQqgVWnUweekfNDEkKS6OgmvBwZ/FqoOLs64OroIg+APi5Oik6CIl3pcUWsT44PI+znvncN99gNCoMs3qGgM03TYzqaSYy6+IoVeEEaXqhSAzy5iVpDR819c9Any/S/As/3t/rj61YDEgIBLPMMO0ideJpzZtg/M+cYyVZZX4nHjUpAaJH7muePzGueSywDNjZjYzRxwjFksdrHQwK5sa8SRxXNV0yhdyHquctzhr1Rpr9clfGCnoy0tcpxpCCgtYhAQRCmqooAobCdp1Uixk6Dzp4x90/RK5FHJVwMgxjw1okF0/+B/8nq1VnBj3kiJJoPvFcT6GgdAu0Kw7zvex4zRPgOAzcKW3/RsNYPqT9Hpbix8B0W3g4rqtKXvA5Q4w8GTIpuxKQSqhWATez+ib8kD/LdCz6s2tdY7TByBLs0rfAAeHwEiJstd83h3unNu/d1rz+wHYXHJptwl4jgAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB+QIDwgMGJjYLkEAAAejSURBVEjHtZZrcJTVGcd/Z2/v3nO/b0hCkiVIQEhIs9BgBRRhsGDRglinH7CdikVlcNqqzFjtzakMrbbVirSECm2HkTJcpQJTCFRZEknCTWBDEkgCmwu5brL33bcfdpNsgAh86Jl5Z973PZffeZ7zPM/5C+6xWUtsCmB+9CkHsoDcaHcbcB2oBo4Ahxy19tB4a4l7gGmB1cBPgIzYPq1GyZJZhahVCjp7BjlU1zK8oBP4JYhNjtqT4XuGFpbYELASeAsojO1b+1Q5j1VMJdeSgkIxusSQx8eFhjb+caCagzXNAF8AKxy19ra7Qq0lNguwA5gtqVWkxJtp7+ljSnYCb699gvwJaV/rHVmWOfHlZV7auAePP3QNqIgFizsA44A6IUReQVYacSYjZxqaKbemsvGnK4g36+81DLjc7GT5qx/jDYS+CIfliiv1p2QA5a0DkzIsvwUWZiYnoFGpaOvoQq2U2fzGM6QkmgFo7+rjSksHSqUSg04aFxoIhJCDfuoa2rOFEF3dzraa2yy1ltgeAvYCcbH/31w1l5WPzwLgX5/V8PqmwwDoNSpObXsFjfq2vXPt+k3mrN6EViWGIe1AtqPWHlTFABOB/XpJY8pMTkCv06JRq6m73IQ/EASg4Wo7r286zNvPP8r0yTnoddIdgQDpKfG07F3PzV4Xf91ZxZaDZ9OBRcA+Rcy4xwFTQXYGacmJmAx6lAoFoXCY5AQjAKfONPLu2sUsW1DGxOxU0pPjxnWtpInYk5xg4sVnFyAi5i4CiIUWA2il0TPqHxwCYEqhJTLAamH+rCm3RapryDPm36DbN/LuGvKi12lYOquAaFEZAx2MLBKOyTsPGpWCnMxkAKZPzkGjVo0BeP1B9h+tH/kOyzJHPj838n285hJuj4/igkyAqdYS2xhoM8CNzm5anZ30uwbxB4LMmWpBiPELl05Ss/3T0wwMRqwdcvvY8VktoXA46l4jOz49hV6nAVADUuy24wC0yiB6Sc25plYUCsF/6gfw+PzoJM0Y2DlHKxsqDzExKxF/IMR5RyuzS6wY9RLnW3qoPtOIs6uPTw7XU9vYRUG6eXhqgjIauXrgwLIKq/b3P1tB+bRcRNDP2aYuABZ/s4ikeOMYqEatwqhVkZpk5hFbEbNnFKJQKBBCoAj5+dOO/zJnRj5FeWksfWgyk3JSOVrbDPDusHtLgbjvPlbK8ZqLLHmlEldMMASiKRPbEswGlswv5TuPzmSe7QFUqtHUWbnYhiXFxMZtRyl/MJ8FFdNiU2tgGJoIYNBrSUuOY+W8B/jWzEI2rFlI1aYXRqL3XlucSc97rz2NQauhctcJAPz+yMZlgWv4TJsAnJ19PFRWhFKpZGZx3n2B7PVXEEKQmxWJ9Pab/SSatVzvHACgsa0L4GLDaTvD0HNAY+Xuk/mlxXn3DQQoyEnjyXWbae/3jl6PGWbefOHbyLLMvs8dAF+Nqb3WEtsiYN83ClOVKxaWcsR+iR8+Nee+XHuz10WrsxsAk0HHhMwkNGoVzW1dLHxpM8AaR639/ZGUcdTaD1pLbIuqGzo/qG44WJBolFhn1N0V5PEFOHCsHmQZAIVCYJteSMNVJye+vEyfy01mavzw8N23ViQctfbDIqIStvS7/aQmjuQWLc5ufP6xUXzlWgc6Sc3SeTPITEugraOXi41OPF4/Nzr7yEyN5/tPVPDRLjtR3XT9jvdpt7ONpAyLUpZZMb90ImnRou4a8lJ9tpGCnFHV0NbRw+ZPqpBlGZNeIiczicKcNIx6iYqZkyjISWP/0Tr2RM7zuW5n2zUA1The+zfQt/doffy0ogkAWNITee/jw6QmmiiZEgm0aZMmUPfVNVa/s3tkYopZy9a3vgfAxcbrrP/oCAohdikEVXfTSBlR8LS/vbEc2/QCAHr6h3jx1//kyUceZPHD05E06sht5HKPuN6glzDoJE5faObld3bR5fIBnASecdTar97m3kkls0jKsKwC9gE5ALurLiD7PCSY9STGGSgrzuG5X+3kYNVZlISQkZGiN08gGOJS0w3+svM4v6g8htsfkb5CKLJBXpWUYbnY7Wy7HJsyucAWYK7BHE9GXgHNF84QCgYw6nUMuj0jV5dC3FUu87AS8hRQGYCM3Hz6ujrxDLkAfqwsLC0nOSP7R8AeIRTWrHwrmflWNJIWZJnB/l5+8OxK1q15nskF+ZywV/OhXubnRpm5KgiFBZdukdOvSTIvG2XKNDJ/9gpM5ngshUW4+noJ+n1lCiGLPwIfGuLiDZNKy0nKyEIOhxnq70XS6YlLSuGDym387g/vo9NGVIUcPZcitcx6U4T4tAp2GGV0QDDarwTKFOAZGiQcDiMiwrxZBSyVdHomFs9ACIHf68E7NIgcTfb4lDQkvYEzjiZqfrMBgM4Yy+RoCmgFSCLy7gwLOkMyQaBVBjkcxtVzE/dAP8BJFfB3n8f9qt/rQdLpCQWDI8ARdWAwojMYCfh9dLRc5UrID1GLzvsFWQK2BmBrIHLW2wOwPTBad9LNcfi8IzrqmLCW2PKAJnNiMjqTmXAwiN/rGTdA3K4BAn4faQI65YilX9d0RhMaSYvXPYTP4w4CCSIauTuBZfz/205HrX35/wBw2NNcMtE/igAAAABJRU5ErkJggg==)](https://ci.pl3x.net/job/Purpur)
 
-Downloads can be obtained from Pl3x's [Jenkins CI Server](https://ci.pl3x.net/job/Purpur/).
+Downloads can be obtained from the [downloads page](https://purpur.pl3x.net/downloads/), the downloads API, or alternatively, from Pl3x's [Jenkins CI Server](https://ci.pl3x.net/job/Purpur/).
 
-* [1.16.4](https://ci.pl3x.net/job/Purpur/lastSuccessfulBuild/artifact/final/purpurclip.jar) builds 809+
-* [1.16.3](https://ci.pl3x.net/job/Purpur/808/artifact/final/purpurclip-808.jar) builds 751-808
-* [1.16.2](https://ci.pl3x.net/job/Purpur/750/artifact/final/purpurclip-750.jar) builds 711-750
-* [1.16.1](https://ci.pl3x.net/job/Purpur/710/artifact/final/purpurclip-710.jar) builds 608-710
-* [1.15.2](https://ci.pl3x.net/job/Purpur/606/artifact/final/purpurclip-606.jar) builds 398-606
-* [1.15.1](https://ci.pl3x.net/job/Purpur/397/artifact/target/purpur-397.jar) builds 348-397
-* [1.15](https://ci.pl3x.net/job/Purpur/346/artifact/target/purpur-346.jar) builds 339-346
-* [1.14.x](https://ci.pl3x.net/job/Purpur/337/artifact/target/purpur-337.jar) builds 337 and below
+Latest build shortcut links:
+* [1.16.4](https://purpur.pl3x.net/api/v1/purpur/1.16.4/latest/download) builds 809+
+* [1.16.3](https://purpur.pl3x.net/api/v1/purpur/1.16.3/latest/download) builds 751-808
+* [1.16.2](https://purpur.pl3x.net/api/v1/purpur/1.16.2/latest/download) builds 711-750
+* [1.16.1](https://purpur.pl3x.net/api/v1/purpur/1.16.1/latest/download) builds 608-710
+* [1.15.2](https://purpur.pl3x.net/api/v1/purpur/1.15.2/latest/download) builds 398-606
+* [1.15.1](https://purpur.pl3x.net/api/v1/purpur/1.15.1/latest/download) builds 348-397
+* [1.15](https://purpur.pl3x.net/api/v1/purpur/1.15/latest/download) builds 339-346
+* [1.14.x](https://purpur.pl3x.net/api/v1/purpur/1.14.4/latest/download) builds 337 and below
+
+
+Downloads API endpoints:
+ * List versions of Minecraft with builds available: `https://purpur.pl3x.net/api/v1/purpur`
+ * List builds for a version of Minecraft: `https://purpur.pl3x.net/api/v1/purpur/<version>`
+ * Download a specific build of a specific version: `https://purpur.pl3x.net/api/v1/purpur/<version>/<build>/download`
+ * Download the latest build for a version of Minecraft: `https://purpur.pl3x.net/api/v1/purpur/<version>/latest/download`
 
 ## License
 [![MIT License](https://img.shields.io/github/license/pl3xgaming/Purpur?&logo=github)](License)


### PR DESCRIPTION
Added some info about the downloads API to the readme, and reverted the readme to use the Purpur logo instead of the website banner. In my opinion the logo looks much cleaner on the white background of GitHub.