### PR TITLE
(modified from EMC) add disable-give-dropping

### DIFF
--- a/patches/server/0158-EMC-Fix-Give-command.patch
+++ b/patches/server/0158-EMC-Fix-Give-command.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Thu, 14 Jan 2016 00:49:14 -0500
+Subject: [PATCH] (EMC) Fix Give command
+
+
+diff --git a/src/main/java/net/minecraft/server/CommandGive.java b/src/main/java/net/minecraft/server/CommandGive.java
+index 1d22c45af..9537ab1d8 100644
+--- a/src/main/java/net/minecraft/server/CommandGive.java
++++ b/src/main/java/net/minecraft/server/CommandGive.java
+@@ -35,6 +35,7 @@ public class CommandGive {
+                 boolean flag = entityplayer.inventory.pickup(itemstack);
+                 EntityItem entityitem;
+ 
++                if (net.pl3x.purpur.PurpurConfig.fixGiveCommand) continue; // EMC - never drop items // Purpur - add config option for Fix Give command
+                 if (flag && itemstack.isEmpty()) {
+                     itemstack.setCount(1);
+                     entityitem = entityplayer.drop(itemstack, false);
+diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+index c06f7dc24..a8f6c5f57 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+@@ -188,6 +188,11 @@ public class PurpurConfig {
+     private static void useAlternateKeepAlive() {
+         useAlternateKeepAlive = getBoolean("settings.use-alternate-keepalive", useAlternateKeepAlive);
+     }
++    
++    public static boolean fixGiveCommand = false;
++    private static void fixGiveCommand() {
++        fixGiveCommand = getBoolean("settings.fix-give-command", fixGiveCommand);
++    }
+ 
+     public static boolean barrelSixRows = false;
+     public static boolean enderChestSixRows = false;

--- a/patches/server/0158-EMC-disable-give-dropping.patch
+++ b/patches/server/0158-EMC-disable-give-dropping.patch
@@ -1,8 +1,9 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 14 Jan 2016 00:49:14 -0500
-Subject: [PATCH] (EMC) Fix Give command
+Subject: [PATCH] (EMC) Configurable disable give dropping
 
+Modified patch by Aikar in EMC that allows /give's ability to drop items if the player's inventory is full via settings.disable-give-dropping in purpur.yml
 
 diff --git a/src/main/java/net/minecraft/server/CommandGive.java b/src/main/java/net/minecraft/server/CommandGive.java
 index 1d22c45af..9537ab1d8 100644
@@ -12,7 +13,7 @@ index 1d22c45af..9537ab1d8 100644
                  boolean flag = entityplayer.inventory.pickup(itemstack);
                  EntityItem entityitem;
  
-+                if (net.pl3x.purpur.PurpurConfig.fixGiveCommand) continue; // EMC - never drop items // Purpur - add config option for Fix Give command
++                if (net.pl3x.purpur.PurpurConfig.GiveCommandDrops) continue; // EMC - never drop items // Purpur - add config option for toggling give command dropping
                  if (flag && itemstack.isEmpty()) {
                      itemstack.setCount(1);
                      entityitem = entityplayer.drop(itemstack, false);
@@ -25,9 +26,9 @@ index c06f7dc24..a8f6c5f57 100644
          useAlternateKeepAlive = getBoolean("settings.use-alternate-keepalive", useAlternateKeepAlive);
      }
 +    
-+    public static boolean fixGiveCommand = false;
-+    private static void fixGiveCommand() {
-+        fixGiveCommand = getBoolean("settings.fix-give-command", fixGiveCommand);
++    public static boolean GiveCommandDrops = false;
++    private static void GiveCommandDrops() {
++        GiveCommandDrops = getBoolean("settings.disable-give-dropping", GiveCommandDrops);
 +    }
  
      public static boolean barrelSixRows = false;

--- a/patches/server/0158-EMC-disable-give-dropping.patch
+++ b/patches/server/0158-EMC-disable-give-dropping.patch
@@ -13,7 +13,7 @@ index 1d22c45af..9537ab1d8 100644
                  boolean flag = entityplayer.inventory.pickup(itemstack);
                  EntityItem entityitem;
  
-+                if (net.pl3x.purpur.PurpurConfig.GiveCommandDrops) continue; // EMC - never drop items // Purpur - add config option for toggling give command dropping
++                if (net.pl3x.purpur.PurpurConfig.GiveCommandDrops) continue; // Purpur - add config option for toggling give command dropping
                  if (flag && itemstack.isEmpty()) {
                      itemstack.setCount(1);
                      entityitem = entityplayer.drop(itemstack, false);


### PR DESCRIPTION
This PR adds an config option `settings.disable-give-dropping` (that is disabled by default) to disable `/give` spewing out items if the target player's inventory is full. This is taken from https://github.com/starlis/empirecraft/blob/master/patches/server/0057-Fix-Give-command.patch but is simply modified to add a config option that controls it in `purpur.yml`

I tested this without any issues.