### PR TITLE
Configurable default wolf collar color

### DIFF
--- a/patches/server/0162-Configurable-default-wolf-collar-color.patch
+++ b/patches/server/0162-Configurable-default-wolf-collar-color.patch
@@ -1,12 +1,13 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Encode42 <me@encode42.dev>
 Date: Thu, 10 Dec 2020 13:43:28 -0500
-Subject: [PATCH] Configurable tamed wolf collar color
+Subject: [PATCH] Configurable default wolf collar color
 
 This allows for the server to set a default collar color when a wolf is tamed.
+Resets to RED when the value is invalid.
 
 diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
-index fa7f47fef..f9faeeafd 100644
+index fa7f47fef..ca38c2224 100644
 --- a/src/main/java/net/minecraft/server/EntityWolf.java
 +++ b/src/main/java/net/minecraft/server/EntityWolf.java
 @@ -114,6 +114,12 @@ public class EntityWolf extends EntityTameableAnimal implements IEntityAngerable
@@ -16,14 +17,14 @@ index fa7f47fef..f9faeeafd 100644
 +
 +    @Override
 +    public void tame(EntityHuman entityhuman) {
-+        setCollarColor(world.purpurConfig.wolfTameCollarColor);
++        setCollarColor(world.purpurConfig.wolfDefaultCollarColor);
 +        super.tame(entityhuman);
 +    }
      // Purpur end
  
      @Override
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index e76ae515d..0755805e3 100644
+index e76ae515d..bebceda3c 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -3,6 +3,7 @@ package net.pl3x.purpur;
@@ -38,7 +39,7 @@ index e76ae515d..0755805e3 100644
  
      public boolean wolfRidable = false;
      public boolean wolfRidableInWater = false;
-+    public EnumColor wolfTameCollarColor = EnumColor.RED;
++    public EnumColor wolfDefaultCollarColor = EnumColor.RED;
      public boolean wolfMilkCuresRabies = true;
      public double wolfNaturalRabid = 0.0D;
      public int wolfBreedingTicks = 6000;
@@ -46,9 +47,9 @@ index e76ae515d..0755805e3 100644
          wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
          wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
 +        try {
-+            wolfTameCollarColor = EnumColor.valueOf(getString("mobs.wolf.tamed-collar-color", wolfTameCollarColor.name()));
++            wolfDefaultCollarColor = EnumColor.valueOf(getString("mobs.wolf.default-collar-color", wolfDefaultCollarColor.name()));
 +        } catch (IllegalArgumentException ignore) {
-+            wolfTameCollarColor = EnumColor.RED;
++            wolfDefaultCollarColor = EnumColor.RED;
 +        }
          wolfMilkCuresRabies = getBoolean("mobs.wolf.milk-cures-rabid-wolves", wolfMilkCuresRabies);
          wolfNaturalRabid = getDouble("mobs.wolf.spawn-rabid-chance", wolfNaturalRabid);

--- a/patches/server/0162-Configurable-tamed-wolf-collar-color.patch
+++ b/patches/server/0162-Configurable-tamed-wolf-collar-color.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Thu, 10 Dec 2020 13:43:28 -0500
+Subject: [PATCH] Configurable tamed wolf collar color
+
+This allows for the server to set a default collar color when a wolf is tamed.
+
+diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
+index fa7f47fef..c52f820da 100644
+--- a/src/main/java/net/minecraft/server/EntityWolf.java
++++ b/src/main/java/net/minecraft/server/EntityWolf.java
+@@ -114,6 +114,13 @@ public class EntityWolf extends EntityTameableAnimal implements IEntityAngerable
+         setRabid(world.purpurConfig.wolfNaturalRabid > 0.0D && random.nextDouble() <= world.purpurConfig.wolfNaturalRabid);
+         return super.prepare(worldaccess, difficultydamagescaler, enummobspawn, groupdataentity, nbttagcompound);
+     }
++
++    @Override
++    public void tame(EntityHuman entityhuman) {
++        EnumColor collarColor = EnumColor.valueOf(world.purpurConfig.wolfTameCollarColor);
++        setCollarColor(collarColor == null ? EnumColor.RED : collarColor);
++        super.tame(entityhuman);
++    }
+     // Purpur end
+ 
+     @Override
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index e76ae515d..fd0ed0235 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -1128,12 +1128,14 @@ public class PurpurWorldConfig {
+ 
+     public boolean wolfRidable = false;
+     public boolean wolfRidableInWater = false;
++    public String wolfTameCollarColor = "RED";
+     public boolean wolfMilkCuresRabies = true;
+     public double wolfNaturalRabid = 0.0D;
+     public int wolfBreedingTicks = 6000;
+     private void wolfSettings() {
+         wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
+         wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
++        wolfTameCollarColor = getString("mobs.wolf.tamed-collar-color", wolfTameCollarColor);
+         wolfMilkCuresRabies = getBoolean("mobs.wolf.milk-cures-rabid-wolves", wolfMilkCuresRabies);
+         wolfNaturalRabid = getDouble("mobs.wolf.spawn-rabid-chance", wolfNaturalRabid);
+         wolfBreedingTicks = getInt("mobs.wolf.breeding-delay-ticks", wolfBreedingTicks);

--- a/patches/server/0162-Configurable-tamed-wolf-collar-color.patch
+++ b/patches/server/0162-Configurable-tamed-wolf-collar-color.patch
@@ -6,39 +6,50 @@ Subject: [PATCH] Configurable tamed wolf collar color
 This allows for the server to set a default collar color when a wolf is tamed.
 
 diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
-index fa7f47fef..c52f820da 100644
+index fa7f47fef..f9faeeafd 100644
 --- a/src/main/java/net/minecraft/server/EntityWolf.java
 +++ b/src/main/java/net/minecraft/server/EntityWolf.java
-@@ -114,6 +114,13 @@ public class EntityWolf extends EntityTameableAnimal implements IEntityAngerable
+@@ -114,6 +114,12 @@ public class EntityWolf extends EntityTameableAnimal implements IEntityAngerable
          setRabid(world.purpurConfig.wolfNaturalRabid > 0.0D && random.nextDouble() <= world.purpurConfig.wolfNaturalRabid);
          return super.prepare(worldaccess, difficultydamagescaler, enummobspawn, groupdataentity, nbttagcompound);
      }
 +
 +    @Override
 +    public void tame(EntityHuman entityhuman) {
-+        EnumColor collarColor = EnumColor.valueOf(world.purpurConfig.wolfTameCollarColor);
-+        setCollarColor(collarColor == null ? EnumColor.RED : collarColor);
++        setCollarColor(world.purpurConfig.wolfTameCollarColor);
 +        super.tame(entityhuman);
 +    }
      // Purpur end
  
      @Override
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index e76ae515d..fd0ed0235 100644
+index e76ae515d..0755805e3 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-@@ -1128,12 +1128,14 @@ public class PurpurWorldConfig {
+@@ -3,6 +3,7 @@ package net.pl3x.purpur;
+ import com.destroystokyo.paper.PaperConfig;
+ import net.minecraft.server.Block;
+ import net.minecraft.server.Blocks;
++import net.minecraft.server.EnumColor;
+ import net.minecraft.server.EnumDifficulty;
+ import net.minecraft.server.Explosion;
+ import net.minecraft.server.IRegistry;
+@@ -1128,12 +1129,18 @@ public class PurpurWorldConfig {
  
      public boolean wolfRidable = false;
      public boolean wolfRidableInWater = false;
-+    public String wolfTameCollarColor = "RED";
++    public EnumColor wolfTameCollarColor = EnumColor.RED;
      public boolean wolfMilkCuresRabies = true;
      public double wolfNaturalRabid = 0.0D;
      public int wolfBreedingTicks = 6000;
      private void wolfSettings() {
          wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
          wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
-+        wolfTameCollarColor = getString("mobs.wolf.tamed-collar-color", wolfTameCollarColor);
++        try {
++            wolfTameCollarColor = EnumColor.valueOf(getString("mobs.wolf.tamed-collar-color", wolfTameCollarColor.name()));
++        } catch (IllegalArgumentException ignore) {
++            wolfTameCollarColor = EnumColor.RED;
++        }
          wolfMilkCuresRabies = getBoolean("mobs.wolf.milk-cures-rabid-wolves", wolfMilkCuresRabies);
          wolfNaturalRabid = getDouble("mobs.wolf.spawn-rabid-chance", wolfNaturalRabid);
          wolfBreedingTicks = getInt("mobs.wolf.breeding-delay-ticks", wolfBreedingTicks);


### PR DESCRIPTION
Configurable via `world-settings.<world>.mobs.wolf.default-collar-color`.
Takes EnumColor as an input. Invalid inputs default to RED.