### PR TITLE
Spread out player list ticks

### DIFF
--- a/patches/server/0161-Spread-out-player-list-ticks.patch
+++ b/patches/server/0161-Spread-out-player-list-ticks.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: James Lyne <jim+github@not-null.co.uk>
+Date: Mon, 7 Dec 2020 17:52:36 +0000
+Subject: [PATCH] Spread out player list ticks
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 3f634a266..7ac756179 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -919,10 +919,11 @@ public abstract class PlayerList {
+     }
+ 
+     public void tick() {
+-        if (++this.w > 600) {
++        if (true) {
++            int tick = getTick();  // Purpur
+             // CraftBukkit start
+-            for (int i = 0; i < this.players.size(); ++i) {
+-                final EntityPlayer target = (EntityPlayer) this.players.get(i);
++            if (tick < this.players.size()) { // Purpur
++                final EntityPlayer target = (EntityPlayer) this.players.get(tick); // Purpur
+ 
+                 target.playerConnection.sendPacket(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.UPDATE_LATENCY, Iterables.filter(this.players, new Predicate<EntityPlayer>() {
+                     @Override
+@@ -931,12 +932,23 @@ public abstract class PlayerList {
+                     }
+                 })));
+             }
++
+             // CraftBukkit end
+-            this.w = 0;
++            // Purpur start
++            if (tick >= 600) {
++                setTick(0);
++            } else {
++                setTick(tick + 1);
++            }
++            // Purpur end
+         }
+ 
+     }
+ 
++    public final int getTick() { return this.w; } // Purpur - OBFHELPER
++
++    public final void setTick(int tick) { this.w = tick; } // Purpur - OBFHELPER
++
+     public void sendAll(Packet<?> packet) {
+         for (int i = 0; i < this.players.size(); ++i) {
+             ((EntityPlayer) this.players.get(i)).playerConnection.sendPacket(packet);


### PR DESCRIPTION
As discussed on the Discord, this PR spreads out the sending of ping update packets to players across multiple ticks, with one player per tick, rather than sending all updates in a single tick.

This should help prevent periodic lag spikes caused by these packets being sent, on servers with high player counts.