### PR TITLE
Config to always tame in Creative

### DIFF
--- a/patches/server/0172-Config-to-always-tame-in-Creative.patch
+++ b/patches/server/0172-Config-to-always-tame-in-Creative.patch
@@ -15,7 +15,7 @@ index f973408b1f098c8a090401205f809e95fdcf2f62..e9908f6b22010851f78a62e35a14371d
              } else if (this.k(itemstack)) {
                  this.a(entityhuman, itemstack);
 -                if (this.random.nextInt(3) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
-+                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(3) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(3) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit // Purpur
                      this.tame(entityhuman);
                      this.setWillSit(true);
                      this.world.broadcastEntityEffect(this, (byte) 7);
@@ -28,7 +28,7 @@ index d19f8dda87c97de594ad051a6791d99eec581e95..f821cbbf6b8e223dc8439bb08bc124c8
  
              if (!this.world.isClientSide) {
 -                if (this.random.nextInt(10) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
-+                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(10) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(10) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit // Purpur
                      this.tame(entityhuman);
                      this.world.broadcastEntityEffect(this, (byte) 7);
                  } else {
@@ -41,7 +41,7 @@ index 03bcbf7c280476ef0e6fe87e3a96edb75544bddb..53982a0b86364a63c4f6ad44c84f585f
  
                  // CraftBukkit - added event call and isCancelled check.
 -                if (this.random.nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) {
-+                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) {
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // Purpur
                      this.tame(entityhuman);
                      this.navigation.o();
                      this.setGoalTarget((EntityLiving) null);

--- a/patches/server/0172-Config-to-always-tame-in-Creative.patch
+++ b/patches/server/0172-Config-to-always-tame-in-Creative.patch
@@ -54,7 +54,7 @@ index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..dee2af04ea27ca06031c7cba744a3446
  
                  // CraftBukkit - fire EntityTameEvent
 -                if (j > 0 && this.entity.getRandom().nextInt(j) < i && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this.entity, ((org.bukkit.craftbukkit.entity.CraftHumanEntity) this.entity.getBukkitEntity().getPassenger()).getHandle()).isCancelled()) {
-+                if ((this.entity.world.purpurConfig.alwaysTameInCreative && ((EntityHuman) entity).abilities.canInstantlyBuild) || j > 0 && this.entity.getRandom().nextInt(j) < i && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this.entity, ((org.bukkit.craftbukkit.entity.CraftHumanEntity) this.entity.getBukkitEntity().getPassenger()).getHandle()).isCancelled()) {
++                if ((this.entity.world.purpurConfig.alwaysTameInCreative && ((EntityHuman) entity).abilities.canInstantlyBuild) || j > 0 && this.entity.getRandom().nextInt(j) < i && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this.entity, ((org.bukkit.craftbukkit.entity.CraftHumanEntity) this.entity.getBukkitEntity().getPassenger()).getHandle()).isCancelled()) { // Purpur
                      this.entity.i((EntityHuman) entity);
                      return;
                  }

--- a/patches/server/0172-Config-to-always-tame-in-Creative.patch
+++ b/patches/server/0172-Config-to-always-tame-in-Creative.patch
@@ -7,7 +7,7 @@ Adds a configuration option that ensures a player in Creative always tames a tam
 This essentially allows Creative mode players to tame animals on their first try.
 
 diff --git a/src/main/java/net/minecraft/server/EntityCat.java b/src/main/java/net/minecraft/server/EntityCat.java
-index f973408b1f098c8a090401205f809e95fdcf2f62..e9908f6b22010851f78a62e35a14371d407c2c7f 100644
+index f973408b1f098c8a090401205f809e95fdcf2f62..a82a87e305634ef5349d3b747460d15064c8f7b0 100644
 --- a/src/main/java/net/minecraft/server/EntityCat.java
 +++ b/src/main/java/net/minecraft/server/EntityCat.java
 @@ -375,7 +375,7 @@ public class EntityCat extends EntityTameableAnimal {
@@ -20,7 +20,7 @@ index f973408b1f098c8a090401205f809e95fdcf2f62..e9908f6b22010851f78a62e35a14371d
                      this.setWillSit(true);
                      this.world.broadcastEntityEffect(this, (byte) 7);
 diff --git a/src/main/java/net/minecraft/server/EntityParrot.java b/src/main/java/net/minecraft/server/EntityParrot.java
-index d19f8dda87c97de594ad051a6791d99eec581e95..f821cbbf6b8e223dc8439bb08bc124c88c23a057 100644
+index d19f8dda87c97de594ad051a6791d99eec581e95..9e7bd6c8a5bc1734b8704e8db7e674f75c3636cd 100644
 --- a/src/main/java/net/minecraft/server/EntityParrot.java
 +++ b/src/main/java/net/minecraft/server/EntityParrot.java
 @@ -245,7 +245,7 @@ public class EntityParrot extends EntityPerchable implements EntityBird {
@@ -33,7 +33,7 @@ index d19f8dda87c97de594ad051a6791d99eec581e95..f821cbbf6b8e223dc8439bb08bc124c8
                      this.world.broadcastEntityEffect(this, (byte) 7);
                  } else {
 diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
-index 03bcbf7c280476ef0e6fe87e3a96edb75544bddb..53982a0b86364a63c4f6ad44c84f585fc5c58452 100644
+index 03bcbf7c280476ef0e6fe87e3a96edb75544bddb..9e3b3aa2ffe10a52f69b268c926e8b8929359f8e 100644
 --- a/src/main/java/net/minecraft/server/EntityWolf.java
 +++ b/src/main/java/net/minecraft/server/EntityWolf.java
 @@ -415,7 +415,7 @@ public class EntityWolf extends EntityTameableAnimal implements IEntityAngerable
@@ -46,7 +46,7 @@ index 03bcbf7c280476ef0e6fe87e3a96edb75544bddb..53982a0b86364a63c4f6ad44c84f585f
                      this.navigation.o();
                      this.setGoalTarget((EntityLiving) null);
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalTame.java b/src/main/java/net/minecraft/server/PathfinderGoalTame.java
-index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..dee2af04ea27ca06031c7cba744a3446938c7c46 100644
+index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..0779c9a41fb91f273b707dee29c93e085d0eb3a1 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalTame.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalTame.java
 @@ -58,7 +58,7 @@ public class PathfinderGoalTame extends PathfinderGoal {

--- a/patches/server/0172-Config-to-always-tame-in-Creative.patch
+++ b/patches/server/0172-Config-to-always-tame-in-Creative.patch
@@ -7,7 +7,7 @@ Adds a configuration option that ensures a player in Creative always tames a tam
 This essentially allows Creative mode players to tame animals on their first try.
 
 diff --git a/src/main/java/net/minecraft/server/EntityCat.java b/src/main/java/net/minecraft/server/EntityCat.java
-index f973408b1f098c8a090401205f809e95fdcf2f62..a82a87e305634ef5349d3b747460d15064c8f7b0 100644
+index f973408b1f098c8a090401205f809e95fdcf2f62..2128d8a9a6fe6bdea81881cfc8ab7b03f448576f 100644
 --- a/src/main/java/net/minecraft/server/EntityCat.java
 +++ b/src/main/java/net/minecraft/server/EntityCat.java
 @@ -375,7 +375,7 @@ public class EntityCat extends EntityTameableAnimal {
@@ -15,12 +15,12 @@ index f973408b1f098c8a090401205f809e95fdcf2f62..a82a87e305634ef5349d3b747460d150
              } else if (this.k(itemstack)) {
                  this.a(entityhuman, itemstack);
 -                if (this.random.nextInt(3) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
-+                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(3) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit // Purpur
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || (this.random.nextInt(3) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled())) { // CraftBukkit // Purpur
                      this.tame(entityhuman);
                      this.setWillSit(true);
                      this.world.broadcastEntityEffect(this, (byte) 7);
 diff --git a/src/main/java/net/minecraft/server/EntityParrot.java b/src/main/java/net/minecraft/server/EntityParrot.java
-index d19f8dda87c97de594ad051a6791d99eec581e95..9e7bd6c8a5bc1734b8704e8db7e674f75c3636cd 100644
+index d19f8dda87c97de594ad051a6791d99eec581e95..6d5a56b96c3759c594fe2ee4b7cdd7fa67f3d3fb 100644
 --- a/src/main/java/net/minecraft/server/EntityParrot.java
 +++ b/src/main/java/net/minecraft/server/EntityParrot.java
 @@ -245,7 +245,7 @@ public class EntityParrot extends EntityPerchable implements EntityBird {
@@ -28,12 +28,12 @@ index d19f8dda87c97de594ad051a6791d99eec581e95..9e7bd6c8a5bc1734b8704e8db7e674f7
  
              if (!this.world.isClientSide) {
 -                if (this.random.nextInt(10) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
-+                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(10) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit // Purpur
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || (this.random.nextInt(10) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled())) { // CraftBukkit // Purpur
                      this.tame(entityhuman);
                      this.world.broadcastEntityEffect(this, (byte) 7);
                  } else {
 diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
-index 03bcbf7c280476ef0e6fe87e3a96edb75544bddb..9e3b3aa2ffe10a52f69b268c926e8b8929359f8e 100644
+index 03bcbf7c280476ef0e6fe87e3a96edb75544bddb..5bf2a3205671a7cb001835ab241c34bcbe47e02c 100644
 --- a/src/main/java/net/minecraft/server/EntityWolf.java
 +++ b/src/main/java/net/minecraft/server/EntityWolf.java
 @@ -415,7 +415,7 @@ public class EntityWolf extends EntityTameableAnimal implements IEntityAngerable
@@ -41,12 +41,12 @@ index 03bcbf7c280476ef0e6fe87e3a96edb75544bddb..9e3b3aa2ffe10a52f69b268c926e8b89
  
                  // CraftBukkit - added event call and isCancelled check.
 -                if (this.random.nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) {
-+                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // Purpur
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || (this.random.nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled())) { // Purpur
                      this.tame(entityhuman);
                      this.navigation.o();
                      this.setGoalTarget((EntityLiving) null);
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalTame.java b/src/main/java/net/minecraft/server/PathfinderGoalTame.java
-index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..0779c9a41fb91f273b707dee29c93e085d0eb3a1 100644
+index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..76dda6f777fbdf515990651594b5b3fa57cc1f66 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalTame.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalTame.java
 @@ -58,7 +58,7 @@ public class PathfinderGoalTame extends PathfinderGoal {
@@ -54,7 +54,7 @@ index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..0779c9a41fb91f273b707dee29c93e08
  
                  // CraftBukkit - fire EntityTameEvent
 -                if (j > 0 && this.entity.getRandom().nextInt(j) < i && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this.entity, ((org.bukkit.craftbukkit.entity.CraftHumanEntity) this.entity.getBukkitEntity().getPassenger()).getHandle()).isCancelled()) {
-+                if ((this.entity.world.purpurConfig.alwaysTameInCreative && ((EntityHuman) entity).abilities.canInstantlyBuild) || j > 0 && this.entity.getRandom().nextInt(j) < i && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this.entity, ((org.bukkit.craftbukkit.entity.CraftHumanEntity) this.entity.getBukkitEntity().getPassenger()).getHandle()).isCancelled()) { // Purpur
++                if ((this.entity.world.purpurConfig.alwaysTameInCreative && ((EntityHuman) entity).abilities.canInstantlyBuild) || (j > 0 && this.entity.getRandom().nextInt(j) < i && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this.entity, ((org.bukkit.craftbukkit.entity.CraftHumanEntity) this.entity.getBukkitEntity().getPassenger()).getHandle()).isCancelled())) { // Purpur
                      this.entity.i((EntityHuman) entity);
                      return;
                  }

--- a/patches/server/0172-Config-to-always-tame-in-Creative.patch
+++ b/patches/server/0172-Config-to-always-tame-in-Creative.patch
@@ -1,0 +1,80 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Tue, 9 Feb 2021 21:23:37 -0500
+Subject: [PATCH] Config to always tame in Creative
+
+Adds a configuration option that ensures a player in Creative always tames a tameable entity.
+This essentially allows Creative mode players to tame animals on their first try.
+
+diff --git a/src/main/java/net/minecraft/server/EntityCat.java b/src/main/java/net/minecraft/server/EntityCat.java
+index f973408b1f098c8a090401205f809e95fdcf2f62..e9908f6b22010851f78a62e35a14371d407c2c7f 100644
+--- a/src/main/java/net/minecraft/server/EntityCat.java
++++ b/src/main/java/net/minecraft/server/EntityCat.java
+@@ -375,7 +375,7 @@ public class EntityCat extends EntityTameableAnimal {
+                 }
+             } else if (this.k(itemstack)) {
+                 this.a(entityhuman, itemstack);
+-                if (this.random.nextInt(3) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(3) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
+                     this.tame(entityhuman);
+                     this.setWillSit(true);
+                     this.world.broadcastEntityEffect(this, (byte) 7);
+diff --git a/src/main/java/net/minecraft/server/EntityParrot.java b/src/main/java/net/minecraft/server/EntityParrot.java
+index d19f8dda87c97de594ad051a6791d99eec581e95..f821cbbf6b8e223dc8439bb08bc124c88c23a057 100644
+--- a/src/main/java/net/minecraft/server/EntityParrot.java
++++ b/src/main/java/net/minecraft/server/EntityParrot.java
+@@ -245,7 +245,7 @@ public class EntityParrot extends EntityPerchable implements EntityBird {
+             }
+ 
+             if (!this.world.isClientSide) {
+-                if (this.random.nextInt(10) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(10) == 0 && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) { // CraftBukkit
+                     this.tame(entityhuman);
+                     this.world.broadcastEntityEffect(this, (byte) 7);
+                 } else {
+diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
+index 03bcbf7c280476ef0e6fe87e3a96edb75544bddb..53982a0b86364a63c4f6ad44c84f585fc5c58452 100644
+--- a/src/main/java/net/minecraft/server/EntityWolf.java
++++ b/src/main/java/net/minecraft/server/EntityWolf.java
+@@ -415,7 +415,7 @@ public class EntityWolf extends EntityTameableAnimal implements IEntityAngerable
+                 }
+ 
+                 // CraftBukkit - added event call and isCancelled check.
+-                if (this.random.nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) {
++                if ((this.world.purpurConfig.alwaysTameInCreative && entityhuman.abilities.canInstantlyBuild) || this.random.nextInt(3) == 0 && !CraftEventFactory.callEntityTameEvent(this, entityhuman).isCancelled()) {
+                     this.tame(entityhuman);
+                     this.navigation.o();
+                     this.setGoalTarget((EntityLiving) null);
+diff --git a/src/main/java/net/minecraft/server/PathfinderGoalTame.java b/src/main/java/net/minecraft/server/PathfinderGoalTame.java
+index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..dee2af04ea27ca06031c7cba744a3446938c7c46 100644
+--- a/src/main/java/net/minecraft/server/PathfinderGoalTame.java
++++ b/src/main/java/net/minecraft/server/PathfinderGoalTame.java
+@@ -58,7 +58,7 @@ public class PathfinderGoalTame extends PathfinderGoal {
+                 int j = this.entity.getMaxDomestication();
+ 
+                 // CraftBukkit - fire EntityTameEvent
+-                if (j > 0 && this.entity.getRandom().nextInt(j) < i && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this.entity, ((org.bukkit.craftbukkit.entity.CraftHumanEntity) this.entity.getBukkitEntity().getPassenger()).getHandle()).isCancelled()) {
++                if ((this.entity.world.purpurConfig.alwaysTameInCreative && ((EntityHuman) entity).abilities.canInstantlyBuild) || j > 0 && this.entity.getRandom().nextInt(j) < i && !org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTameEvent(this.entity, ((org.bukkit.craftbukkit.entity.CraftHumanEntity) this.entity.getBukkitEntity().getPassenger()).getHandle()).isCancelled()) {
+                     this.entity.i((EntityHuman) entity);
+                     return;
+                 }
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index ad6f5bf3a2f0734ffeba044025a52fd15e9970fb..82707a40a16c5f983f755e91211aa0061097d892 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -255,6 +255,7 @@ public class PurpurWorldConfig {
+     }
+ 
+     public boolean useBetterMending = false;
++    public boolean alwaysTameInCreative = false;
+     public boolean boatEjectPlayersOnLand = false;
+     public boolean boatsDoFallDamage = true;
+     public boolean disableDropsOnCrammingDeath = false;
+@@ -271,6 +272,7 @@ public class PurpurWorldConfig {
+     public int animalBreedingCooldownSeconds = 0;
+     private void miscGameplayMechanicsSettings() {
+         useBetterMending = getBoolean("gameplay-mechanics.use-better-mending", useBetterMending);
++        alwaysTameInCreative = getBoolean("gameplay-mechanics.always-tame-in-creative", alwaysTameInCreative);
+         boatEjectPlayersOnLand = getBoolean("gameplay-mechanics.boat.eject-players-on-land", boatEjectPlayersOnLand);
+         boatsDoFallDamage = getBoolean("gameplay-mechanics.boat.do-fall-damage", boatsDoFallDamage);
+         disableDropsOnCrammingDeath = getBoolean("gameplay-mechanics.disable-drops-on-cramming-death", disableDropsOnCrammingDeath);


### PR DESCRIPTION
Adds a configuration option that ensures a player in Creative always tames a tameable entity.
This essentially allows Creative mode players to tame animals on their first try.

I'm pretty sure all tameable animals are covered.
Here are the animals I know definitely were affected:
- Wolf
- Cat
- Horse
- Parrot
- Llama

Example: https://m.cft.li/p/fI5.mp4