### PR TITLE
Add mobGriefing bypass to everything else

### DIFF
--- a/patches/server/0166-Add-mobGriefing-bypass-to-everything-affected.patch
+++ b/patches/server/0166-Add-mobGriefing-bypass-to-everything-affected.patch
@@ -1,0 +1,560 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Tue, 5 Jan 2021 22:21:56 -0500
+Subject: [PATCH] Add mobGriefing bypass to everything affected
+
+This adds the "bypass-mob-griefing" world config option to everything that is affected by the gamerule.
+
+diff --git a/src/main/java/net/minecraft/server/BlockCampfire.java b/src/main/java/net/minecraft/server/BlockCampfire.java
+index 7b37bb1a3f9d274acfb49f6708927e9b2ea6bdeb..331c9d55f685b25331349d01091b446894363530 100644
+--- a/src/main/java/net/minecraft/server/BlockCampfire.java
++++ b/src/main/java/net/minecraft/server/BlockCampfire.java
+@@ -139,7 +139,7 @@ public class BlockCampfire extends BlockTileEntity implements IBlockWaterlogged
+     public void a(World world, IBlockData iblockdata, MovingObjectPositionBlock movingobjectpositionblock, IProjectile iprojectile) {
+         if (!world.isClientSide && iprojectile.isBurning()) {
+             Entity entity = iprojectile.getShooter();
+-            boolean flag = entity == null || entity instanceof EntityHuman || world.getGameRules().getBoolean(GameRules.MOB_GRIEFING);
++            boolean flag = entity == null || entity instanceof EntityHuman || world.purpurConfig.fireballsBypassMobGriefing || world.getGameRules().getBoolean(GameRules.MOB_GRIEFING); // Purpur
+ 
+             if (flag && !(Boolean) iblockdata.get(BlockCampfire.b) && !(Boolean) iblockdata.get(BlockCampfire.d)) {
+                 BlockPosition blockposition = movingobjectpositionblock.getBlockPosition();
+diff --git a/src/main/java/net/minecraft/server/BlockCrops.java b/src/main/java/net/minecraft/server/BlockCrops.java
+index 0fdc960fa3bbe6506185480a7a86d5009d70b385..d49c309d7c31b3be0a21544ba23c0fd663f3317b 100644
+--- a/src/main/java/net/minecraft/server/BlockCrops.java
++++ b/src/main/java/net/minecraft/server/BlockCrops.java
+@@ -144,7 +144,7 @@ public class BlockCrops extends BlockPlant implements IBlockFragilePlantElement
+ 
+     @Override
+     public void a(IBlockData iblockdata, World world, BlockPosition blockposition, Entity entity) {
+-        if (entity instanceof EntityRavager && !CraftEventFactory.callEntityChangeBlockEvent(entity, blockposition, Blocks.AIR.getBlockData(), !world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)).isCancelled()) { // CraftBukkit
++        if (entity instanceof EntityRavager && !CraftEventFactory.callEntityChangeBlockEvent(entity, blockposition, Blocks.AIR.getBlockData(), (!world.purpurConfig.ravagerBypassMobGriefing && !world.getGameRules().getBoolean(GameRules.MOB_GRIEFING))).isCancelled()) { // CraftBukkit // Purpur
+             world.a(blockposition, true, entity);
+         }
+ 
+diff --git a/src/main/java/net/minecraft/server/BlockSoil.java b/src/main/java/net/minecraft/server/BlockSoil.java
+index 099e0d3df219408ebe2a741a02e53eb9f7def28e..73dc0f499c456c21d298013fbab8c79ebcdecd6b 100644
+--- a/src/main/java/net/minecraft/server/BlockSoil.java
++++ b/src/main/java/net/minecraft/server/BlockSoil.java
+@@ -76,7 +76,7 @@ public class BlockSoil extends Block {
+     @Override
+     public void fallOn(World world, BlockPosition blockposition, Entity entity, float f) {
+         super.fallOn(world, blockposition, entity, f); // CraftBukkit - moved here as game rules / events shouldn't affect fall damage.
+-        if (!world.isClientSide && world.random.nextFloat() < f - 0.5F && entity instanceof EntityLiving && (entity instanceof EntityHuman || world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) && entity.getWidth() * entity.getWidth() * entity.getHeight() > 0.512F) {
++        if (!world.isClientSide && world.random.nextFloat() < f - 0.5F && entity instanceof EntityLiving && (entity instanceof EntityHuman || world.purpurConfig.farmlandBypassMobGriefing || world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) && entity.getWidth() * entity.getWidth() * entity.getHeight() > 0.512F) { // Purpur
+             // CraftBukkit start - Interact soil
+             org.bukkit.event.Cancellable cancellable;
+             if (entity instanceof EntityHuman) {
+diff --git a/src/main/java/net/minecraft/server/BlockTurtleEgg.java b/src/main/java/net/minecraft/server/BlockTurtleEgg.java
+index 92cca6c44f12a9283988b84681aac760f1c38d7e..31f2ca273eb35aa389caf328abe1b0e87c8846f8 100644
+--- a/src/main/java/net/minecraft/server/BlockTurtleEgg.java
++++ b/src/main/java/net/minecraft/server/BlockTurtleEgg.java
+@@ -177,7 +177,7 @@ public class BlockTurtleEgg extends Block {
+             return false;
+         }
+         if (entity instanceof EntityLiving && !(entity instanceof EntityHuman)) {
+-            return world.getGameRules().getBoolean(GameRules.MOB_GRIEFING);
++            return world.purpurConfig.turtleEggsBypassMobGriefing || world.getGameRules().getBoolean(GameRules.MOB_GRIEFING); // Purpur
+         }
+         return true;
+         // Purpur end
+diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
+index 8e16ae4be41a0f20b057b70e9ef255c548a36f08..87b691afd226ec9c59685261c20454c2d312ca17 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
++++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
+@@ -489,7 +489,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
+                     Block block = iblockdata.getBlock();
+ 
+                     if (!iblockdata.isAir() && iblockdata.getMaterial() != Material.FIRE) {
+-                        if (this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) && !TagsBlock.DRAGON_IMMUNE.isTagged(block)) {
++                        if ((this.world.purpurConfig.enderDragonBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) && !TagsBlock.DRAGON_IMMUNE.isTagged(block)) { // Purpur
+                             // CraftBukkit start - Add blocks to list rather than destroying them
+                             // flag1 = this.world.a(blockposition, false) || flag1;
+                             flag1 = true;
+diff --git a/src/main/java/net/minecraft/server/EntityEnderman.java b/src/main/java/net/minecraft/server/EntityEnderman.java
+index dfe6175ec8107f684ea1567d932d11de06c46372..beee80c3d8277f2d784fb6b8a4152a871ee020b0 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderman.java
++++ b/src/main/java/net/minecraft/server/EntityEnderman.java
+@@ -392,7 +392,7 @@ public class EntityEnderman extends EntityMonster implements IEntityAngerable {
+         @Override
+         public boolean a() {
+             if (!enderman.world.purpurConfig.endermanAllowGriefing) return false; // Purpur
+-            return this.enderman.getCarried() != null ? false : (!this.enderman.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) ? false : this.enderman.getRandom().nextInt(20) == 0);
++            return this.enderman.getCarried() != null ? false : (!this.enderman.world.purpurConfig.endermanBypassMobGriefing && !this.enderman.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) ? false : this.enderman.getRandom().nextInt(20) == 0); // Purpur
+         }
+ 
+         @Override
+@@ -435,7 +435,7 @@ public class EntityEnderman extends EntityMonster implements IEntityAngerable {
+         @Override
+         public boolean a() {
+             if (!getEnderman().world.purpurConfig.endermanAllowGriefing) return false; // Purpur
+-            return this.a.getCarried() == null ? false : (!this.a.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) ? false : this.a.getRandom().nextInt(2000) == 0);
++            return this.a.getCarried() == null ? false : (!this.a.world.purpurConfig.endermanBypassMobGriefing && !this.a.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) ? false : this.a.getRandom().nextInt(2000) == 0); // Purpur
+         }
+ 
+         @Override
+diff --git a/src/main/java/net/minecraft/server/EntityEvoker.java b/src/main/java/net/minecraft/server/EntityEvoker.java
+index f0ecc6e6ef5843714a6423af5d6619856ef23977..5f24c36bf45a656e220475449113786732a47c56 100644
+--- a/src/main/java/net/minecraft/server/EntityEvoker.java
++++ b/src/main/java/net/minecraft/server/EntityEvoker.java
+@@ -134,7 +134,7 @@ public class EntityEvoker extends EntityIllagerWizard {
+                 return false;
+             } else if (EntityEvoker.this.ticksLived < this.c) {
+                 return false;
+-            } else if (!EntityEvoker.this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++            } else if (!EntityEvoker.this.world.purpurConfig.evokerBypassMobGriefing && !EntityEvoker.this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) { // Purpur
+                 return false;
+             } else {
+                 List<EntitySheep> list = EntityEvoker.this.world.a(EntitySheep.class, this.e, EntityEvoker.this, EntityEvoker.this.getBoundingBox().grow(16.0D, 4.0D, 16.0D));
+diff --git a/src/main/java/net/minecraft/server/EntityFox.java b/src/main/java/net/minecraft/server/EntityFox.java
+index c63878087ff0414602c4e7ed768a62f8e4899a3a..18d14aca159db9c82a2f56020f503b5d3c4aae59 100644
+--- a/src/main/java/net/minecraft/server/EntityFox.java
++++ b/src/main/java/net/minecraft/server/EntityFox.java
+@@ -1002,7 +1002,7 @@ public class EntityFox extends EntityAnimal {
+         }
+ 
+         protected void n() {
+-            if (EntityFox.this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++            if (EntityFox.this.world.purpurConfig.foxBypassMobGriefing || EntityFox.this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) { // Purpur
+                 IBlockData iblockdata = EntityFox.this.world.getType(this.e);
+ 
+                 if (iblockdata.a(Blocks.SWEET_BERRY_BUSH)) {
+diff --git a/src/main/java/net/minecraft/server/EntityLargeFireball.java b/src/main/java/net/minecraft/server/EntityLargeFireball.java
+index d12de20cf4bb2345c616d3cc0b9f50bddb5135ee..3f3be1b2ded6ad118ae7860c1231c7affc0715b6 100644
+--- a/src/main/java/net/minecraft/server/EntityLargeFireball.java
++++ b/src/main/java/net/minecraft/server/EntityLargeFireball.java
+@@ -8,19 +8,19 @@ public class EntityLargeFireball extends EntityFireballFireball {
+ 
+     public EntityLargeFireball(EntityTypes<? extends EntityLargeFireball> entitytypes, World world) {
+         super(entitytypes, world);
+-        isIncendiary = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING); // CraftBukkit
++        isIncendiary = this.world.purpurConfig.fireballsBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING); // CraftBukkit // Purpur
+     }
+ 
+     public EntityLargeFireball(World world, EntityLiving entityliving, double d0, double d1, double d2) {
+         super(EntityTypes.FIREBALL, entityliving, d0, d1, d2, world);
+-        isIncendiary = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING); // CraftBukkit
++        isIncendiary = this.world.purpurConfig.fireballsBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING); // CraftBukkit // Purpur
+     }
+ 
+     @Override
+     protected void a(MovingObjectPosition movingobjectposition) {
+         super.a(movingobjectposition);
+         if (!this.world.isClientSide) {
+-            boolean flag = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING);
++            boolean flag = this.world.purpurConfig.fireballsBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING); // Purpur
+ 
+             // CraftBukkit start - fire ExplosionPrimeEvent
+             ExplosionPrimeEvent event = new ExplosionPrimeEvent((org.bukkit.entity.Explosive) this.getBukkitEntity());
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 60216266e9b18871b7b00be55805bce191e2105b..58d988d3722b3b452ccf2daf40dd3d486dbc7b48 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -1472,7 +1472,7 @@ public abstract class EntityLiving extends Entity {
+             boolean flag = false;
+ 
+             if (this.killed && entityliving instanceof EntityWither) { // Paper
+-                if (this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++                if (this.world.purpurConfig.witherBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) { // Purpur
+                     BlockPosition blockposition = this.getChunkCoordinates();
+                     IBlockData iblockdata = Blocks.WITHER_ROSE.getBlockData();
+ 
+diff --git a/src/main/java/net/minecraft/server/EntityRabbit.java b/src/main/java/net/minecraft/server/EntityRabbit.java
+index 75f42e91449de71e154e2169ea986ff09224e2f0..9017e56d4ecff810b07271362dce1c1354a3404d 100644
+--- a/src/main/java/net/minecraft/server/EntityRabbit.java
++++ b/src/main/java/net/minecraft/server/EntityRabbit.java
+@@ -462,7 +462,7 @@ public class EntityRabbit extends EntityAnimal {
+         @Override
+         public boolean a() {
+             if (this.c <= 0) {
+-                if (!this.entity.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++                if (!this.entity.world.purpurConfig.rabbitBypassMobGriefing && !this.entity.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) { // Purpur
+                     return false;
+                 }
+ 
+diff --git a/src/main/java/net/minecraft/server/EntityRaider.java b/src/main/java/net/minecraft/server/EntityRaider.java
+index ad2a2c27f0ef064064ded28cc049a6856d476808..e07f224289a937689a26d58639899abbfd6a6302 100644
+--- a/src/main/java/net/minecraft/server/EntityRaider.java
++++ b/src/main/java/net/minecraft/server/EntityRaider.java
+@@ -496,7 +496,7 @@ public abstract class EntityRaider extends EntityMonsterPatrolling {
+ 
+         @Override
+         public boolean a() {
+-            if (!getRaider().world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) || !getRaider().canPickupLoot()) return false; // Paper - respect game and entity rules for picking up items
++            if ((!getRaider().world.purpurConfig.pillagerBypassMobGriefing && !getRaider().world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) || !getRaider().canPickupLoot()) return false; // Paper - respect game and entity rules for picking up items // Purpur
+             Raid raid = this.b.fa();
+ 
+             if (this.b.fb() && !this.b.fa().a() && this.b.eN() && !ItemStack.matches(this.b.getEquipment(EnumItemSlot.HEAD), Raid.s())) {
+diff --git a/src/main/java/net/minecraft/server/EntityRavager.java b/src/main/java/net/minecraft/server/EntityRavager.java
+index 9e21603cb1681cc702084fdeebb6f93754d87bc8..f9df1389189962ce08e50647baffd9eecb00968a 100644
+--- a/src/main/java/net/minecraft/server/EntityRavager.java
++++ b/src/main/java/net/minecraft/server/EntityRavager.java
+@@ -137,7 +137,7 @@ public class EntityRavager extends EntityRaider {
+                 this.getAttributeInstance(GenericAttributes.MOVEMENT_SPEED).setValue(MathHelper.d(0.1D, d1, d0));
+             }
+ 
+-            if (this.positionChanged && this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++            if (this.positionChanged && (this.world.purpurConfig.ravagerBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING))) { // Purpur
+                 boolean flag = false;
+                 AxisAlignedBB axisalignedbb = this.getBoundingBox().g(0.2D);
+                 Iterator iterator = BlockPosition.b(MathHelper.floor(axisalignedbb.minX), MathHelper.floor(axisalignedbb.minY), MathHelper.floor(axisalignedbb.minZ), MathHelper.floor(axisalignedbb.maxX), MathHelper.floor(axisalignedbb.maxY), MathHelper.floor(axisalignedbb.maxZ)).iterator();
+diff --git a/src/main/java/net/minecraft/server/EntitySilverfish.java b/src/main/java/net/minecraft/server/EntitySilverfish.java
+index 6bd00f0b5735d694e370cf85fdbf508c31fc7c27..9ccb7a805adf8c1e429f3fab2bc261c4dad5eda8 100644
+--- a/src/main/java/net/minecraft/server/EntitySilverfish.java
++++ b/src/main/java/net/minecraft/server/EntitySilverfish.java
+@@ -144,7 +144,7 @@ public class EntitySilverfish extends EntityMonster {
+             } else {
+                 Random random = this.a.getRandom();
+ 
+-                if (this.a.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) && random.nextInt(10) == 0) {
++                if ((this.a.world.purpurConfig.silverfishBypassMobGriefing || this.a.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) && random.nextInt(10) == 0) { // Purpur
+                     this.h = EnumDirection.a(random);
+                     BlockPosition blockposition = (new BlockPosition(this.a.locX(), this.a.locY() + 0.5D, this.a.locZ())).shift(this.h);
+                     IBlockData iblockdata = this.a.world.getType(blockposition);
+@@ -232,7 +232,7 @@ public class EntitySilverfish extends EntityMonster {
+                                     continue;
+                                 }
+                                 // CraftBukkit end
+-                                if (world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++                                if (world.purpurConfig.silverfishBypassMobGriefing || world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) { // Purpur
+                                     world.a(blockposition1, true, this.silverfish);
+                                 } else {
+                                     world.setTypeAndData(blockposition1, ((BlockMonsterEggs) block).c().getBlockData(), 3);
+diff --git a/src/main/java/net/minecraft/server/EntitySmallFireball.java b/src/main/java/net/minecraft/server/EntitySmallFireball.java
+index 4ed7a20bfed267776628457a4b33178bac7d1972..e7e12ce2338102b875444c3f3cc767858de38dca 100644
+--- a/src/main/java/net/minecraft/server/EntitySmallFireball.java
++++ b/src/main/java/net/minecraft/server/EntitySmallFireball.java
+@@ -12,7 +12,7 @@ public class EntitySmallFireball extends EntityFireballFireball {
+         super(EntityTypes.SMALL_FIREBALL, entityliving, d0, d1, d2, world);
+         // CraftBukkit start
+         if (this.getShooter() != null && this.getShooter() instanceof EntityInsentient) {
+-            isIncendiary = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING);
++            isIncendiary = this.world.purpurConfig.fireballsBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING); // Purpur
+         }
+         // CraftBukkit end
+     }
+diff --git a/src/main/java/net/minecraft/server/EntitySnowman.java b/src/main/java/net/minecraft/server/EntitySnowman.java
+index 319bb68f27f360bb36897c73a68ddeac64b67a6f..550decf12140596e63b57a7ee5940e4f7b7dbc0b 100644
+--- a/src/main/java/net/minecraft/server/EntitySnowman.java
++++ b/src/main/java/net/minecraft/server/EntitySnowman.java
+@@ -86,7 +86,7 @@ public class EntitySnowman extends EntityGolem implements IShearable, IRangedEnt
+                 this.damageEntity(CraftEventFactory.MELTING, 1.0F); // CraftBukkit - DamageSource.BURN -> CraftEventFactory.MELTING
+             }
+ 
+-            if (!this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++            if (!this.world.purpurConfig.snowGolemBypassMobGriefing && !this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) { // Purpur
+                 return;
+             }
+ 
+diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
+index 71b6fc480617f040029b2201f24d05affeb90b70..48d27d58358e0568579d69320f47e751ea4ec37a 100644
+--- a/src/main/java/net/minecraft/server/EntityWither.java
++++ b/src/main/java/net/minecraft/server/EntityWither.java
+@@ -317,7 +317,7 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
+         if (this.getInvul() > 0) {
+             i = this.getInvul() - 1;
+             if (i <= 0) {
+-                Explosion.Effect explosion_effect = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) ? Explosion.Effect.DESTROY : Explosion.Effect.NONE;
++                Explosion.Effect explosion_effect = (this.world.purpurConfig.witherBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) ? Explosion.Effect.DESTROY : Explosion.Effect.NONE; // Purpur
+                 // CraftBukkit start
+                 // this.world.createExplosion(this, this.locX(), this.getHeadY(), this.locZ(), 7.0F, false, explosion_effect);
+                 ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), 7.0F, false);
+@@ -429,7 +429,7 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
+ 
+             if (this.bw > 0) {
+                 --this.bw;
+-                if (this.bw == 0 && this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++                if (this.bw == 0 && (this.world.purpurConfig.witherBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING))) { // Purpur
+                     i = MathHelper.floor(this.locY());
+                     j = MathHelper.floor(this.locX());
+                     int j1 = MathHelper.floor(this.locZ());
+diff --git a/src/main/java/net/minecraft/server/EntityWitherSkull.java b/src/main/java/net/minecraft/server/EntityWitherSkull.java
+index 4a97a7517dc1a2a25c578d9e168240cc19ab0831..fedc78e4111864d1413e6fcd588b9951595b463a 100644
+--- a/src/main/java/net/minecraft/server/EntityWitherSkull.java
++++ b/src/main/java/net/minecraft/server/EntityWitherSkull.java
+@@ -73,7 +73,7 @@ public class EntityWitherSkull extends EntityFireball {
+     protected void a(MovingObjectPosition movingobjectposition) {
+         super.a(movingobjectposition);
+         if (!this.world.isClientSide) {
+-            Explosion.Effect explosion_effect = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) ? Explosion.Effect.DESTROY : Explosion.Effect.NONE;
++            Explosion.Effect explosion_effect = (this.world.purpurConfig.witherBypassMobGriefing || this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) ? Explosion.Effect.DESTROY : Explosion.Effect.NONE; // Purpur
+ 
+             // CraftBukkit start
+             // this.world.createExplosion(this, this.locX(), this.locY(), this.locZ(), 1.0F, false, explosion_effect);
+diff --git a/src/main/java/net/minecraft/server/PathfinderGoalBreakDoor.java b/src/main/java/net/minecraft/server/PathfinderGoalBreakDoor.java
+index 23870a271b759a953a095df835e08ea2a09f4218..c31bacf786ea750e922c938c042656515d8b0041 100644
+--- a/src/main/java/net/minecraft/server/PathfinderGoalBreakDoor.java
++++ b/src/main/java/net/minecraft/server/PathfinderGoalBreakDoor.java
+@@ -27,7 +27,7 @@ public class PathfinderGoalBreakDoor extends PathfinderGoalDoorInteract {
+ 
+     @Override
+     public boolean a() {
+-        return !super.a() ? false : (!this.entity.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) ? false : this.a(this.entity.world.getDifficulty()) && !this.g());
++        return !super.a() ? false : ((!this.entity.world.purpurConfig.zombieBypassMobGriefing && !this.entity.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) ? false : this.a(this.entity.world.getDifficulty()) && !this.g()); // Purpur
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/PathfinderGoalEatTile.java b/src/main/java/net/minecraft/server/PathfinderGoalEatTile.java
+index b7e1e7e35a33cf6a476b11284ebdb0cdda524af2..9e8f720ee0a39ccc27d671df4ae83ef404788a2f 100644
+--- a/src/main/java/net/minecraft/server/PathfinderGoalEatTile.java
++++ b/src/main/java/net/minecraft/server/PathfinderGoalEatTile.java
+@@ -11,7 +11,7 @@ public class PathfinderGoalEatTile extends PathfinderGoal {
+ 
+     private static final Predicate<IBlockData> a = BlockStatePredicate.a(Blocks.GRASS);
+     private final EntityInsentient b;
+-    private final World c;
++    private final World c; private final World getWorld() { return c; } // Purpur - OBFHELPER
+     private int d;
+ 
+     public PathfinderGoalEatTile(EntityInsentient entityinsentient) {
+@@ -60,7 +60,7 @@ public class PathfinderGoalEatTile extends PathfinderGoal {
+ 
+             if (PathfinderGoalEatTile.a.test(this.c.getType(blockposition))) {
+                 // CraftBukkit
+-                if (!CraftEventFactory.callEntityChangeBlockEvent(this.b, blockposition, Blocks.AIR.getBlockData(), !this.c.getGameRules().getBoolean(GameRules.MOB_GRIEFING)).isCancelled()) {
++                if (!CraftEventFactory.callEntityChangeBlockEvent(this.b, blockposition, Blocks.AIR.getBlockData(), !this.getWorld().purpurConfig.sheepBypassMobGriefing && !this.c.getGameRules().getBoolean(GameRules.MOB_GRIEFING)).isCancelled()) { // Purpur
+                     this.c.b(blockposition, false);
+                 }
+ 
+@@ -70,7 +70,7 @@ public class PathfinderGoalEatTile extends PathfinderGoal {
+ 
+                 if (this.c.getType(blockposition1).a(Blocks.GRASS_BLOCK)) {
+                     // CraftBukkit
+-                    if (!CraftEventFactory.callEntityChangeBlockEvent(this.b, blockposition, Blocks.AIR.getBlockData(), !this.c.getGameRules().getBoolean(GameRules.MOB_GRIEFING)).isCancelled()) {
++                    if (!CraftEventFactory.callEntityChangeBlockEvent(this.b, blockposition, Blocks.AIR.getBlockData(), !this.getWorld().purpurConfig.sheepBypassMobGriefing && !this.c.getGameRules().getBoolean(GameRules.MOB_GRIEFING)).isCancelled()) { // Purpur
+                         this.c.triggerEffect(2001, blockposition1, Block.getCombinedId(Blocks.GRASS_BLOCK.getBlockData()));
+                         this.c.setTypeAndData(blockposition1, Blocks.DIRT.getBlockData(), 2);
+                     }
+diff --git a/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java b/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
+index c03ebbc933197be3e7097ea3f7b7cd08c90db7bb..37c1d1ac1bfcaf84d00135ad3c9d9e9b213fdaea 100644
+--- a/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
++++ b/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
+@@ -23,7 +23,7 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
+ 
+     @Override
+     public boolean a() {
+-        if (!this.entity.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) {
++        if (!this.entity.world.purpurConfig.zombieBypassMobGriefing && !this.entity.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING)) { // Purpur
+             return false;
+         } else if (this.c > 0) {
+             --this.c;
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index dfac03988f3f6bc12f4d48941b3bcde1f2819593..f4da2ab6b2e71b17ad3b2adec264ff3af272535d 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -234,6 +234,7 @@ public class PurpurWorldConfig {
+     public boolean disableDropsOnCrammingDeath = false;
+     public boolean entitiesPickUpLootBypassMobGriefing = false;
+     public boolean entitiesCanUsePortals = true;
++    public boolean fireballsBypassMobGriefing = false;
+     public boolean milkCuresBadOmen = true;
+     public boolean persistentTileEntityDisplayNames = false;
+     public boolean persistentDroppableEntityDisplayNames = false;
+@@ -248,6 +249,7 @@ public class PurpurWorldConfig {
+         disableDropsOnCrammingDeath = getBoolean("gameplay-mechanics.disable-drops-on-cramming-death", disableDropsOnCrammingDeath);
+         entitiesPickUpLootBypassMobGriefing = getBoolean("gameplay-mechanics.entities-pick-up-loot-bypass-mob-griefing", entitiesPickUpLootBypassMobGriefing);
+         entitiesCanUsePortals = getBoolean("gameplay-mechanics.entities-can-use-portals", entitiesCanUsePortals);
++        fireballsBypassMobGriefing = getBoolean("gameplay-mechanics.fireballs-bypass-mob-griefing", fireballsBypassMobGriefing);
+         milkCuresBadOmen = getBoolean("gameplay-mechanics.milk-cures-bad-omen", milkCuresBadOmen);
+         persistentTileEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-tileentity-display-names-and-lore", persistentTileEntityDisplayNames);
+         persistentDroppableEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-droppable-entity-display-names", persistentDroppableEntityDisplayNames);
+@@ -388,9 +390,11 @@ public class PurpurWorldConfig {
+         dispenserPlaceAnvils = getBoolean("blocks.dispenser.place-anvils", dispenserPlaceAnvils);
+     }
+ 
++    public boolean farmlandBypassMobGriefing = false;
+     public boolean farmlandGetsMoistFromBelow = false;
+     public boolean farmlandAlpha = false;
+     private void farmlandSettings() {
++        farmlandBypassMobGriefing = getBoolean("blocks.farmland.bypass-mob-greifing", farmlandBypassMobGriefing);
+         farmlandGetsMoistFromBelow = getBoolean("blocks.farmland.gets-moist-from-below", farmlandGetsMoistFromBelow);
+         farmlandAlpha = getBoolean("blocks.farmland.use-alpha-farmland", farmlandAlpha);
+     }
+@@ -449,10 +453,12 @@ public class PurpurWorldConfig {
+         stonecutterDamage = (float) getDouble("blocks.stonecutter.damage", stonecutterDamage);
+     }
+ 
++    public boolean turtleEggsBypassMobGriefing = false;
+     public boolean turtleEggsBreakFromExpOrbs = true;
+     public boolean turtleEggsBreakFromItems = true;
+     public boolean turtleEggsBreakFromMinecarts = true;
+     private void turtleEggSettings() {
++        turtleEggsBypassMobGriefing = getBoolean("blocks.turtle_egg.bypass-mob-griefing", turtleEggsBypassMobGriefing);
+         turtleEggsBreakFromExpOrbs = getBoolean("blocks.turtle_egg.break-from-exp-orbs", turtleEggsBreakFromExpOrbs);
+         turtleEggsBreakFromItems = getBoolean("blocks.turtle_egg.break-from-items", turtleEggsBreakFromItems);
+         turtleEggsBreakFromMinecarts = getBoolean("blocks.turtle_egg.break-from-minecarts", turtleEggsBreakFromMinecarts);
+@@ -725,6 +731,7 @@ public class PurpurWorldConfig {
+     public double enderDragonMaxY = 256D;
+     public boolean enderDragonAlwaysDropsEggBlock = false;
+     public boolean enderDragonAlwaysDropsFullExp = false;
++    public boolean enderDragonBypassMobGriefing = false;
+     public double enderDragonMaxHealth = 200.0D;
+     private void enderDragonSettings() {
+         enderDragonRidable = getBoolean("mobs.ender_dragon.ridable", enderDragonRidable);
+@@ -732,6 +739,7 @@ public class PurpurWorldConfig {
+         enderDragonMaxY = getDouble("mobs.ender_dragon.ridable-max-y", enderDragonMaxY);
+         enderDragonAlwaysDropsEggBlock = getBoolean("mobs.ender_dragon.always-drop-egg-block", enderDragonAlwaysDropsEggBlock);
+         enderDragonAlwaysDropsFullExp = getBoolean("mobs.ender_dragon.always-drop-full-exp", enderDragonAlwaysDropsFullExp);
++        enderDragonBypassMobGriefing = getBoolean("mobs.ender_dragon.bypass-mob-griefing", enderDragonBypassMobGriefing);
+         if (PurpurConfig.version < 8) {
+             double oldValue = getDouble("mobs.ender_dragon.max-health", enderDragonMaxHealth);
+             set("mobs.ender_dragon.max-health", null);
+@@ -747,12 +755,14 @@ public class PurpurWorldConfig {
+     public boolean endermanRidable = false;
+     public boolean endermanRidableInWater = false;
+     public boolean endermanAllowGriefing = true;
++    public boolean endermanBypassMobGriefing = false;
+     public boolean endermanDespawnEvenWithBlock = false;
+     public double endermanMaxHealth = 40.0D;
+     private void endermanSettings() {
+         endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
+         endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
+         endermanAllowGriefing = getBoolean("mobs.enderman.allow-griefing", endermanAllowGriefing);
++        endermanBypassMobGriefing = getBoolean("mobs.enderman.bypass-mob-griefing", endermanBypassMobGriefing);
+         endermanDespawnEvenWithBlock = getBoolean("mobs.enderman.can-despawn-with-held-block", endermanDespawnEvenWithBlock);
+         if (PurpurConfig.version < 10) {
+             double oldValue = getDouble("mobs.enderman.attributes.max-health", endermanMaxHealth);
+@@ -778,10 +788,12 @@ public class PurpurWorldConfig {
+ 
+     public boolean evokerRidable = false;
+     public boolean evokerRidableInWater = false;
++    public boolean evokerBypassMobGriefing = false;
+     public double evokerMaxHealth = 24.0D;
+     private void evokerSettings() {
+         evokerRidable = getBoolean("mobs.evoker.ridable", evokerRidable);
+         evokerRidableInWater = getBoolean("mobs.evoker.ridable-in-water", evokerRidableInWater);
++        evokerBypassMobGriefing = getBoolean("mobs.evoker.bypass-mob-griefing", evokerBypassMobGriefing);
+         if (PurpurConfig.version < 10) {
+             double oldValue = getDouble("mobs.evoker.attributes.max-health", evokerMaxHealth);
+             set("mobs.evoker.attributes.max-health", null);
+@@ -792,12 +804,14 @@ public class PurpurWorldConfig {
+ 
+     public boolean foxRidable = false;
+     public boolean foxRidableInWater = false;
++    public boolean foxBypassMobGriefing = false;
+     public boolean foxTypeChangesWithTulips = false;
+     public int foxBreedingTicks = 6000;
+     public double foxMaxHealth = 10.0D;
+     private void foxSettings() {
+         foxRidable = getBoolean("mobs.fox.ridable", foxRidable);
+         foxRidableInWater = getBoolean("mobs.fox.ridable-in-water", foxRidableInWater);
++        foxBypassMobGriefing = getBoolean("mobs.fox.bypass-mob-griefing", foxBypassMobGriefing);
+         foxTypeChangesWithTulips = getBoolean("mobs.fox.tulips-change-type", foxTypeChangesWithTulips);
+         foxBreedingTicks = getInt("mobs.fox.breeding-delay-ticks", foxBreedingTicks);
+         if (PurpurConfig.version < 10) {
+@@ -1232,10 +1246,12 @@ public class PurpurWorldConfig {
+ 
+     public boolean pillagerRidable = false;
+     public boolean pillagerRidableInWater = false;
++    public boolean pillagerBypassMobGriefing = false;
+     public double pillagerMaxHealth = 24.0D;
+     private void pillagerSettings() {
+         pillagerRidable = getBoolean("mobs.pillager.ridable", pillagerRidable);
+         pillagerRidableInWater = getBoolean("mobs.pillager.ridable-in-water", pillagerRidableInWater);
++        pillagerBypassMobGriefing = getBoolean("mobs.pillager.bypass-mob-griefing", pillagerBypassMobGriefing);
+         if (PurpurConfig.version < 10) {
+             double oldValue = getDouble("mobs.pillager.attributes.max-health", pillagerMaxHealth);
+             set("mobs.pillager.attributes.max-health", null);
+@@ -1279,6 +1295,7 @@ public class PurpurWorldConfig {
+ 
+     public boolean rabbitRidable = false;
+     public boolean rabbitRidableInWater = false;
++    public boolean rabbitBypassMobGriefing = false;
+     public double rabbitNaturalToast = 0.0D;
+     public double rabbitNaturalKiller = 0.0D;
+     public int rabbitBreedingTicks = 6000;
+@@ -1286,6 +1303,7 @@ public class PurpurWorldConfig {
+     private void rabbitSettings() {
+         rabbitRidable = getBoolean("mobs.rabbit.ridable", rabbitRidable);
+         rabbitRidableInWater = getBoolean("mobs.rabbit.ridable-in-water", rabbitRidableInWater);
++        rabbitBypassMobGriefing = getBoolean("mobs.rabbit.bypass-mob-griefing", rabbitBypassMobGriefing);
+         rabbitNaturalToast = getDouble("mobs.rabbit.spawn-toast-chance", rabbitNaturalToast);
+         rabbitNaturalKiller = getDouble("mobs.rabbit.spawn-killer-rabbit-chance", rabbitNaturalKiller);
+         rabbitBreedingTicks = getInt("mobs.rabbit.breeding-delay-ticks", rabbitBreedingTicks);
+@@ -1299,10 +1317,12 @@ public class PurpurWorldConfig {
+ 
+     public boolean ravagerRidable = false;
+     public boolean ravagerRidableInWater = false;
++    public boolean ravagerBypassMobGriefing = false;
+     public double ravagerMaxHealth = 100.0D;
+     private void ravagerSettings() {
+         ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
+         ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
++        ravagerBypassMobGriefing = getBoolean("mobs.ravager.bypass-mob-griefing", ravagerBypassMobGriefing);
+         if (PurpurConfig.version < 10) {
+             double oldValue = getDouble("mobs.ravager.attributes.max-health", ravagerMaxHealth);
+             set("mobs.ravager.attributes.max-health", null);
+@@ -1326,11 +1346,13 @@ public class PurpurWorldConfig {
+     public boolean sheepRidable = false;
+     public boolean sheepRidableInWater = false;
+     public int sheepBreedingTicks = 6000;
++    public boolean sheepBypassMobGriefing = false;
+     public double sheepMaxHealth = 8.0D;
+     private void sheepSettings() {
+         sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
+         sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
+         sheepBreedingTicks = getInt("mobs.sheep.breeding-delay-ticks", sheepBreedingTicks);
++        sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
+         if (PurpurConfig.version < 10) {
+             double oldValue = getDouble("mobs.sheep.attributes.max-health", sheepMaxHealth);
+             set("mobs.sheep.attributes.max-health", null);
+@@ -1355,10 +1377,12 @@ public class PurpurWorldConfig {
+ 
+     public boolean silverfishRidable = false;
+     public boolean silverfishRidableInWater = false;
++    public boolean silverfishBypassMobGriefing = false;
+     public double silverfishMaxHealth = 8.0D;
+     private void silverfishSettings() {
+         silverfishRidable = getBoolean("mobs.silverfish.ridable", silverfishRidable);
+         silverfishRidableInWater = getBoolean("mobs.silverfish.ridable-in-water", silverfishRidableInWater);
++        silverfishBypassMobGriefing = getBoolean("mobs.silverfish.bypass-mob-griefing", silverfishBypassMobGriefing);
+         if (PurpurConfig.version < 10) {
+             double oldValue = getDouble("mobs.silverfish.attributes.max-health", silverfishMaxHealth);
+             set("mobs.silverfish.attributes.max-health", null);
+@@ -1423,6 +1447,7 @@ public class PurpurWorldConfig {
+     public boolean snowGolemRidable = false;
+     public boolean snowGolemRidableInWater = false;
+     public boolean snowGolemLeaveTrailWhenRidden = false;
++    public boolean snowGolemBypassMobGriefing = false;
+     public boolean snowGolemDropsPumpkin = false;
+     public boolean snowGolemPutPumpkinBack = false;
+     public int snowGolemSnowBallMin = 20;
+@@ -1434,6 +1459,7 @@ public class PurpurWorldConfig {
+         snowGolemRidable = getBoolean("mobs.snow_golem.ridable", snowGolemRidable);
+         snowGolemRidableInWater = getBoolean("mobs.snow_golem.ridable-in-water", snowGolemRidableInWater);
+         snowGolemLeaveTrailWhenRidden = getBoolean("mobs.snow_golem.leave-trail-when-ridden", snowGolemLeaveTrailWhenRidden);
++        snowGolemBypassMobGriefing = getBoolean("mobs.snow_golem.bypass-mob-griefing", snowGolemBypassMobGriefing);
+         snowGolemDropsPumpkin = getBoolean("mobs.snow_golem.drop-pumpkin-when-sheared", snowGolemDropsPumpkin);
+         snowGolemPutPumpkinBack = getBoolean("mobs.snow_golem.pumpkin-can-be-added-back", snowGolemPutPumpkinBack);
+         snowGolemSnowBallMin = getInt("mobs.snow_golem.min-shoot-interval-ticks", snowGolemSnowBallMin);
+@@ -1650,6 +1676,7 @@ public class PurpurWorldConfig {
+     public boolean witherRidable = false;
+     public boolean witherRidableInWater = false;
+     public double witherMaxY = 256D;
++    public boolean witherBypassMobGriefing = false;
+     public float witherHealthRegenAmount = 1.0f;
+     public int witherHealthRegenDelay = 20;
+     public double witherMaxHealth = 300.0D;
+@@ -1657,6 +1684,7 @@ public class PurpurWorldConfig {
+         witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
+         witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
+         witherMaxY = getDouble("mobs.wither.ridable-max-y", witherMaxY);
++        witherBypassMobGriefing = getBoolean("mobs.wither.bypass-mob-griefing", witherBypassMobGriefing);
+         witherHealthRegenAmount = (float) getDouble("mobs.wither.health-regen-amount", witherHealthRegenAmount);
+         witherHealthRegenDelay = getInt("mobs.wither.health-regen-delay", witherHealthRegenDelay);
+         if (PurpurConfig.version < 8) {
+@@ -1729,6 +1757,7 @@ public class PurpurWorldConfig {
+ 
+     public boolean zombieRidable = false;
+     public boolean zombieRidableInWater = false;
++    public boolean zombieBypassMobGriefing = false;
+     public boolean zombieJockeyOnlyBaby = true;
+     public double zombieJockeyChance = 0.05D;
+     public boolean zombieJockeyTryExistingChickens = true;
+@@ -1739,6 +1768,7 @@ public class PurpurWorldConfig {
+     private void zombieSettings() {
+         zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
+         zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
++        zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
+         zombieJockeyOnlyBaby = getBoolean("mobs.zombie.jockey.only-babies", zombieJockeyOnlyBaby);
+         zombieJockeyChance = getDouble("mobs.zombie.jockey.chance", zombieJockeyChance);
+         zombieJockeyTryExistingChickens = getBoolean("mobs.zombie.jockey.try-existing-chickens", zombieJockeyTryExistingChickens);


### PR DESCRIPTION
I was able to test most of these, but a few go untested. In theory, the options should still work!
This also resolves #132

**Mobs**
- Enderman
- Ender Dragon
- Evoker
- Fox
- Pillager
- Rabbit
- Ravager
- Sheep
- Silverfish
- Snow Golem
- Wither
- Zombie

**Blocks**
- Farmland
- Turtle Egg

**Misc**
- Fireball