### PR TITLE
Config to use infinity bows without arrows

### DIFF
--- a/patches/server/0172-Config-to-use-infinity-bows-without-arrows.patch
+++ b/patches/server/0172-Config-to-use-infinity-bows-without-arrows.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Mon, 25 Jan 2021 11:36:39 -0500
+Subject: [PATCH] Config to use infinity bows without arrows
+
+Allows for bows with infinity to be used without any arrows in the player's inventory.
+Uses a standard arrow when shot.
+
+diff --git a/src/main/java/net/minecraft/server/ItemBow.java b/src/main/java/net/minecraft/server/ItemBow.java
+index 8241f3dafa5852bed7a3967e7260b36f47198dba..edfb09fe673a9a7fe4e0410c0c0eeeda0d164270 100644
+--- a/src/main/java/net/minecraft/server/ItemBow.java
++++ b/src/main/java/net/minecraft/server/ItemBow.java
+@@ -119,7 +119,7 @@ public class ItemBow extends ItemProjectileWeapon implements ItemVanishable {
+         ItemStack itemstack = entityhuman.b(enumhand);
+         boolean flag = !entityhuman.f(itemstack).isEmpty();
+ 
+-        if (!entityhuman.abilities.canInstantlyBuild && !flag) {
++        if (!(world.purpurConfig.infinityWorksWithoutArrows && EnchantmentManager.getEnchantmentLevel(Enchantments.ARROW_INFINITE, itemstack) > 0) && !entityhuman.abilities.canInstantlyBuild && !flag) { // Purpur
+             return InteractionResultWrapper.fail(itemstack);
+         } else {
+             entityhuman.c(enumhand);
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 54d39ce779a0a4ae79b23a3cd98d3f9761d9c9e1..5d38992c909fd1caca2deb3496c8c314ef3db13b 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -197,10 +197,12 @@ public class PurpurWorldConfig {
+         idleTimeoutUpdateTabList = getBoolean("gameplay-mechanics.player.idle-timeout.update-tab-list", idleTimeoutUpdateTabList);
+     }
+ 
++    public boolean infinityWorksWithoutArrows = false;
+     public boolean infinityWorksWithNormalArrows = true;
+     public boolean infinityWorksWithSpectralArrows = false;
+     public boolean infinityWorksWithTippedArrows = false;
+     private void infinityArrowsSettings() {
++        infinityWorksWithoutArrows = getBoolean("gameplay-mechanics.infinity-bow.works-without-arrows", infinityWorksWithoutArrows);
+         infinityWorksWithNormalArrows = getBoolean("gameplay-mechanics.infinity-bow.normal-arrows", infinityWorksWithNormalArrows);
+         infinityWorksWithSpectralArrows = getBoolean("gameplay-mechanics.infinity-bow.spectral-arrows", infinityWorksWithSpectralArrows);
+         infinityWorksWithTippedArrows = getBoolean("gameplay-mechanics.infinity-bow.tipped-arrows", infinityWorksWithTippedArrows);


### PR DESCRIPTION
Allows for bows with infinity to be used without any arrows in the player's inventory.