### PR TITLE
Toggle for water sensitive mobs getting damaged by... water

### DIFF
--- a/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
@@ -31,18 +31,16 @@ index beee80c3d8277f2d784fb6b8a4152a871ee020b0..b884addf2ce6f1ef7394658078deb2e7
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 523fdb6a73a918bc04cbc88a440e72a1d934d148..f6a4377f724ecc35772db5de78989d02b18695f5 100644
+index 523fdb6a73a918bc04cbc88a440e72a1d934d148..5c892ab68f0b85b2adf3d56940892bc227404fe9 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
-@@ -786,9 +786,13 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -786,9 +786,11 @@ public abstract class EntityInsentient extends EntityLiving {
                  if (goalFloat.validConditions()) goalFloat.update();
                  this.getControllerJump().jumpIfSet();
              }
 -            if ((this instanceof EntityBlaze || this instanceof EntityEnderman) && isInWaterOrRainOrBubble()) {
 +            // Purpur start - Toggle for water sensitive mob damage
-+            if (this instanceof EntityEnderman && world.purpurConfig.endermanTakeDamageFromWater && isInWaterOrRainOrBubble()) {
-+                damageEntity(DamageSource.DROWN, 1.0F);
-+            } else if (this instanceof EntityBlaze && world.purpurConfig.blazeTakeDamageFromWater && isInWaterOrRainOrBubble()) {
++            if (dO() && isInWaterOrRainOrBubble()) {
                  damageEntity(DamageSource.DROWN, 1.0F);
              }
 +            // Purpur end

--- a/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
@@ -44,6 +44,19 @@ index 523fdb6a73a918bc04cbc88a440e72a1d934d148..df7fbd30a25f444a8d5743d95be10d9a
                  damageEntity(DamageSource.DROWN, 1.0F);
              }
              return;
+diff --git a/src/main/java/net/minecraft/server/EntitySnowman.java b/src/main/java/net/minecraft/server/EntitySnowman.java
+index 550decf12140596e63b57a7ee5940e4f7b7dbc0b..286c956bc56ff2adc75b35ac8bfaaf985d9e3368 100644
+--- a/src/main/java/net/minecraft/server/EntitySnowman.java
++++ b/src/main/java/net/minecraft/server/EntitySnowman.java
+@@ -71,7 +71,7 @@ public class EntitySnowman extends EntityGolem implements IShearable, IRangedEnt
+ 
+     @Override
+     public boolean dO() {
+-        return true;
++        return world.purpurConfig.snowGolemTakeDamageFromWater; // Purpur - Toggle for water sensitive mob damage
+     }
+ 
+     @Override
 diff --git a/src/main/java/net/minecraft/server/EntityStrider.java b/src/main/java/net/minecraft/server/EntityStrider.java
 index 964956a0027bf0941ff75d658be760b754772fa0..7c5472a5138011a3376b7b6ec2467bdfc1739033 100644
 --- a/src/main/java/net/minecraft/server/EntityStrider.java

--- a/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
@@ -31,22 +31,19 @@ index beee80c3d8277f2d784fb6b8a4152a871ee020b0..b884addf2ce6f1ef7394658078deb2e7
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 523fdb6a73a918bc04cbc88a440e72a1d934d148..5c892ab68f0b85b2adf3d56940892bc227404fe9 100644
+index 523fdb6a73a918bc04cbc88a440e72a1d934d148..df7fbd30a25f444a8d5743d95be10d9a47a83ea2 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
-@@ -786,9 +786,11 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -786,7 +786,8 @@ public abstract class EntityInsentient extends EntityLiving {
                  if (goalFloat.validConditions()) goalFloat.update();
                  this.getControllerJump().jumpIfSet();
              }
 -            if ((this instanceof EntityBlaze || this instanceof EntityEnderman) && isInWaterOrRainOrBubble()) {
-+            // Purpur start - Toggle for water sensitive mob damage
-+            if (dO() && isInWaterOrRainOrBubble()) {
++
++            if (dO() && isInWaterOrRainOrBubble()) { // Purpur - Toggle for water sensitive mob damage
                  damageEntity(DamageSource.DROWN, 1.0F);
              }
-+            // Purpur end
              return;
-         }
-         // Paper end
 diff --git a/src/main/java/net/minecraft/server/EntityStrider.java b/src/main/java/net/minecraft/server/EntityStrider.java
 index 964956a0027bf0941ff75d658be760b754772fa0..7c5472a5138011a3376b7b6ec2467bdfc1739033 100644
 --- a/src/main/java/net/minecraft/server/EntityStrider.java

--- a/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
@@ -31,7 +31,7 @@ index beee80c3d8277f2d784fb6b8a4152a871ee020b0..b884addf2ce6f1ef7394658078deb2e7
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 523fdb6a73a918bc04cbc88a440e72a1d934d148..df7fbd30a25f444a8d5743d95be10d9a47a83ea2 100644
+index 523fdb6a73a918bc04cbc88a440e72a1d934d148..afb64bceb4d39e1d1dd4e89a93b393e1357b764b 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -786,7 +786,8 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -40,10 +40,26 @@ index 523fdb6a73a918bc04cbc88a440e72a1d934d148..df7fbd30a25f444a8d5743d95be10d9a
              }
 -            if ((this instanceof EntityBlaze || this instanceof EntityEnderman) && isInWaterOrRainOrBubble()) {
 +
-+            if (dO() && isInWaterOrRainOrBubble()) { // Purpur - Toggle for water sensitive mob damage
++            if (isSensitiveToWater() && isInWaterOrRainOrBubble()) { // Purpur - Toggle for water sensitive mob damage
                  damageEntity(DamageSource.DROWN, 1.0F);
              }
              return;
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 330f27f649a2ab1567ebc1b547f1f2a5ce645055..6fd5606e110fa552315630b189ded60458867ce4 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -2876,9 +2876,8 @@ public abstract class EntityLiving extends Entity {
+ 
+     }
+ 
+-    public boolean dO() {
+-        return false;
+-    }
++    public boolean isSensitiveToWater() { return dO(); } // Purpur - OBFHELPER
++    public boolean dO() { return false; }
+ 
+     private void r() {
+         boolean flag = this.getFlag(7);
 diff --git a/src/main/java/net/minecraft/server/EntitySnowman.java b/src/main/java/net/minecraft/server/EntitySnowman.java
 index 550decf12140596e63b57a7ee5940e4f7b7dbc0b..286c956bc56ff2adc75b35ac8bfaaf985d9e3368 100644
 --- a/src/main/java/net/minecraft/server/EntitySnowman.java

--- a/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
@@ -1,0 +1,132 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: YouHaveTrouble <garrenpolska@gmail.com>
+Date: Fri, 5 Feb 2021 01:11:22 +0100
+Subject: [PATCH] Toggle for water sensitive mob damage
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityBlaze.java b/src/main/java/net/minecraft/server/EntityBlaze.java
+index 90b90fa33b39020189a1d4a5826fa3ab720488cd..b4db9869d172406f4eff84cfb2648b5c6c6d00e2 100644
+--- a/src/main/java/net/minecraft/server/EntityBlaze.java
++++ b/src/main/java/net/minecraft/server/EntityBlaze.java
+@@ -116,7 +116,7 @@ public class EntityBlaze extends EntityMonster {
+ 
+     @Override
+     public boolean dO() {
+-        return true;
++        return world.purpurConfig.blazeTakeDamageFromWater; // Purpur - Toggle for water sensitive mob damage
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityEnderman.java b/src/main/java/net/minecraft/server/EntityEnderman.java
+index beee80c3d8277f2d784fb6b8a4152a871ee020b0..b884addf2ce6f1ef7394658078deb2e75370654f 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderman.java
++++ b/src/main/java/net/minecraft/server/EntityEnderman.java
+@@ -234,7 +234,7 @@ public class EntityEnderman extends EntityMonster implements IEntityAngerable {
+ 
+     @Override
+     public boolean dO() {
+-        return true;
++        return world.purpurConfig.endermanTakeDamageFromWater; // Purpur - Toggle for water sensitive mob damage
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
+index 523fdb6a73a918bc04cbc88a440e72a1d934d148..f6a4377f724ecc35772db5de78989d02b18695f5 100644
+--- a/src/main/java/net/minecraft/server/EntityInsentient.java
++++ b/src/main/java/net/minecraft/server/EntityInsentient.java
+@@ -786,9 +786,13 @@ public abstract class EntityInsentient extends EntityLiving {
+                 if (goalFloat.validConditions()) goalFloat.update();
+                 this.getControllerJump().jumpIfSet();
+             }
+-            if ((this instanceof EntityBlaze || this instanceof EntityEnderman) && isInWaterOrRainOrBubble()) {
++            // Purpur start - Toggle for water sensitive mob damage
++            if (this instanceof EntityEnderman && world.purpurConfig.endermanTakeDamageFromWater && isInWaterOrRainOrBubble()) {
++                damageEntity(DamageSource.DROWN, 1.0F);
++            } else if (this instanceof EntityBlaze && world.purpurConfig.blazeTakeDamageFromWater && isInWaterOrRainOrBubble()) {
+                 damageEntity(DamageSource.DROWN, 1.0F);
+             }
++            // Purpur end
+             return;
+         }
+         // Paper end
+diff --git a/src/main/java/net/minecraft/server/EntityStrider.java b/src/main/java/net/minecraft/server/EntityStrider.java
+index 964956a0027bf0941ff75d658be760b754772fa0..7c5472a5138011a3376b7b6ec2467bdfc1739033 100644
+--- a/src/main/java/net/minecraft/server/EntityStrider.java
++++ b/src/main/java/net/minecraft/server/EntityStrider.java
+@@ -338,7 +338,7 @@ public class EntityStrider extends EntityAnimal implements ISteerable, ISaddleab
+ 
+     @Override
+     public boolean dO() {
+-        return true;
++        return world.purpurConfig.striderTakeDamageFromWater; // Purpur - Toggle for water sensitive mob damage
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 074ebb5ee808875b1a90b70e42ef440af002f5c6..42e09d1a20de61b68fedd4ca56517e06aa18f173 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -569,6 +569,7 @@ public class PurpurWorldConfig {
+     public boolean blazeRidableInWater = false;
+     public double blazeMaxY = 256D;
+     public double blazeMaxHealth = 20.0D;
++    public boolean blazeTakeDamageFromWater = true;
+     private void blazeSettings() {
+         blazeRidable = getBoolean("mobs.blaze.ridable", blazeRidable);
+         blazeRidableInWater = getBoolean("mobs.blaze.ridable-in-water", blazeRidableInWater);
+@@ -579,6 +580,7 @@ public class PurpurWorldConfig {
+             set("mobs.blaze.attributes.max_health", oldValue);
+         }
+         blazeMaxHealth = getDouble("mobs.blaze.attributes.max_health", blazeMaxHealth);
++        blazeTakeDamageFromWater = getBoolean("mobs.blaze.takes-damage-from-water", blazeTakeDamageFromWater);
+     }
+ 
+     public boolean catRidable = false;
+@@ -793,6 +795,7 @@ public class PurpurWorldConfig {
+     public boolean endermanBypassMobGriefing = false;
+     public boolean endermanDespawnEvenWithBlock = false;
+     public double endermanMaxHealth = 40.0D;
++    public boolean endermanTakeDamageFromWater = true;
+     private void endermanSettings() {
+         endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
+         endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
+@@ -805,6 +808,7 @@ public class PurpurWorldConfig {
+             set("mobs.enderman.attributes.max_health", oldValue);
+         }
+         endermanMaxHealth = getDouble("mobs.enderman.attributes.max_health", endermanMaxHealth);
++        endermanTakeDamageFromWater = getBoolean("mobs.enderman.takes-damage-from-water", endermanTakeDamageFromWater);
+     }
+ 
+     public boolean endermiteRidable = false;
+@@ -1490,6 +1494,7 @@ public class PurpurWorldConfig {
+     public float snowGolemSnowBallModifier = 10.0F;
+     public double snowGolemAttackDistance = 1.25D;
+     public double snowGolemMaxHealth = 4.0D;
++    public boolean snowGolemTakeDamageFromWater = true;
+     private void snowGolemSettings() {
+         snowGolemRidable = getBoolean("mobs.snow_golem.ridable", snowGolemRidable);
+         snowGolemRidableInWater = getBoolean("mobs.snow_golem.ridable-in-water", snowGolemRidableInWater);
+@@ -1507,6 +1512,7 @@ public class PurpurWorldConfig {
+             set("mobs.snow_golem.attributes.max_health", oldValue);
+         }
+         snowGolemMaxHealth = getDouble("mobs.snow_golem.attributes.max_health", snowGolemMaxHealth);
++        snowGolemTakeDamageFromWater = getBoolean("mobs.snow_golem.takes-damage-from-water", snowGolemTakeDamageFromWater);
+     }
+ 
+     public boolean squidRidable = false;
+@@ -1560,6 +1566,7 @@ public class PurpurWorldConfig {
+     public int striderBreedingTicks = 6000;
+     public boolean striderGiveSaddleBack = false;
+     public double striderMaxHealth = 20.0D;
++    public boolean striderTakeDamageFromWater = true;
+     private void striderSettings() {
+         striderRidable = getBoolean("mobs.strider.ridable", striderRidable);
+         striderRidableInWater = getBoolean("mobs.strider.ridable-in-water", striderRidableInWater);
+@@ -1571,6 +1578,7 @@ public class PurpurWorldConfig {
+             set("mobs.strider.attributes.max_health", oldValue);
+         }
+         striderMaxHealth = getDouble("mobs.strider.attributes.max_health", striderMaxHealth);
++        striderTakeDamageFromWater = getBoolean("mobs.strider.takes-damage-from-water", striderTakeDamageFromWater);
+     }
+ 
+     public boolean tropicalFishRidable = false;

--- a/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0171-Toggle-for-water-sensitive-mob-damage.patch
@@ -45,21 +45,17 @@ index 523fdb6a73a918bc04cbc88a440e72a1d934d148..afb64bceb4d39e1d1dd4e89a93b393e1
              }
              return;
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 330f27f649a2ab1567ebc1b547f1f2a5ce645055..6fd5606e110fa552315630b189ded60458867ce4 100644
+index 330f27f649a2ab1567ebc1b547f1f2a5ce645055..5f9d8999ae7a1d742918e58c0f1bb36fc74d45fe 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -2876,9 +2876,8 @@ public abstract class EntityLiving extends Entity {
+@@ -2876,6 +2876,7 @@ public abstract class EntityLiving extends Entity {
  
      }
  
--    public boolean dO() {
--        return false;
--    }
 +    public boolean isSensitiveToWater() { return dO(); } // Purpur - OBFHELPER
-+    public boolean dO() { return false; }
- 
-     private void r() {
-         boolean flag = this.getFlag(7);
+     public boolean dO() {
+         return false;
+     }
 diff --git a/src/main/java/net/minecraft/server/EntitySnowman.java b/src/main/java/net/minecraft/server/EntitySnowman.java
 index 550decf12140596e63b57a7ee5940e4f7b7dbc0b..286c956bc56ff2adc75b35ac8bfaaf985d9e3368 100644
 --- a/src/main/java/net/minecraft/server/EntitySnowman.java


### PR DESCRIPTION
This patch allows to control if normally water sensitive mobs (enderman, blaze, snow golem, strider) should get damaged by water or rain.