### PR TITLE
Config to allow Note Block sounds when blocked

### DIFF
--- a/patches/server/0167-Config-to-allow-Note-Block-sounds-when-blocked.patch
+++ b/patches/server/0167-Config-to-allow-Note-Block-sounds-when-blocked.patch
@@ -1,9 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Encode42 <me@encode42.dev>
 Date: Fri, 8 Jan 2021 16:07:32 -0500
-Subject: [PATCH] Noteblock ignore air above
+Subject: [PATCH] Config to allow Note Block sounds when blocked
 
 Allows for Note Blocks to ignore whether or not there's air above them to play.
+
+Normally, the sounds will only play when the block directly above is air.
+With this patch enabled, players can place any block above the Note Block and it will still work.
 
 diff --git a/src/main/java/net/minecraft/server/BlockNote.java b/src/main/java/net/minecraft/server/BlockNote.java
 index df69d00d3a38417e53f433cd1eb1f6cf3ec9b55b..6bb6e229c8734d7b9f4e3cd3dd1b4b646bca1777 100644

--- a/patches/server/0167-Noteblock-ignore-air-above.patch
+++ b/patches/server/0167-Noteblock-ignore-air-above.patch
@@ -3,10 +3,10 @@ From: Encode42 <me@encode42.dev>
 Date: Fri, 8 Jan 2021 16:07:32 -0500
 Subject: [PATCH] Noteblock ignore air above
 
-Allows for noteblocks to ignore whether or not there's air above them to play.
+Allows for Note Blocks to ignore whether or not there's air above them to play.
 
 diff --git a/src/main/java/net/minecraft/server/BlockNote.java b/src/main/java/net/minecraft/server/BlockNote.java
-index df69d00d3a38417e53f433cd1eb1f6cf3ec9b55b..b769f77e5e28ed425c8dbfb35f782a7c1465c68a 100644
+index df69d00d3a38417e53f433cd1eb1f6cf3ec9b55b..088c109f417cba7ac091bdeba6f017a47878cb96 100644
 --- a/src/main/java/net/minecraft/server/BlockNote.java
 +++ b/src/main/java/net/minecraft/server/BlockNote.java
 @@ -37,7 +37,7 @@ public class BlockNote extends Block {
@@ -14,19 +14,19 @@ index df69d00d3a38417e53f433cd1eb1f6cf3ec9b55b..b769f77e5e28ed425c8dbfb35f782a7c
  
      private void play(World world, BlockPosition blockposition, IBlockData data) { // CraftBukkit
 -        if (world.getType(blockposition.up()).isAir()) {
-+        if (world.purpurConfig.noteblockIgnoresAir || world.getType(blockposition.up()).isAir()) {
++        if (world.purpurConfig.noteBlocksIgnoreAir || world.getType(blockposition.up()).isAir()) {
              // CraftBukkit start
              org.bukkit.event.block.NotePlayEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callNotePlayEvent(world, blockposition, data.get(BlockNote.INSTRUMENT), data.get(BlockNote.NOTE));
              if (!event.isCancelled()) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index f4da2ab6b2e71b17ad3b2adec264ff3af272535d..4c53b5166d401930b9adad7efd03066a6145df3f 100644
+index f4da2ab6b2e71b17ad3b2adec264ff3af272535d..d39be467cc8e5295df6c3ba17636c17b6bbbe364 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -236,6 +236,7 @@ public class PurpurWorldConfig {
      public boolean entitiesCanUsePortals = true;
      public boolean fireballsBypassMobGriefing = false;
      public boolean milkCuresBadOmen = true;
-+    public boolean noteblockIgnoresAir = false;
++    public boolean noteBlocksIgnoreAir = false;
      public boolean persistentTileEntityDisplayNames = false;
      public boolean persistentDroppableEntityDisplayNames = false;
      public double tridentLoyaltyVoidReturnHeight = 0.0D;
@@ -34,7 +34,7 @@ index f4da2ab6b2e71b17ad3b2adec264ff3af272535d..4c53b5166d401930b9adad7efd03066a
          entitiesCanUsePortals = getBoolean("gameplay-mechanics.entities-can-use-portals", entitiesCanUsePortals);
          fireballsBypassMobGriefing = getBoolean("gameplay-mechanics.fireballs-bypass-mob-griefing", fireballsBypassMobGriefing);
          milkCuresBadOmen = getBoolean("gameplay-mechanics.milk-cures-bad-omen", milkCuresBadOmen);
-+        noteblockIgnoresAir = getBoolean("gameplay-mechanics.noteblock-ignores-air", noteblockIgnoresAir);
++        noteBlocksIgnoreAir = getBoolean("gameplay-mechanics.note-blocks-ignore-air", noteBlocksIgnoreAir);
          persistentTileEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-tileentity-display-names-and-lore", persistentTileEntityDisplayNames);
          persistentDroppableEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-droppable-entity-display-names", persistentDroppableEntityDisplayNames);
          tridentLoyaltyVoidReturnHeight = getDouble("gameplay-mechanics.trident-loyalty-void-return-height", tridentLoyaltyVoidReturnHeight);

--- a/patches/server/0167-Noteblock-ignore-air-above.patch
+++ b/patches/server/0167-Noteblock-ignore-air-above.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Fri, 8 Jan 2021 16:07:32 -0500
+Subject: [PATCH] Noteblock ignore air above
+
+Allows for noteblocks to ignore whether or not there's air above them to play.
+
+diff --git a/src/main/java/net/minecraft/server/BlockNote.java b/src/main/java/net/minecraft/server/BlockNote.java
+index df69d00d3a38417e53f433cd1eb1f6cf3ec9b55b..b769f77e5e28ed425c8dbfb35f782a7c1465c68a 100644
+--- a/src/main/java/net/minecraft/server/BlockNote.java
++++ b/src/main/java/net/minecraft/server/BlockNote.java
+@@ -37,7 +37,7 @@ public class BlockNote extends Block {
+     }
+ 
+     private void play(World world, BlockPosition blockposition, IBlockData data) { // CraftBukkit
+-        if (world.getType(blockposition.up()).isAir()) {
++        if (world.purpurConfig.noteblockIgnoresAir || world.getType(blockposition.up()).isAir()) {
+             // CraftBukkit start
+             org.bukkit.event.block.NotePlayEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callNotePlayEvent(world, blockposition, data.get(BlockNote.INSTRUMENT), data.get(BlockNote.NOTE));
+             if (!event.isCancelled()) {
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index f4da2ab6b2e71b17ad3b2adec264ff3af272535d..4c53b5166d401930b9adad7efd03066a6145df3f 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -236,6 +236,7 @@ public class PurpurWorldConfig {
+     public boolean entitiesCanUsePortals = true;
+     public boolean fireballsBypassMobGriefing = false;
+     public boolean milkCuresBadOmen = true;
++    public boolean noteblockIgnoresAir = false;
+     public boolean persistentTileEntityDisplayNames = false;
+     public boolean persistentDroppableEntityDisplayNames = false;
+     public double tridentLoyaltyVoidReturnHeight = 0.0D;
+@@ -251,6 +252,7 @@ public class PurpurWorldConfig {
+         entitiesCanUsePortals = getBoolean("gameplay-mechanics.entities-can-use-portals", entitiesCanUsePortals);
+         fireballsBypassMobGriefing = getBoolean("gameplay-mechanics.fireballs-bypass-mob-griefing", fireballsBypassMobGriefing);
+         milkCuresBadOmen = getBoolean("gameplay-mechanics.milk-cures-bad-omen", milkCuresBadOmen);
++        noteblockIgnoresAir = getBoolean("gameplay-mechanics.noteblock-ignores-air", noteblockIgnoresAir);
+         persistentTileEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-tileentity-display-names-and-lore", persistentTileEntityDisplayNames);
+         persistentDroppableEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-droppable-entity-display-names", persistentDroppableEntityDisplayNames);
+         tridentLoyaltyVoidReturnHeight = getDouble("gameplay-mechanics.trident-loyalty-void-return-height", tridentLoyaltyVoidReturnHeight);

--- a/patches/server/0167-Noteblock-ignore-air-above.patch
+++ b/patches/server/0167-Noteblock-ignore-air-above.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Noteblock ignore air above
 Allows for Note Blocks to ignore whether or not there's air above them to play.
 
 diff --git a/src/main/java/net/minecraft/server/BlockNote.java b/src/main/java/net/minecraft/server/BlockNote.java
-index df69d00d3a38417e53f433cd1eb1f6cf3ec9b55b..088c109f417cba7ac091bdeba6f017a47878cb96 100644
+index df69d00d3a38417e53f433cd1eb1f6cf3ec9b55b..6bb6e229c8734d7b9f4e3cd3dd1b4b646bca1777 100644
 --- a/src/main/java/net/minecraft/server/BlockNote.java
 +++ b/src/main/java/net/minecraft/server/BlockNote.java
 @@ -37,7 +37,7 @@ public class BlockNote extends Block {
@@ -14,19 +14,19 @@ index df69d00d3a38417e53f433cd1eb1f6cf3ec9b55b..088c109f417cba7ac091bdeba6f017a4
  
      private void play(World world, BlockPosition blockposition, IBlockData data) { // CraftBukkit
 -        if (world.getType(blockposition.up()).isAir()) {
-+        if (world.purpurConfig.noteBlocksIgnoreAir || world.getType(blockposition.up()).isAir()) {
++        if (world.purpurConfig.noteBlockIgnoreAbove || world.getType(blockposition.up()).isAir()) {
              // CraftBukkit start
              org.bukkit.event.block.NotePlayEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callNotePlayEvent(world, blockposition, data.get(BlockNote.INSTRUMENT), data.get(BlockNote.NOTE));
              if (!event.isCancelled()) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index f4da2ab6b2e71b17ad3b2adec264ff3af272535d..d39be467cc8e5295df6c3ba17636c17b6bbbe364 100644
+index f4da2ab6b2e71b17ad3b2adec264ff3af272535d..19aef77f5cf511d2b34888fc2b730dcba4bfc88d 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -236,6 +236,7 @@ public class PurpurWorldConfig {
      public boolean entitiesCanUsePortals = true;
      public boolean fireballsBypassMobGriefing = false;
      public boolean milkCuresBadOmen = true;
-+    public boolean noteBlocksIgnoreAir = false;
++    public boolean noteBlockIgnoreAbove = false;
      public boolean persistentTileEntityDisplayNames = false;
      public boolean persistentDroppableEntityDisplayNames = false;
      public double tridentLoyaltyVoidReturnHeight = 0.0D;
@@ -34,7 +34,7 @@ index f4da2ab6b2e71b17ad3b2adec264ff3af272535d..d39be467cc8e5295df6c3ba17636c17b
          entitiesCanUsePortals = getBoolean("gameplay-mechanics.entities-can-use-portals", entitiesCanUsePortals);
          fireballsBypassMobGriefing = getBoolean("gameplay-mechanics.fireballs-bypass-mob-griefing", fireballsBypassMobGriefing);
          milkCuresBadOmen = getBoolean("gameplay-mechanics.milk-cures-bad-omen", milkCuresBadOmen);
-+        noteBlocksIgnoreAir = getBoolean("gameplay-mechanics.note-blocks-ignore-air", noteBlocksIgnoreAir);
++        noteBlockIgnoreAbove = getBoolean("gameplay-mechanics.note-block-ignore-above", noteBlockIgnoreAbove);
          persistentTileEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-tileentity-display-names-and-lore", persistentTileEntityDisplayNames);
          persistentDroppableEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-droppable-entity-display-names", persistentDroppableEntityDisplayNames);
          tridentLoyaltyVoidReturnHeight = getDouble("gameplay-mechanics.trident-loyalty-void-return-height", tridentLoyaltyVoidReturnHeight);


### PR DESCRIPTION
Alternative title: Ignore blocks blocking note blocks
Allows for Note Blocks to play sounds even if a block is above them.

The patch in action: https://m.cft.li/p/ca1.mp4