### PR TITLE
The dead could still cause lag

### DIFF
--- a/patches/server/0055-Fix-the-dead-lagging-the-server.patch
+++ b/patches/server/0055-Fix-the-dead-lagging-the-server.patch
@@ -5,17 +5,18 @@ Subject: [PATCH] Fix the dead lagging the server
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 3d1c3232632e49ae2d7a22c9a48545540200efa0..cbdfc8d929f9419d49b0642e8cfc7219741e0e38 100644
+index 3d1c3232632e49ae2d7a22c9a48545540200efa0..ab2111c0b99624e20584d2769eff5e87bb625722 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -1532,6 +1532,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
-         this.pitch = MathHelper.a(f1, -90.0F, 90.0F) % 360.0F;
-         this.lastYaw = this.yaw;
-         this.lastPitch = this.pitch;
+@@ -1542,7 +1542,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+         this.lastY = d1;
+         this.lastZ = d4;
+         this.setPosition(d3, d1, d4);
+-        if (valid) world.getChunkAt((int) Math.floor(this.locX()) >> 4, (int) Math.floor(this.locZ()) >> 4); // CraftBukkit // Paper
 +        if (valid && !dead) world.getChunkAt((int) Math.floor(this.locX()) >> 4, (int) Math.floor(this.locZ()) >> 4); // CraftBukkit // Paper // Purpur
      }
  
-     public void f(double d0, double d1, double d2) {
+     public void d(Vec3D vec3d) {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
 index 737b812d3932de29233b26fe7a978b98b2c3cc8f..435726651ada6ccb4bbd31fe21a439d29f131098 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java

--- a/patches/server/0071-Add-canSaveToDisk-to-Entity.patch
+++ b/patches/server/0071-Add-canSaveToDisk-to-Entity.patch
@@ -17,7 +17,7 @@ index 423da11d4910bbe12625ec5a16edfd6e80cd3dea..77f31dc1e45b438ece691617deb17d7a
                          final EntityTypes<?> projectileType = entity.getEntityType();
                          if (savedProjectileCounts.getOrDefault(projectileType, 0) >= worldserver.paperConfig.projectileSaveLimit) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index cbdfc8d929f9419d49b0642e8cfc7219741e0e38..85f7c97136195bd7c77685244e89ceedec72dee5 100644
+index ab2111c0b99624e20584d2769eff5e87bb625722..7851ed934c02311c59663b498c41c9ac3767fd22 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -308,6 +308,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/patches/server/0072-Configurable-void-damage-height.patch
+++ b/patches/server/0072-Configurable-void-damage-height.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable void damage height
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 85f7c97136195bd7c77685244e89ceedec72dee5..2e6b621694c4bbaeb2d7e3e2773bacda8374aa0d 100644
+index 7851ed934c02311c59663b498c41c9ac3767fd22..15de47bdd6a277faf7a60f9981c973d15f48032d 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -611,7 +611,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/patches/server/0080-Item-entity-immunities.patch
+++ b/patches/server/0080-Item-entity-immunities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Item entity immunities
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 2e6b621694c4bbaeb2d7e3e2773bacda8374aa0d..308cb9cfb418e63f17f8f39c3db94f93d874763f 100644
+index 15de47bdd6a277faf7a60f9981c973d15f48032d..dcf90733475dad49f7225990693598b127227bfd 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1481,6 +1481,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/patches/server/0083-Phantoms-attracted-to-crystals-and-crystals-shoot-ph.patch
+++ b/patches/server/0083-Phantoms-attracted-to-crystals-and-crystals-shoot-ph.patch
@@ -17,10 +17,10 @@ index 6fe5678cffc2487fe00c953d772f764bb37a4b11..bd0267ee4b3782f6d1ec39cba7966ba4
          return (new EntityDamageSourceIndirect("indirectMagic", entity, entity1)).setIgnoreArmor().setMagic();
      }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 308cb9cfb418e63f17f8f39c3db94f93d874763f..d542cd8014a929b421e631075f1ee14423e9b66a 100644
+index dcf90733475dad49f7225990693598b127227bfd..bd1ed7ae33366b898771963d3b4db21c9a9d9cb9 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -2146,8 +2146,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2145,8 +2145,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          return this.a(new ItemStack(imaterial), (float) i);
      }
  

--- a/patches/server/0109-Stop-squids-floating-on-top-of-water.patch
+++ b/patches/server/0109-Stop-squids-floating-on-top-of-water.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Stop squids floating on top of water
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d542cd8014a929b421e631075f1ee14423e9b66a..bbe567dad1212ad3a49503ca9b33c3f28c58a16d 100644
+index bd1ed7ae33366b898771963d3b4db21c9a9d9cb9..53d0b9f6db4c34a8520faba965cc8adc7ee5eb45 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -3450,8 +3450,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3449,8 +3449,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          this.lastYaw = this.yaw;
      }
  

--- a/patches/server/0110-Ridables.patch
+++ b/patches/server/0110-Ridables.patch
@@ -161,7 +161,7 @@ index bd0267ee4b3782f6d1ec39cba7966ba4f62f1adf..8b36ac2b0950a827763aa2357700f37e
          this.B = true;
          return this;
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index bbe567dad1212ad3a49503ca9b33c3f28c58a16d..0be1f47b13f617a7aaad4d6334929d9e5f943d3e 100644
+index 53d0b9f6db4c34a8520faba965cc8adc7ee5eb45..12e622876ef3a706fffdc614495e07a84f880729 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -80,7 +80,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -208,7 +208,7 @@ index bbe567dad1212ad3a49503ca9b33c3f28c58a16d..0be1f47b13f617a7aaad4d6334929d9e
      public void a(float f, Vec3D vec3d) {
          Vec3D vec3d1 = a(vec3d, f, this.yaw);
  
-@@ -2246,6 +2247,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2245,6 +2246,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          return this.a(entity, false);
      }
  
@@ -216,7 +216,7 @@ index bbe567dad1212ad3a49503ca9b33c3f28c58a16d..0be1f47b13f617a7aaad4d6334929d9e
      public boolean a(Entity entity, boolean flag) {
          for (Entity entity1 = entity; entity1.vehicle != null; entity1 = entity1.vehicle) {
              if (entity1.vehicle == this) {
-@@ -2341,6 +2343,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2340,6 +2342,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
                  this.passengers.add(entity);
              }
  
@@ -230,7 +230,7 @@ index bbe567dad1212ad3a49503ca9b33c3f28c58a16d..0be1f47b13f617a7aaad4d6334929d9e
          }
          return true; // CraftBukkit
      }
-@@ -2381,6 +2390,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2380,6 +2389,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
                  return false;
              }
              // Spigot end
@@ -243,7 +243,7 @@ index bbe567dad1212ad3a49503ca9b33c3f28c58a16d..0be1f47b13f617a7aaad4d6334929d9e
              this.passengers.remove(entity);
              entity.j = 60;
          }
-@@ -2546,6 +2561,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2545,6 +2560,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          this.setFlag(4, flag);
      }
  
@@ -251,7 +251,7 @@ index bbe567dad1212ad3a49503ca9b33c3f28c58a16d..0be1f47b13f617a7aaad4d6334929d9e
      public boolean bE() {
          return this.glowing || this.world.isClientSide && this.getFlag(6);
      }
-@@ -2768,6 +2784,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2767,6 +2783,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
  
      public void setHeadRotation(float f) {}
  
@@ -259,7 +259,7 @@ index bbe567dad1212ad3a49503ca9b33c3f28c58a16d..0be1f47b13f617a7aaad4d6334929d9e
      public void n(float f) {}
  
      public boolean bL() {
-@@ -3203,6 +3220,18 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3202,6 +3219,18 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          return false;
      }
  
@@ -278,7 +278,7 @@ index bbe567dad1212ad3a49503ca9b33c3f28c58a16d..0be1f47b13f617a7aaad4d6334929d9e
      @Override
      public void sendMessage(IChatBaseComponent ichatbasecomponent, UUID uuid) {}
  
-@@ -3655,4 +3684,47 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3654,4 +3683,47 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          return ((ChunkProviderServer) world.getChunkProvider()).isInEntityTickingChunk(this);
      }
      // Paper end

--- a/patches/server/0113-Entities-can-use-portals-configuration.patch
+++ b/patches/server/0113-Entities-can-use-portals-configuration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entities can use portals configuration
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 0be1f47b13f617a7aaad4d6334929d9e5f943d3e..b882c049870e461472fe3252922f206c6045dbff 100644
+index 12e622876ef3a706fffdc614495e07a84f880729..34dce026f216fda50d97501ef0bde197aa477927 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -2422,7 +2422,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2421,7 +2421,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
      public void d(BlockPosition blockposition) {
          if (this.ai()) {
              this.resetPortalCooldown();
@@ -17,7 +17,7 @@ index 0be1f47b13f617a7aaad4d6334929d9e5f943d3e..b882c049870e461472fe3252922f206c
              if (!this.world.isClientSide && !blockposition.equals(this.ac)) {
                  this.ac = blockposition.immutableCopy();
              }
-@@ -2996,7 +2996,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2995,7 +2995,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
      }
  
      public boolean canPortal() {

--- a/patches/server/0152-Lobotomize-stuck-villagers.patch
+++ b/patches/server/0152-Lobotomize-stuck-villagers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Lobotomize stuck villagers
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index b882c049870e461472fe3252922f206c6045dbff..073be230a8c0e2ccf6b4304e2988c270749f1a35 100644
+index 34dce026f216fda50d97501ef0bde197aa477927..50c6750dcc94aa27d694e9400f8984a4b8cb8eb7 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -114,7 +114,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke


### PR DESCRIPTION
Paper moved this a while back so this wasn't blocking dead entities from causing lag. Plus was causing a double getChunkAt for valid and alive entities.