### PR TITLE
Updated Upstream (Paper/Tuinity/Airplane)

### DIFF
--- a/patches/api/0001-Tuinity-API-Changes.patch
+++ b/patches/api/0001-Tuinity-API-Changes.patch
@@ -216,3 +216,106 @@ index f3e27d2d02a9407bb1b091b8c1125ad5abf99e55..b3e7b2a8eaa3980e34bc74a846320b78
          /**
           * Sends the component to the player
           *
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 064497506e6a5ab89ca43b99968ca79d51d67c46..5848c8c03a1520b95c9f494e0820e075f1757fc6 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -3508,6 +3508,26 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+      * @param viewDistance view distance in [2, 32]
+      */
+     void setNoTickViewDistance(int viewDistance);
++
++    // Tuinity start - add view distances
++    /**
++     * Gets the sending view distance for this world.
++     * <p>
++     * Sending view distance is the view distance where chunks will load in for players in this world.
++     * </p>
++     * @return The sending view distance for this world.
++     */
++    public int getSendViewDistance();
++
++    /**
++     * Sets the sending view distance for this world.
++     * <p>
++     * Sending view distance is the view distance where chunks will load in for players in this world.
++     * </p>
++     * @param viewDistance view distance in [2, 32] or -1
++     */
++    public void setSendViewDistance(int viewDistance);
++    // Tuinity end - add view distances
+     // Paper end - view distance api
+ 
+     // Spigot start
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 2ea531eaef8c455fdd503f0c0258813fe9136085..a84ea92d02d34cd48174152e0391f1af6c6b5def 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1768,23 +1768,63 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * Gets the view distance for this player
+      *
+      * @return the player's view distance
+-     * @deprecated This is unimplemented and <i>will</i> throw an exception at runtime. The {@link org.bukkit.World World}-based methods still work.
++     * // Tuinity - implemented
+      * @see org.bukkit.World#getViewDistance()
+      * @see org.bukkit.World#getNoTickViewDistance()
+      */
+-    @Deprecated
++    //@Deprecated // Tuinity - implemented
+     public int getViewDistance();
+ 
+     /**
+      * Sets the view distance for this player
+      *
+      * @param viewDistance the player's view distance
+-     * @deprecated This is unimplemented and <i>will</i> throw an exception at runtime. The {@link org.bukkit.World World}-based methods still work.
++     * // Tuinity - implemented
+      * @see org.bukkit.World#setViewDistance(int)
+      * @see org.bukkit.World#setNoTickViewDistance(int)
+      */
+-    @Deprecated
++    //@Deprecated // Tuinity - implemented
+     public void setViewDistance(int viewDistance);
++
++    // Tuinity start - add view distances api
++    /**
++     * Gets the no-ticking view distance for this player.
++     * <p>
++     * No-tick view distance is the view distance where chunks will load, however the chunks and their entities will not
++     * be set to tick.
++     * </p>
++     * @return The no-tick view distance for this player.
++     */
++    public int getNoTickViewDistance();
++
++    /**
++     * Sets the no-ticking view distance for this player.
++     * <p>
++     * No-tick view distance is the view distance where chunks will load, however the chunks and their entities will not
++     * be set to tick.
++     * </p>
++     * @param viewDistance view distance in [2, 32] or -1
++     */
++    public void setNoTickViewDistance(int viewDistance);
++
++    /**
++     * Gets the sending view distance for this player.
++     * <p>
++     * Sending view distance is the view distance where chunks will load in for players.
++     * </p>
++     * @return The sending view distance for this player.
++     */
++    public int getSendViewDistance();
++
++    /**
++     * Sets the sending view distance for this player.
++     * <p>
++     * Sending view distance is the view distance where chunks will load in for players.
++     * </p>
++     * @param viewDistance view distance in [2, 32] or -1
++     */
++    public void setSendViewDistance(int viewDistance);
++    // Tuinity end - add view distances api
+     // Paper end
+ 
+     /**

--- a/patches/api/0002-Airplane-API-Changes.patch
+++ b/patches/api/0002-Airplane-API-Changes.patch
@@ -3,627 +3,627 @@ From: Paul Sauve <paul@technove.co>
 Date: Sat, 19 Dec 2020 19:06:37 -0600
 Subject: [PATCH] Airplane API Changes
 
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-                            Preamble
-
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
-
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
-
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
-
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
-
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
-
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
-
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.
-
-                       TERMS AND CONDITIONS
-
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-  13. Use with the GNU Affero General Public License.
-
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
-
-  14. Revised Versions of this License.
-
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-  If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-  15. Disclaimer of Warranty.
-
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
-
-                     END OF TERMS AND CONDITIONS
+                                     GNU GENERAL PUBLIC LICENSE
+                                        Version 3, 29 June 2007
+
+                  Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+                  Everyone is permitted to copy and distribute verbatim copies
+                  of this license document, but changing it is not allowed.
+
+                                             Preamble
+
+                   The GNU General Public License is a free, copyleft license for
+                 software and other kinds of works.
+
+                   The licenses for most software and other practical works are designed
+                 to take away your freedom to share and change the works.  By contrast,
+                 the GNU General Public License is intended to guarantee your freedom to
+                 share and change all versions of a program--to make sure it remains free
+                 software for all its users.  We, the Free Software Foundation, use the
+                 GNU General Public License for most of our software; it applies also to
+                 any other work released this way by its authors.  You can apply it to
+                 your programs, too.
+
+                   When we speak of free software, we are referring to freedom, not
+                 price.  Our General Public Licenses are designed to make sure that you
+                 have the freedom to distribute copies of free software (and charge for
+                 them if you wish), that you receive source code or can get it if you
+                 want it, that you can change the software or use pieces of it in new
+                 free programs, and that you know you can do these things.
+
+                   To protect your rights, we need to prevent others from denying you
+                 these rights or asking you to surrender the rights.  Therefore, you have
+                 certain responsibilities if you distribute copies of the software, or if
+                 you modify it: responsibilities to respect the freedom of others.
+
+                   For example, if you distribute copies of such a program, whether
+                 gratis or for a fee, you must pass on to the recipients the same
+                 freedoms that you received.  You must make sure that they, too, receive
+                 or can get the source code.  And you must show them these terms so they
+                 know their rights.
+
+                   Developers that use the GNU GPL protect your rights with two steps:
+                 (1) assert copyright on the software, and (2) offer you this License
+                 giving you legal permission to copy, distribute and/or modify it.
+
+                   For the developers' and authors' protection, the GPL clearly explains
+                 that there is no warranty for this free software.  For both users' and
+                 authors' sake, the GPL requires that modified versions be marked as
+                 changed, so that their problems will not be attributed erroneously to
+                 authors of previous versions.
+
+                   Some devices are designed to deny users access to install or run
+                 modified versions of the software inside them, although the manufacturer
+                 can do so.  This is fundamentally incompatible with the aim of
+                 protecting users' freedom to change the software.  The systematic
+                 pattern of such abuse occurs in the area of products for individuals to
+                 use, which is precisely where it is most unacceptable.  Therefore, we
+                 have designed this version of the GPL to prohibit the practice for those
+                 products.  If such problems arise substantially in other domains, we
+                 stand ready to extend this provision to those domains in future versions
+                 of the GPL, as needed to protect the freedom of users.
+
+                   Finally, every program is threatened constantly by software patents.
+                 States should not allow patents to restrict development and use of
+                 software on general-purpose computers, but in those that do, we wish to
+                 avoid the special danger that patents applied to a free program could
+                 make it effectively proprietary.  To prevent this, the GPL assures that
+                 patents cannot be used to render the program non-free.
+
+                   The precise terms and conditions for copying, distribution and
+                 modification follow.
+
+                                        TERMS AND CONDITIONS
+
+                   0. Definitions.
+
+                   "This License" refers to version 3 of the GNU General Public License.
+
+                   "Copyright" also means copyright-like laws that apply to other kinds of
+                 works, such as semiconductor masks.
+
+                   "The Program" refers to any copyrightable work licensed under this
+                 License.  Each licensee is addressed as "you".  "Licensees" and
+                 "recipients" may be individuals or organizations.
+
+                   To "modify" a work means to copy from or adapt all or part of the work
+                 in a fashion requiring copyright permission, other than the making of an
+                 exact copy.  The resulting work is called a "modified version" of the
+                 earlier work or a work "based on" the earlier work.
+
+                   A "covered work" means either the unmodified Program or a work based
+                 on the Program.
+
+                   To "propagate" a work means to do anything with it that, without
+                 permission, would make you directly or secondarily liable for
+                 infringement under applicable copyright law, except executing it on a
+                 computer or modifying a private copy.  Propagation includes copying,
+                 distribution (with or without modification), making available to the
+                 public, and in some countries other activities as well.
+
+                   To "convey" a work means any kind of propagation that enables other
+                 parties to make or receive copies.  Mere interaction with a user through
+                 a computer network, with no transfer of a copy, is not conveying.
+
+                   An interactive user interface displays "Appropriate Legal Notices"
+                 to the extent that it includes a convenient and prominently visible
+                 feature that (1) displays an appropriate copyright notice, and (2)
+                 tells the user that there is no warranty for the work (except to the
+                 extent that warranties are provided), that licensees may convey the
+                 work under this License, and how to view a copy of this License.  If
+                 the interface presents a list of user commands or options, such as a
+                 menu, a prominent item in the list meets this criterion.
+
+                   1. Source Code.
+
+                   The "source code" for a work means the preferred form of the work
+                 for making modifications to it.  "Object code" means any non-source
+                 form of a work.
+
+                   A "Standard Interface" means an interface that either is an official
+                 standard defined by a recognized standards body, or, in the case of
+                 interfaces specified for a particular programming language, one that
+                 is widely used among developers working in that language.
+
+                   The "System Libraries" of an executable work include anything, other
+                 than the work as a whole, that (a) is included in the normal form of
+                 packaging a Major Component, but which is not part of that Major
+                 Component, and (b) serves only to enable use of the work with that
+                 Major Component, or to implement a Standard Interface for which an
+                 implementation is available to the public in source code form.  A
+                 "Major Component", in this context, means a major essential component
+                 (kernel, window system, and so on) of the specific operating system
+                 (if any) on which the executable work runs, or a compiler used to
+                 produce the work, or an object code interpreter used to run it.
+
+                   The "Corresponding Source" for a work in object code form means all
+                 the source code needed to generate, install, and (for an executable
+                 work) run the object code and to modify the work, including scripts to
+                 control those activities.  However, it does not include the work's
+                 System Libraries, or general-purpose tools or generally available free
+                 programs which are used unmodified in performing those activities but
+                 which are not part of the work.  For example, Corresponding Source
+                 includes interface definition files associated with source files for
+                 the work, and the source code for shared libraries and dynamically
+                 linked subprograms that the work is specifically designed to require,
+                 such as by intimate data communication or control flow between those
+                 subprograms and other parts of the work.
+
+                   The Corresponding Source need not include anything that users
+                 can regenerate automatically from other parts of the Corresponding
+                 Source.
+
+                   The Corresponding Source for a work in source code form is that
+                 same work.
+
+                   2. Basic Permissions.
+
+                   All rights granted under this License are granted for the term of
+                 copyright on the Program, and are irrevocable provided the stated
+                 conditions are met.  This License explicitly affirms your unlimited
+                 permission to run the unmodified Program.  The output from running a
+                 covered work is covered by this License only if the output, given its
+                 content, constitutes a covered work.  This License acknowledges your
+                 rights of fair use or other equivalent, as provided by copyright law.
+
+                   You may make, run and propagate covered works that you do not
+                 convey, without conditions so long as your license otherwise remains
+                 in force.  You may convey covered works to others for the sole purpose
+                 of having them make modifications exclusively for you, or provide you
+                 with facilities for running those works, provided that you comply with
+                 the terms of this License in conveying all material for which you do
+                 not control copyright.  Those thus making or running the covered works
+                 for you must do so exclusively on your behalf, under your direction
+                 and control, on terms that prohibit them from making any copies of
+                 your copyrighted material outside their relationship with you.
+
+                   Conveying under any other circumstances is permitted solely under
+                 the conditions stated below.  Sublicensing is not allowed; section 10
+                 makes it unnecessary.
+
+                   3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+                   No covered work shall be deemed part of an effective technological
+                 measure under any applicable law fulfilling obligations under article
+                 11 of the WIPO copyright treaty adopted on 20 December 1996, or
+                 similar laws prohibiting or restricting circumvention of such
+                 measures.
+
+                   When you convey a covered work, you waive any legal power to forbid
+                 circumvention of technological measures to the extent such circumvention
+                 is effected by exercising rights under this License with respect to
+                 the covered work, and you disclaim any intention to limit operation or
+                 modification of the work as a means of enforcing, against the work's
+                 users, your or third parties' legal rights to forbid circumvention of
+                 technological measures.
+
+                   4. Conveying Verbatim Copies.
+
+                   You may convey verbatim copies of the Program's source code as you
+                 receive it, in any medium, provided that you conspicuously and
+                 appropriately publish on each copy an appropriate copyright notice;
+                 keep intact all notices stating that this License and any
+                 non-permissive terms added in accord with section 7 apply to the code;
+                 keep intact all notices of the absence of any warranty; and give all
+                 recipients a copy of this License along with the Program.
+
+                   You may charge any price or no price for each copy that you convey,
+                 and you may offer support or warranty protection for a fee.
+
+                   5. Conveying Modified Source Versions.
+
+                   You may convey a work based on the Program, or the modifications to
+                 produce it from the Program, in the form of source code under the
+                 terms of section 4, provided that you also meet all of these conditions:
+
+                     a) The work must carry prominent notices stating that you modified
+                     it, and giving a relevant date.
+
+                     b) The work must carry prominent notices stating that it is
+                     released under this License and any conditions added under section
+                     7.  This requirement modifies the requirement in section 4 to
+                     "keep intact all notices".
+
+                     c) You must license the entire work, as a whole, under this
+                     License to anyone who comes into possession of a copy.  This
+                     License will therefore apply, along with any applicable section 7
+                     additional terms, to the whole of the work, and all its parts,
+                     regardless of how they are packaged.  This License gives no
+                     permission to license the work in any other way, but it does not
+                     invalidate such permission if you have separately received it.
+
+                     d) If the work has interactive user interfaces, each must display
+                     Appropriate Legal Notices; however, if the Program has interactive
+                     interfaces that do not display Appropriate Legal Notices, your
+                     work need not make them do so.
+
+                   A compilation of a covered work with other separate and independent
+                 works, which are not by their nature extensions of the covered work,
+                 and which are not combined with it such as to form a larger program,
+                 in or on a volume of a storage or distribution medium, is called an
+                 "aggregate" if the compilation and its resulting copyright are not
+                 used to limit the access or legal rights of the compilation's users
+                 beyond what the individual works permit.  Inclusion of a covered work
+                 in an aggregate does not cause this License to apply to the other
+                 parts of the aggregate.
+
+                   6. Conveying Non-Source Forms.
+
+                   You may convey a covered work in object code form under the terms
+                 of sections 4 and 5, provided that you also convey the
+                 machine-readable Corresponding Source under the terms of this License,
+                 in one of these ways:
+
+                     a) Convey the object code in, or embodied in, a physical product
+                     (including a physical distribution medium), accompanied by the
+                     Corresponding Source fixed on a durable physical medium
+                     customarily used for software interchange.
+
+                     b) Convey the object code in, or embodied in, a physical product
+                     (including a physical distribution medium), accompanied by a
+                     written offer, valid for at least three years and valid for as
+                     long as you offer spare parts or customer support for that product
+                     model, to give anyone who possesses the object code either (1) a
+                     copy of the Corresponding Source for all the software in the
+                     product that is covered by this License, on a durable physical
+                     medium customarily used for software interchange, for a price no
+                     more than your reasonable cost of physically performing this
+                     conveying of source, or (2) access to copy the
+                     Corresponding Source from a network server at no charge.
+
+                     c) Convey individual copies of the object code with a copy of the
+                     written offer to provide the Corresponding Source.  This
+                     alternative is allowed only occasionally and noncommercially, and
+                     only if you received the object code with such an offer, in accord
+                     with subsection 6b.
+
+                     d) Convey the object code by offering access from a designated
+                     place (gratis or for a charge), and offer equivalent access to the
+                     Corresponding Source in the same way through the same place at no
+                     further charge.  You need not require recipients to copy the
+                     Corresponding Source along with the object code.  If the place to
+                     copy the object code is a network server, the Corresponding Source
+                     may be on a different server (operated by you or a third party)
+                     that supports equivalent copying facilities, provided you maintain
+                     clear directions next to the object code saying where to find the
+                     Corresponding Source.  Regardless of what server hosts the
+                     Corresponding Source, you remain obligated to ensure that it is
+                     available for as long as needed to satisfy these requirements.
+
+                     e) Convey the object code using peer-to-peer transmission, provided
+                     you inform other peers where the object code and Corresponding
+                     Source of the work are being offered to the general public at no
+                     charge under subsection 6d.
+
+                   A separable portion of the object code, whose source code is excluded
+                 from the Corresponding Source as a System Library, need not be
+                 included in conveying the object code work.
+
+                   A "User Product" is either (1) a "consumer product", which means any
+                 tangible personal property which is normally used for personal, family,
+                 or household purposes, or (2) anything designed or sold for incorporation
+                 into a dwelling.  In determining whether a product is a consumer product,
+                 doubtful cases shall be resolved in favor of coverage.  For a particular
+                 product received by a particular user, "normally used" refers to a
+                 typical or common use of that class of product, regardless of the status
+                 of the particular user or of the way in which the particular user
+                 actually uses, or expects or is expected to use, the product.  A product
+                 is a consumer product regardless of whether the product has substantial
+                 commercial, industrial or non-consumer uses, unless such uses represent
+                 the only significant mode of use of the product.
+
+                   "Installation Information" for a User Product means any methods,
+                 procedures, authorization keys, or other information required to install
+                 and execute modified versions of a covered work in that User Product from
+                 a modified version of its Corresponding Source.  The information must
+                 suffice to ensure that the continued functioning of the modified object
+                 code is in no case prevented or interfered with solely because
+                 modification has been made.
+
+                   If you convey an object code work under this section in, or with, or
+                 specifically for use in, a User Product, and the conveying occurs as
+                 part of a transaction in which the right of possession and use of the
+                 User Product is transferred to the recipient in perpetuity or for a
+                 fixed term (regardless of how the transaction is characterized), the
+                 Corresponding Source conveyed under this section must be accompanied
+                 by the Installation Information.  But this requirement does not apply
+                 if neither you nor any third party retains the ability to install
+                 modified object code on the User Product (for example, the work has
+                 been installed in ROM).
+
+                   The requirement to provide Installation Information does not include a
+                 requirement to continue to provide support service, warranty, or updates
+                 for a work that has been modified or installed by the recipient, or for
+                 the User Product in which it has been modified or installed.  Access to a
+                 network may be denied when the modification itself materially and
+                 adversely affects the operation of the network or violates the rules and
+                 protocols for communication across the network.
+
+                   Corresponding Source conveyed, and Installation Information provided,
+                 in accord with this section must be in a format that is publicly
+                 documented (and with an implementation available to the public in
+                 source code form), and must require no special password or key for
+                 unpacking, reading or copying.
+
+                   7. Additional Terms.
+
+                   "Additional permissions" are terms that supplement the terms of this
+                 License by making exceptions from one or more of its conditions.
+                 Additional permissions that are applicable to the entire Program shall
+                 be treated as though they were included in this License, to the extent
+                 that they are valid under applicable law.  If additional permissions
+                 apply only to part of the Program, that part may be used separately
+                 under those permissions, but the entire Program remains governed by
+                 this License without regard to the additional permissions.
+
+                   When you convey a copy of a covered work, you may at your option
+                 remove any additional permissions from that copy, or from any part of
+                 it.  (Additional permissions may be written to require their own
+                 removal in certain cases when you modify the work.)  You may place
+                 additional permissions on material, added by you to a covered work,
+                 for which you have or can give appropriate copyright permission.
+
+                   Notwithstanding any other provision of this License, for material you
+                 add to a covered work, you may (if authorized by the copyright holders of
+                 that material) supplement the terms of this License with terms:
+
+                     a) Disclaiming warranty or limiting liability differently from the
+                     terms of sections 15 and 16 of this License; or
+
+                     b) Requiring preservation of specified reasonable legal notices or
+                     author attributions in that material or in the Appropriate Legal
+                     Notices displayed by works containing it; or
+
+                     c) Prohibiting misrepresentation of the origin of that material, or
+                     requiring that modified versions of such material be marked in
+                     reasonable ways as different from the original version; or
+
+                     d) Limiting the use for publicity purposes of names of licensors or
+                     authors of the material; or
+
+                     e) Declining to grant rights under trademark law for use of some
+                     trade names, trademarks, or service marks; or
+
+                     f) Requiring indemnification of licensors and authors of that
+                     material by anyone who conveys the material (or modified versions of
+                     it) with contractual assumptions of liability to the recipient, for
+                     any liability that these contractual assumptions directly impose on
+                     those licensors and authors.
+
+                   All other non-permissive additional terms are considered "further
+                 restrictions" within the meaning of section 10.  If the Program as you
+                 received it, or any part of it, contains a notice stating that it is
+                 governed by this License along with a term that is a further
+                 restriction, you may remove that term.  If a license document contains
+                 a further restriction but permits relicensing or conveying under this
+                 License, you may add to a covered work material governed by the terms
+                 of that license document, provided that the further restriction does
+                 not survive such relicensing or conveying.
+
+                   If you add terms to a covered work in accord with this section, you
+                 must place, in the relevant source files, a statement of the
+                 additional terms that apply to those files, or a notice indicating
+                 where to find the applicable terms.
+
+                   Additional terms, permissive or non-permissive, may be stated in the
+                 form of a separately written license, or stated as exceptions;
+                 the above requirements apply either way.
+
+                   8. Termination.
+
+                   You may not propagate or modify a covered work except as expressly
+                 provided under this License.  Any attempt otherwise to propagate or
+                 modify it is void, and will automatically terminate your rights under
+                 this License (including any patent licenses granted under the third
+                 paragraph of section 11).
+
+                   However, if you cease all violation of this License, then your
+                 license from a particular copyright holder is reinstated (a)
+                 provisionally, unless and until the copyright holder explicitly and
+                 finally terminates your license, and (b) permanently, if the copyright
+                 holder fails to notify you of the violation by some reasonable means
+                 prior to 60 days after the cessation.
+
+                   Moreover, your license from a particular copyright holder is
+                 reinstated permanently if the copyright holder notifies you of the
+                 violation by some reasonable means, this is the first time you have
+                 received notice of violation of this License (for any work) from that
+                 copyright holder, and you cure the violation prior to 30 days after
+                 your receipt of the notice.
+
+                   Termination of your rights under this section does not terminate the
+                 licenses of parties who have received copies or rights from you under
+                 this License.  If your rights have been terminated and not permanently
+                 reinstated, you do not qualify to receive new licenses for the same
+                 material under section 10.
+
+                   9. Acceptance Not Required for Having Copies.
+
+                   You are not required to accept this License in order to receive or
+                 run a copy of the Program.  Ancillary propagation of a covered work
+                 occurring solely as a consequence of using peer-to-peer transmission
+                 to receive a copy likewise does not require acceptance.  However,
+                 nothing other than this License grants you permission to propagate or
+                 modify any covered work.  These actions infringe copyright if you do
+                 not accept this License.  Therefore, by modifying or propagating a
+                 covered work, you indicate your acceptance of this License to do so.
+
+                   10. Automatic Licensing of Downstream Recipients.
+
+                   Each time you convey a covered work, the recipient automatically
+                 receives a license from the original licensors, to run, modify and
+                 propagate that work, subject to this License.  You are not responsible
+                 for enforcing compliance by third parties with this License.
+
+                   An "entity transaction" is a transaction transferring control of an
+                 organization, or substantially all assets of one, or subdividing an
+                 organization, or merging organizations.  If propagation of a covered
+                 work results from an entity transaction, each party to that
+                 transaction who receives a copy of the work also receives whatever
+                 licenses to the work the party's predecessor in interest had or could
+                 give under the previous paragraph, plus a right to possession of the
+                 Corresponding Source of the work from the predecessor in interest, if
+                 the predecessor has it or can get it with reasonable efforts.
+
+                   You may not impose any further restrictions on the exercise of the
+                 rights granted or affirmed under this License.  For example, you may
+                 not impose a license fee, royalty, or other charge for exercise of
+                 rights granted under this License, and you may not initiate litigation
+                 (including a cross-claim or counterclaim in a lawsuit) alleging that
+                 any patent claim is infringed by making, using, selling, offering for
+                 sale, or importing the Program or any portion of it.
+
+                   11. Patents.
+
+                   A "contributor" is a copyright holder who authorizes use under this
+                 License of the Program or a work on which the Program is based.  The
+                 work thus licensed is called the contributor's "contributor version".
+
+                   A contributor's "essential patent claims" are all patent claims
+                 owned or controlled by the contributor, whether already acquired or
+                 hereafter acquired, that would be infringed by some manner, permitted
+                 by this License, of making, using, or selling its contributor version,
+                 but do not include claims that would be infringed only as a
+                 consequence of further modification of the contributor version.  For
+                 purposes of this definition, "control" includes the right to grant
+                 patent sublicenses in a manner consistent with the requirements of
+                 this License.
+
+                   Each contributor grants you a non-exclusive, worldwide, royalty-free
+                 patent license under the contributor's essential patent claims, to
+                 make, use, sell, offer for sale, import and otherwise run, modify and
+                 propagate the contents of its contributor version.
+
+                   In the following three paragraphs, a "patent license" is any express
+                 agreement or commitment, however denominated, not to enforce a patent
+                 (such as an express permission to practice a patent or covenant not to
+                 sue for patent infringement).  To "grant" such a patent license to a
+                 party means to make such an agreement or commitment not to enforce a
+                 patent against the party.
+
+                   If you convey a covered work, knowingly relying on a patent license,
+                 and the Corresponding Source of the work is not available for anyone
+                 to copy, free of charge and under the terms of this License, through a
+                 publicly available network server or other readily accessible means,
+                 then you must either (1) cause the Corresponding Source to be so
+                 available, or (2) arrange to deprive yourself of the benefit of the
+                 patent license for this particular work, or (3) arrange, in a manner
+                 consistent with the requirements of this License, to extend the patent
+                 license to downstream recipients.  "Knowingly relying" means you have
+                 actual knowledge that, but for the patent license, your conveying the
+                 covered work in a country, or your recipient's use of the covered work
+                 in a country, would infringe one or more identifiable patents in that
+                 country that you have reason to believe are valid.
+
+                   If, pursuant to or in connection with a single transaction or
+                 arrangement, you convey, or propagate by procuring conveyance of, a
+                 covered work, and grant a patent license to some of the parties
+                 receiving the covered work authorizing them to use, propagate, modify
+                 or convey a specific copy of the covered work, then the patent license
+                 you grant is automatically extended to all recipients of the covered
+                 work and works based on it.
+
+                   A patent license is "discriminatory" if it does not include within
+                 the scope of its coverage, prohibits the exercise of, or is
+                 conditioned on the non-exercise of one or more of the rights that are
+                 specifically granted under this License.  You may not convey a covered
+                 work if you are a party to an arrangement with a third party that is
+                 in the business of distributing software, under which you make payment
+                 to the third party based on the extent of your activity of conveying
+                 the work, and under which the third party grants, to any of the
+                 parties who would receive the covered work from you, a discriminatory
+                 patent license (a) in connection with copies of the covered work
+                 conveyed by you (or copies made from those copies), or (b) primarily
+                 for and in connection with specific products or compilations that
+                 contain the covered work, unless you entered into that arrangement,
+                 or that patent license was granted, prior to 28 March 2007.
+
+                   Nothing in this License shall be construed as excluding or limiting
+                 any implied license or other defenses to infringement that may
+                 otherwise be available to you under applicable patent law.
+
+                   12. No Surrender of Others' Freedom.
+
+                   If conditions are imposed on you (whether by court order, agreement or
+                 otherwise) that contradict the conditions of this License, they do not
+                 excuse you from the conditions of this License.  If you cannot convey a
+                 covered work so as to satisfy simultaneously your obligations under this
+                 License and any other pertinent obligations, then as a consequence you may
+                 not convey it at all.  For example, if you agree to terms that obligate you
+                 to collect a royalty for further conveying from those to whom you convey
+                 the Program, the only way you could satisfy both those terms and this
+                 License would be to refrain entirely from conveying the Program.
+
+                   13. Use with the GNU Affero General Public License.
+
+                   Notwithstanding any other provision of this License, you have
+                 permission to link or combine any covered work with a work licensed
+                 under version 3 of the GNU Affero General Public License into a single
+                 combined work, and to convey the resulting work.  The terms of this
+                 License will continue to apply to the part which is the covered work,
+                 but the special requirements of the GNU Affero General Public License,
+                 section 13, concerning interaction through a network will apply to the
+                 combination as such.
+
+                   14. Revised Versions of this License.
+
+                   The Free Software Foundation may publish revised and/or new versions of
+                 the GNU General Public License from time to time.  Such new versions will
+                 be similar in spirit to the present version, but may differ in detail to
+                 address new problems or concerns.
+
+                   Each version is given a distinguishing version number.  If the
+                 Program specifies that a certain numbered version of the GNU General
+                 Public License "or any later version" applies to it, you have the
+                 option of following the terms and conditions either of that numbered
+                 version or of any later version published by the Free Software
+                 Foundation.  If the Program does not specify a version number of the
+                 GNU General Public License, you may choose any version ever published
+                 by the Free Software Foundation.
+
+                   If the Program specifies that a proxy can decide which future
+                 versions of the GNU General Public License can be used, that proxy's
+                 public statement of acceptance of a version permanently authorizes you
+                 to choose that version for the Program.
+
+                   Later license versions may give you additional or different
+                 permissions.  However, no additional obligations are imposed on any
+                 author or copyright holder as a result of your choosing to follow a
+                 later version.
+
+                   15. Disclaimer of Warranty.
+
+                   THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+                 APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+                 HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+                 OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+                 THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+                 PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+                 IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+                 ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+                   16. Limitation of Liability.
+
+                   IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+                 WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+                 THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+                 GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+                 USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+                 DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+                 PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+                 EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+                 SUCH DAMAGES.
+
+                   17. Interpretation of Sections 15 and 16.
+
+                   If the disclaimer of warranty and limitation of liability provided
+                 above cannot be given local legal effect according to their terms,
+                 reviewing courts shall apply local law that most closely approximates
+                 an absolute waiver of all civil liability in connection with the
+                 Program, unless a warranty or assumption of liability accompanies a
+                 copy of the Program in return for a fee.
+
+                                      END OF TERMS AND CONDITIONS
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 index 7760be3e34fa20825faf145d9fb5b2855c1a4602..79d839034d38c941745c6b91f973f908d6cdb8ee 100644

--- a/patches/api/0008-AFK-API.patch
+++ b/patches/api/0008-AFK-API.patch
@@ -81,10 +81,10 @@ index 0000000000000000000000000000000000000000..0c8b3e5e4ba412624357ea5662a78862
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2ea531eaef8c455fdd503f0c0258813fe9136085..53e10ef71fcd904d59c9c9825b2a736b6b35027c 100644
+index a84ea92d02d34cd48174152e0391f1af6c6b5def..023ca23e8c91a6525cc31d483d873dfe14e97da3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2076,4 +2076,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2116,4 +2116,25 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Override
      Spigot spigot();
      // Spigot end

--- a/patches/api/0017-Player-invulnerabilities.patch
+++ b/patches/api/0017-Player-invulnerabilities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player invulnerabilities
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 53e10ef71fcd904d59c9c9825b2a736b6b35027c..117a073dcff9c6d00c54cf5214b92bd50cd67f2c 100644
+index 023ca23e8c91a6525cc31d483d873dfe14e97da3..88bda8c25ad746ccc584c7d490bd3257a74a6a20 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2096,5 +2096,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2136,5 +2136,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the idle timer back to 0
       */
      void resetIdleTimer();

--- a/patches/api/0019-ItemStack-convenience-methods.patch
+++ b/patches/api/0019-ItemStack-convenience-methods.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack convenience methods
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 7b77c7132723a01e8c38ddaa616b363be300b653..c6b1131b1700797e0515045f4e5c81f85aa3449f 100644
+index 0a31a5321ac519568db936c94394f71b2e2fcec1..42a77a5f5b8968351a737cb1fd7cebf160b13245 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
-@@ -8649,4 +8649,36 @@ public enum Material implements Keyed {
+@@ -8660,4 +8660,36 @@ public enum Material implements Keyed {
              // </editor-fold>
          }
      }

--- a/patches/api/0033-Fix-javadoc-warnings-missing-param-and-return.patch
+++ b/patches/api/0033-Fix-javadoc-warnings-missing-param-and-return.patch
@@ -490,7 +490,7 @@ index 28a1fe3af1546daa779df46468e0ff8ad823f9ca..7a3be414ef9d54d7a852ba92d704011f
  
          @NotNull
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index f486d7c819f6330223980793c9b086fded0af059..632e53338c4d902aea7e8589152b1c1b6e6dde6a 100644
+index 7f90ef2fd1c87c5b8b69f2e9dba3ad8e6e9ce3ec..85f77a58bf6c21da815b6652c7b50d578951a14c 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
 @@ -81,6 +81,8 @@ public interface UnsafeValues {
@@ -950,10 +950,10 @@ index a6a7429ed2e1eefb2b12b7480ed74fcc3963a864..e8027e1d505dda6effbb1698550016e8
  
          NORMAL(false),
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 117a073dcff9c6d00c54cf5214b92bd50cd67f2c..0d1edff31a725f88f203fe3066ef1daf9c9a051e 100644
+index 88bda8c25ad746ccc584c7d490bd3257a74a6a20..1f667efd4b9bf00c0be8707849a6927483aef7ca 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1898,6 +1898,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1938,6 +1938,8 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void resetCooldown();
  
      /**
@@ -962,7 +962,7 @@ index 117a073dcff9c6d00c54cf5214b92bd50cd67f2c..0d1edff31a725f88f203fe3066ef1daf
       * @return the client option value of the player
       */
      @NotNull
-@@ -1937,6 +1939,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1977,6 +1979,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      // Paper end
  
      // Spigot start

--- a/patches/api/0038-Add-unsafe-Entity-serialization-API.patch
+++ b/patches/api/0038-Add-unsafe-Entity-serialization-API.patch
@@ -17,12 +17,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 632e53338c4d902aea7e8589152b1c1b6e6dde6a..e64d28359c6f5180f1dfd3896a5ba99fd30a943c 100644
+index 85f77a58bf6c21da815b6652c7b50d578951a14c..59a91250d80e6f67a32cb4c7a216f1389338ddbf 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -136,4 +136,28 @@ public interface UnsafeValues {
-     public int nextEntityId();
- 
+@@ -152,4 +152,28 @@ public interface UnsafeValues {
+      */
+     public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);
      // Paper end
 +
 +    // Purpur start

--- a/patches/server/0001-Tuinity-Server-Changes.patch
+++ b/patches/server/0001-Tuinity-Server-Changes.patch
@@ -283,9 +283,18 @@ index 884b59d478aa7de49906520e77866a7949bed19d..68ab5ccb2fcfe1de0503c9336572f28e
  
      private MinecraftTimings() {}
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index e33e889c291d37a821a4fbd40d9aac7bb079de0d..5dfa0658838c4801cdf260eae8b98163f729e5af 100644
+index e33e889c291d37a821a4fbd40d9aac7bb079de0d..35810f42d7a0cd50a4cbe90e8d698fe57914c889 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
+@@ -154,7 +154,7 @@ public class TimingsExport extends Thread {
+                     return pair(rule, world.getWorld().getGameRuleValue(rule));
+                 })),
+                 pair("ticking-distance", world.getChunkProvider().playerChunkMap.getEffectiveViewDistance()),
+-                pair("notick-viewdistance", world.getChunkProvider().playerChunkMap.getEffectiveNoTickViewDistance())
++                pair("notick-viewdistance", world.getChunkProvider().playerChunkMap.playerChunkManager.getTargetNoTickViewDistance()) // Tuinity - replace old player chunk management
+             ));
+         }));
+ 
 @@ -229,7 +229,8 @@ public class TimingsExport extends Thread {
          parent.put("config", createObject(
              pair("spigot", mapAsJSON(Bukkit.spigot().getSpigotConfig(), null)),
@@ -319,10 +328,10 @@ index dee00aac05f1acf050f05d4db557a08dd0f301c8..52c0ab1ce46e1f3233ef746d9bc69935
                  metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {
                      Map<String, Map<String, Integer>> map = new HashMap<>();
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index dcbee6ebfac34f793c18f21e07187ae7dcb37695..c891f7c247c81a865720237f316f352b2289c724 100644
+index 2f2701b9f0aa1a26a3e3eb7a14eac370f509ce1e..baa0ac754689ab67bf470b86bfb9c209e47c7eee 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -186,6 +186,44 @@ public class PaperCommand extends Command {
+@@ -219,6 +219,44 @@ public class PaperCommand extends Command {
          }
      }
  
@@ -367,7 +376,7 @@ index dcbee6ebfac34f793c18f21e07187ae7dcb37695..c891f7c247c81a865720237f316f352b
      private void doFixLight(CommandSender sender, String[] args) {
          if (!(sender instanceof Player)) {
              sender.sendMessage("Only players can use this command");
-@@ -194,7 +232,7 @@ public class PaperCommand extends Command {
+@@ -227,7 +265,7 @@ public class PaperCommand extends Command {
          int radius = 2;
          if (args.length > 1) {
              try {
@@ -376,7 +385,7 @@ index dcbee6ebfac34f793c18f21e07187ae7dcb37695..c891f7c247c81a865720237f316f352b
              } catch (Exception e) {
                  sender.sendMessage("Not a number");
                  return;
-@@ -207,6 +245,13 @@ public class PaperCommand extends Command {
+@@ -240,6 +278,13 @@ public class PaperCommand extends Command {
          net.minecraft.server.WorldServer world = (WorldServer) handle.world;
          LightEngineThreaded lightengine = world.getChunkProvider().getLightEngine();
  
@@ -587,16 +596,975 @@ index 7720578796e28d28e8c0c9aa40155cd205c17d54..e5db29d4cadb5702c7d06b0b6e2d0558
              return builder.suggest(literal).buildFuture();
          } else {
              return Suggestions.empty();
-diff --git a/src/main/java/com/tuinity/tuinity/chunk/SingleThreadChunkRegionManager.java b/src/main/java/com/tuinity/tuinity/chunk/SingleThreadChunkRegionManager.java
+diff --git a/src/main/java/com/tuinity/tuinity/chunk/PlayerChunkLoader.java b/src/main/java/com/tuinity/tuinity/chunk/PlayerChunkLoader.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba815b0ab8cd
+index 0000000000000000000000000000000000000000..afdaa263dd4aa7bb5132b3bcd16ac23f0739c2b8
 --- /dev/null
-+++ b/src/main/java/com/tuinity/tuinity/chunk/SingleThreadChunkRegionManager.java
-@@ -0,0 +1,491 @@
++++ b/src/main/java/com/tuinity/tuinity/chunk/PlayerChunkLoader.java
+@@ -0,0 +1,955 @@
 +package com.tuinity.tuinity.chunk;
 +
-+import co.aikar.timings.MinecraftTimings;
-+import co.aikar.timings.Timing;
++import com.destroystokyo.paper.util.misc.PlayerAreaMap;
++import com.destroystokyo.paper.util.misc.PooledLinkedHashSets;
++import com.tuinity.tuinity.config.TuinityConfig;
++import com.tuinity.tuinity.util.TickThread;
++import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
++import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
++import it.unimi.dsi.fastutil.objects.Reference2ObjectLinkedOpenHashMap;
++import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
++import net.minecraft.server.Chunk;
++import net.minecraft.server.ChunkCoordIntPair;
++import net.minecraft.server.EntityPlayer;
++import net.minecraft.server.MCUtil;
++import net.minecraft.server.MathHelper;
++import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.Packet;
++import net.minecraft.server.PacketPlayOutViewCentre;
++import net.minecraft.server.PacketPlayOutViewDistance;
++import net.minecraft.server.PlayerChunk;
++import net.minecraft.server.PlayerChunkMap;
++import net.minecraft.server.TicketType;
++import java.util.ArrayDeque;
++import java.util.ArrayList;
++import java.util.List;
++import java.util.TreeSet;
++import java.util.concurrent.atomic.AtomicInteger;
++
++public final class PlayerChunkLoader {
++
++    public static final int MIN_VIEW_DISTANCE = 2;
++    public static final int MAX_VIEW_DISTANCE = 32;
++
++    public static final int TICK_TICKET_LEVEL = 31;
++    public static final int LOADED_TICKET_LEVEL = 33;
++
++    protected final PlayerChunkMap chunkMap;
++    protected final Reference2ObjectLinkedOpenHashMap<EntityPlayer, PlayerLoaderData> playerMap = new Reference2ObjectLinkedOpenHashMap<>(512, 0.7f);
++    protected final ReferenceLinkedOpenHashSet<PlayerLoaderData> chunkSendQueue = new ReferenceLinkedOpenHashSet<>(512, 0.7f);
++
++    protected final TreeSet<PlayerLoaderData> chunkLoadQueue = new TreeSet<>((final PlayerLoaderData p1, final PlayerLoaderData p2) -> {
++        if (p1 == p2) {
++            return 0;
++        }
++
++        final ChunkPriorityHolder holder1 = p1.loadQueue.peekFirst();
++        final ChunkPriorityHolder holder2 = p2.loadQueue.peekFirst();
++
++        final int priorityCompare = Double.compare(holder1 == null ? Double.MAX_VALUE : holder1.priority, holder2 == null ? Double.MAX_VALUE : holder2.priority);
++
++        if (priorityCompare != 0) {
++            return priorityCompare;
++        }
++
++        final int idCompare = Integer.compare(p1.player.getId(), p2.player.getId());
++
++        if (idCompare != 0) {
++            return idCompare;
++        }
++
++        // last resort
++        return Integer.compare(System.identityHashCode(p1), System.identityHashCode(p2));
++    });
++
++    protected final TreeSet<PlayerLoaderData> chunkSendWaitQueue = new TreeSet<>((final PlayerLoaderData p1, final PlayerLoaderData p2) -> {
++        if (p1 == p2) {
++            return 0;
++        }
++
++        final int timeCompare = Long.compare(p1.nextChunkSendTarget, p2.nextChunkSendTarget);
++        if (timeCompare != 0) {
++            return timeCompare;
++        }
++
++        final int idCompare = Integer.compare(p1.player.getId(), p2.player.getId());
++
++        if (idCompare != 0) {
++            return idCompare;
++        }
++
++        // last resort
++        return Integer.compare(System.identityHashCode(p1), System.identityHashCode(p2));
++    });
++
++
++    // no throttling is applied below this VD for loading
++
++    /**
++     * The chunks to be sent to players, provided they're send-ready. Send-ready means the chunk and its 1 radius neighbours are loaded.
++     */
++    public final PlayerAreaMap broadcastMap;
++
++    /**
++     * The chunks to be brought up to send-ready status. Send-ready means the chunk and its 1 radius neighbours are loaded.
++     */
++    public final PlayerAreaMap loadMap;
++
++    /**
++     * Areamap used only to remove tickets for send-ready chunks. View distance is always + 1 of load view distance. Thus,
++     * this map is always representing the chunks we are actually going to load.
++     */
++    public final PlayerAreaMap loadTicketCleanup;
++
++    /**
++     * The chunks to brought to ticking level. Each chunk must have 2 radius neighbours loaded before this can happen.
++     */
++    public final PlayerAreaMap tickMap;
++
++    /**
++     * -1 if defaulting to [load distance], else always in [2, load distance]
++     */
++    protected int rawSendDistance = -1;
++
++    /**
++     * -1 if defaulting to [tick view distance + 1], else always in [tick view distance + 1, 32 + 1]
++     */
++    protected int rawLoadDistance = -1;
++
++    /**
++     * Never -1, always in [2, 32]
++     */
++    protected int rawTickDistance = -1;
++
++    // methods to bridge for API
++
++    public int getTargetViewDistance() {
++        return this.getTickDistance();
++    }
++
++    public void setTargetViewDistance(final int distance) {
++        this.setTickDistance(distance);
++    }
++
++    public int getTargetNoTickViewDistance() {
++        return this.getLoadDistance() - 1;
++    }
++
++    public void setTargetNoTickViewDistance(final int distance) {
++        this.setLoadDistance(distance == -1 ? -1 : distance + 1);
++    }
++
++    public int getTargetSendDistance() {
++        return this.rawSendDistance == -1 ? this.getLoadDistance() : this.rawSendDistance;
++    }
++
++    public void setTargetSendDistance(final int distance) {
++        this.setSendDistance(distance);
++    }
++
++    // internal methods
++
++    public int getSendDistance() {
++        final int loadDistance = this.getLoadDistance();
++        return this.rawSendDistance == -1 ? loadDistance : Math.min(this.rawSendDistance, loadDistance);
++    }
++
++    public void setSendDistance(final int distance) {
++        if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE + 1)) {
++            throw new IllegalArgumentException(Integer.toString(distance));
++        }
++        this.rawSendDistance = distance;
++    }
++
++    public int getLoadDistance() {
++        final int tickDistance = this.getTickDistance();
++        return this.rawLoadDistance == -1 ? tickDistance + 1 : Math.max(tickDistance + 1, this.rawLoadDistance);
++    }
++
++    public void setLoadDistance(final int distance) {
++        if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE + 1)) {
++            throw new IllegalArgumentException(Integer.toString(distance));
++        }
++        this.rawLoadDistance = distance;
++    }
++
++    public int getTickDistance() {
++        return this.rawTickDistance;
++    }
++
++    public void setTickDistance(final int distance) {
++        if (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE) {
++            throw new IllegalArgumentException(Integer.toString(distance));
++        }
++        this.rawTickDistance = distance;
++    }
++
++    /*
++      Players have 3 different types of view distance:
++      1. Sending view distance
++      2. Loading view distance
++      3. Ticking view distance
++
++      But for configuration purposes (and API) there are:
++      1. No-tick view distance
++      2. Tick view distance
++      3. Broadcast view distance
++
++      These aren't always the same as the types we represent internally.
++
++      Loading view distance is always max(no-tick + 1, tick + 1)
++      - no-tick has 1 added because clients need an extra radius to render chunks
++      - tick has 1 added because it needs an extra radius of chunks to load before they can be marked ticking
++
++      Loading view distance is defined as the radius of chunks that will be brought to send-ready status, which means
++      it loads chunks in radius load-view-distance + 1.
++
++      The maximum value for send view distance is the load view distance. API can set it lower.
++     */
++
++    public PlayerChunkLoader(final PlayerChunkMap chunkMap, final PooledLinkedHashSets<EntityPlayer> pooledHashSets) {
++        this.chunkMap = chunkMap;
++        this.broadcastMap = new PlayerAreaMap(pooledHashSets,
++                (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
++                 com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
++                    if (player.needsChunkCenterUpdate) {
++                        player.needsChunkCenterUpdate = false;
++                        player.playerConnection.sendPacket(new PacketPlayOutViewCentre(currPosX, currPosZ));
++                    }
++                    PlayerChunkLoader.this.onChunkEnter(player, rangeX, rangeZ);
++                },
++                (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
++                 com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
++                    PlayerChunkLoader.this.onChunkLeave(player, rangeX, rangeZ);
++                });
++        this.loadMap = new PlayerAreaMap(pooledHashSets,
++                null,
++                (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
++                 com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
++                    if (newState != null) {
++                        return;
++                    }
++                    PlayerChunkLoader.this.isTargetedForPlayerLoad.remove(MCUtil.getCoordinateKey(rangeX, rangeZ));
++                });
++        this.loadTicketCleanup = new PlayerAreaMap(pooledHashSets,
++                null,
++                (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
++                 com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
++                    if (newState != null) {
++                        return;
++                    }
++                    ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(rangeX, rangeZ);
++                    PlayerChunkLoader.this.chunkMap.world.getChunkProvider().removeTicketAtLevel(TicketType.PLAYER, chunkPos, LOADED_TICKET_LEVEL, chunkPos);
++                    if (PlayerChunkLoader.this.chunkTicketTracker.remove(chunkPos.pair())) {
++                        --PlayerChunkLoader.this.concurrentChunkLoads;
++                    }
++                });
++        this.tickMap = new PlayerAreaMap(pooledHashSets,
++                (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
++                 com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
++                    if (newState.size() != 1) {
++                        return;
++                    }
++                    Chunk chunk = PlayerChunkLoader.this.chunkMap.world.getChunkProvider().getChunkAtIfLoadedMainThreadNoCache(rangeX, rangeZ);
++                    if (chunk == null || !chunk.areNeighboursLoaded(2)) {
++                        return;
++                    }
++
++                    ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(rangeX, rangeZ);
++                    PlayerChunkLoader.this.chunkMap.world.getChunkProvider().addTicketAtLevel(TicketType.PLAYER, chunkPos, TICK_TICKET_LEVEL, chunkPos);
++                },
++                (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
++                 com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
++                    if (newState != null) {
++                        return;
++                    }
++                    ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(rangeX, rangeZ);
++                    PlayerChunkLoader.this.chunkMap.world.getChunkProvider().removeTicketAtLevel(TicketType.PLAYER, chunkPos, TICK_TICKET_LEVEL, chunkPos);
++                });
++    }
++
++    protected final LongOpenHashSet isTargetedForPlayerLoad = new LongOpenHashSet();
++    protected final LongOpenHashSet chunkTicketTracker = new LongOpenHashSet();
++
++    // rets whether the chunk is at a loaded stage that is ready to be sent to players
++    public boolean isChunkPlayerLoaded(final int chunkX, final int chunkZ) {
++        final long key = MCUtil.getCoordinateKey(chunkX, chunkZ);
++        final PlayerChunk chunk = this.chunkMap.getVisibleChunk(key);
++
++        if (chunk == null) {
++            return false;
++        }
++
++        return chunk.getSendingChunk() != null && this.isTargetedForPlayerLoad.contains(key);
++    }
++
++    public boolean isChunkSent(final EntityPlayer player, final int chunkX, final int chunkZ) {
++        final PlayerLoaderData data = this.playerMap.get(player);
++        if (data == null) {
++            return false;
++        }
++
++        return data.hasSentChunk(chunkX, chunkZ);
++    }
++
++    protected int getMaxConcurrentChunkSends() {
++        double config = TuinityConfig.playerMaxConcurrentChunkSends;
++        return Math.max(1, config <= 0 ? (int)Math.ceil(-config * this.chunkMap.world.getPlayers().size()) : (int)config);
++    }
++
++    protected int getMaxChunkLoads() {
++        double config = TuinityConfig.playerMaxConcurrentChunkLoads;
++        return Math.max(1, (config <= 0 ? (int)Math.ceil(-config * MinecraftServer.getServer().getPlayerCount()) : (int)config) * 9);
++    }
++
++    protected double getTargetSendRatePerPlayer() {
++        double config = TuinityConfig.playerTargetChunkSendRate;
++        return config <= 0 ? -config : (int)Math.ceil(-config / MinecraftServer.getServer().getPlayerCount());
++    }
++
++    public void onChunkPlayerTickReady(final int chunkX, final int chunkZ) {
++        final ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(chunkX, chunkZ);
++        this.chunkMap.world.getChunkProvider().addTicketAtLevel(TicketType.PLAYER, chunkPos, TICK_TICKET_LEVEL, chunkPos);
++    }
++
++    public void onChunkSendReady(final int chunkX, final int chunkZ) {
++        final long chunkKey = MCUtil.getCoordinateKey(chunkX, chunkZ);
++
++        final PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> playersInSendRange = this.broadcastMap.getObjectsInRange(chunkX, chunkZ);
++
++        if (playersInSendRange == null) {
++            return;
++        }
++
++        final Object[] rawData = playersInSendRange.getBackingSet();
++        for (int i = 0, len = rawData.length; i < len; ++i) {
++            final Object raw = rawData[i];
++
++            if (!(raw instanceof EntityPlayer)) {
++                continue;
++            }
++            this.onChunkEnter((EntityPlayer)raw, chunkX, chunkZ);
++        }
++
++        // now let's try and queue mid tick logic again
++    }
++
++    public void onChunkEnter(final EntityPlayer player, final int chunkX, final int chunkZ) {
++        final PlayerLoaderData data = this.playerMap.get(player);
++
++        if (data == null) {
++            return;
++        }
++
++        if (data.hasSentChunk(chunkX, chunkZ) || !this.isChunkPlayerLoaded(chunkX, chunkZ)) {
++            // if we don't have player tickets, then the load logic will pick this up and queue to send
++            return;
++        }
++
++        final long playerPos = this.broadcastMap.getLastCoordinate(player);
++        final int playerChunkX = MCUtil.getCoordinateX(playerPos);
++        final int playerChunkZ = MCUtil.getCoordinateZ(playerPos);
++        final int manhattanDistance = Math.abs(playerChunkX - chunkX) + Math.abs(playerChunkZ - chunkZ);
++
++        final ChunkPriorityHolder holder = new ChunkPriorityHolder(chunkX, chunkZ, manhattanDistance, 0.0);
++        data.sendQueue.add(holder);
++    }
++
++    public void onChunkLoad(final int chunkX, final int chunkZ) {
++        if (this.chunkTicketTracker.remove(MCUtil.getCoordinateKey(chunkX, chunkZ))) {
++            --this.concurrentChunkLoads;
++        }
++    }
++
++    public void onChunkLeave(final EntityPlayer player, final int chunkX, final int chunkZ) {
++        final PlayerLoaderData data = this.playerMap.get(player);
++
++        if (data == null) {
++            return;
++        }
++
++        data.unloadChunk(chunkX, chunkZ);
++    }
++
++    public void addPlayer(final EntityPlayer player) {
++        TickThread.ensureTickThread("Cannot add player async");
++        final PlayerLoaderData data = new PlayerLoaderData(player, this);
++        if (this.playerMap.putIfAbsent(player, data) == null) {
++            data.update();
++        }
++    }
++
++    public void removePlayer(final EntityPlayer player) {
++        TickThread.ensureTickThread("Cannot remove player async");
++
++        final PlayerLoaderData loaderData = this.playerMap.remove(player);
++        if (loaderData == null) {
++            return;
++        }
++        loaderData.remove();
++        this.chunkLoadQueue.remove(loaderData);
++        this.chunkSendQueue.remove(loaderData);
++        this.chunkSendWaitQueue.remove(loaderData);
++        synchronized (this.sendingChunkCounts) {
++            final int count = this.sendingChunkCounts.removeInt(loaderData);
++            if (count != 0) {
++                concurrentChunkSends.getAndAdd(-count);
++            }
++        }
++    }
++
++    public void updatePlayer(final EntityPlayer player) {
++        TickThread.ensureTickThread("Cannot update player async");
++        final PlayerLoaderData loaderData = this.playerMap.get(player);
++        if (loaderData != null) {
++            loaderData.update();
++        }
++    }
++
++    public PlayerLoaderData getData(final EntityPlayer player) {
++        return this.playerMap.get(player);
++    }
++
++    public void tick() {
++        TickThread.ensureTickThread("Cannot tick async");
++        for (final PlayerLoaderData data : this.playerMap.values()) {
++            data.update();
++        }
++        this.tickMidTick();
++    }
++
++    protected static final AtomicInteger concurrentChunkSends = new AtomicInteger();
++    protected final Reference2IntOpenHashMap<PlayerLoaderData> sendingChunkCounts = new Reference2IntOpenHashMap<>();
++    private void trySendChunks() {
++        final long time = System.nanoTime();
++        // drain entries from wait queue
++        while (!this.chunkSendWaitQueue.isEmpty()) {
++            final PlayerLoaderData data = this.chunkSendWaitQueue.first();
++
++            if (data.nextChunkSendTarget > time) {
++                break;
++            }
++
++            this.chunkSendWaitQueue.pollFirst();
++
++            this.chunkSendQueue.add(data);
++        }
++
++        if (this.chunkSendQueue.isEmpty()) {
++            return;
++        }
++
++        final int maxSends = this.getMaxConcurrentChunkSends();
++        final double sendRate = this.getTargetSendRatePerPlayer();
++        final long nextDeadline = (long)((1 / sendRate) * 1.0e9) + time;
++        for (;;) {
++            if (this.chunkSendQueue.isEmpty()) {
++                break;
++            }
++            final int currSends = concurrentChunkSends.get();
++            if (currSends >= maxSends) {
++                break;
++            }
++
++            if (!concurrentChunkSends.compareAndSet(currSends, currSends + 1)) {
++                continue;
++            }
++
++            // send chunk
++
++            final PlayerLoaderData data = this.chunkSendQueue.removeFirst();
++
++            final ChunkPriorityHolder queuedSend = data.sendQueue.pollFirst();
++            if (queuedSend == null) {
++                concurrentChunkSends.getAndDecrement(); // we never sent, so decrease
++                // stop iterating over players who have nothing to send
++                if (this.chunkSendQueue.isEmpty()) {
++                    // nothing left
++                    break;
++                }
++                continue;
++            }
++
++            if (!this.isChunkPlayerLoaded(queuedSend.chunkX, queuedSend.chunkZ)) {
++                throw new IllegalStateException();
++            }
++
++            data.nextChunkSendTarget = nextDeadline;
++            this.chunkSendWaitQueue.add(data);
++
++            synchronized (this.sendingChunkCounts) {
++                this.sendingChunkCounts.addTo(data, 1);
++            }
++
++            data.sendChunk(queuedSend.chunkX, queuedSend.chunkZ, () -> {
++                synchronized (this.sendingChunkCounts) {
++                    final int count = this.sendingChunkCounts.getInt(data);
++                    if (count == 0) {
++                        // disconnected, so we don't need to decrement: it will be decremented for us
++                        return;
++                    }
++                    if (count == 1) {
++                        this.sendingChunkCounts.removeInt(data);
++                    } else {
++                        this.sendingChunkCounts.put(data, count - 1);
++                    }
++                }
++
++                concurrentChunkSends.getAndDecrement();
++            });
++        }
++    }
++
++    protected int concurrentChunkLoads;
++    private void tryLoadChunks() {
++        if (this.chunkLoadQueue.isEmpty()) {
++            return;
++        }
++
++        final int maxLoads = this.getMaxChunkLoads();
++        for (;;) {
++            final PlayerLoaderData data = this.chunkLoadQueue.pollFirst();
++
++            final ChunkPriorityHolder queuedLoad = data.loadQueue.peekFirst();
++            if (queuedLoad == null) {
++                if (this.chunkLoadQueue.isEmpty()) {
++                    break;
++                }
++                continue;
++            }
++
++            if (this.isChunkPlayerLoaded(queuedLoad.chunkX, queuedLoad.chunkZ)) {
++                // already loaded!
++                data.loadQueue.pollFirst(); // already loaded so we just skip
++                this.chunkLoadQueue.add(data);
++
++                // ensure the chunk is queued to send
++                this.onChunkSendReady(queuedLoad.chunkX, queuedLoad.chunkZ);
++                continue;
++            }
++
++            final long chunkKey = MCUtil.getCoordinateKey(queuedLoad.chunkX, queuedLoad.chunkZ);
++
++            final double priority = queuedLoad.priority;
++            // while we do need to rate limit chunk loads, the logic for sending chunks requires that tickets are present.
++            // when chunks are loaded (i.e spawn) but do not have this player's tickets, they have to wait behind the
++            // load queue. To avoid this problem, we check early here if tickets are required to load the chunk - if they
++            // aren't required, it bypasses the limiter system.
++            boolean unloadedTargetChunk = false;
++            unloaded_check:
++            for (int dz = -1; dz <= 1; ++dz) {
++                for (int dx = -1; dx <= 1; ++dx) {
++                    final int offX = queuedLoad.chunkX + dx;
++                    final int offZ = queuedLoad.chunkZ + dz;
++                    if (this.chunkMap.world.getChunkProvider().getChunkAtIfLoadedMainThreadNoCache(offX, offZ) == null) {
++                        unloadedTargetChunk = true;
++                        break unloaded_check;
++                    }
++                }
++            }
++            if (unloadedTargetChunk && priority > 0.0) {
++                // priority > 0.0 implies rate limited chunks
++
++                final int currentChunkLoads = this.concurrentChunkLoads;
++                if (currentChunkLoads >= maxLoads) {
++                    // don't poll, we didn't load it
++                    this.chunkLoadQueue.add(data);
++                    break;
++                }
++            }
++
++            // can only poll after we decide to load
++            data.loadQueue.pollFirst();
++
++            // now that we've polled we can re-add to load queue
++            this.chunkLoadQueue.add(data);
++
++            // add necessary tickets to load chunk up to send-ready
++            for (int dz = -1; dz <= 1; ++dz) {
++                for (int dx = -1; dx <= 1; ++dx) {
++                    final int offX = queuedLoad.chunkX + dx;
++                    final int offZ = queuedLoad.chunkZ + dz;
++                    final ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(offX, offZ);
++
++                    this.chunkMap.world.getChunkProvider().addTicketAtLevel(TicketType.PLAYER, chunkPos, LOADED_TICKET_LEVEL, chunkPos);
++                    if (this.chunkMap.world.getChunkProvider().getChunkAtIfLoadedMainThreadNoCache(offX, offZ) != null) {
++                        continue;
++                    }
++
++                    if (priority > 0.0 && this.chunkTicketTracker.add(MCUtil.getCoordinateKey(offX, offZ))) {
++                        // wont reach here if unloadedTargetChunk is false
++                        ++this.concurrentChunkLoads;
++                    }
++                }
++            }
++
++            // mark that we've added tickets here
++            this.isTargetedForPlayerLoad.add(chunkKey);
++
++            // it's possible all we needed was the player tickets to queue up the send.
++            if (this.isChunkPlayerLoaded(queuedLoad.chunkX, queuedLoad.chunkZ)) {
++                // yup, all we needed.
++                this.onChunkSendReady(queuedLoad.chunkX, queuedLoad.chunkZ);
++            }
++        }
++    }
++
++    public void tickMidTick() {
++        // try to send more chunks
++        this.trySendChunks();
++
++        // try to queue more chunks to load
++        this.tryLoadChunks();
++    }
++
++    static final class ChunkPriorityHolder {
++        public final int chunkX;
++        public final int chunkZ;
++        public final int manhattanDistanceToPlayer;
++        public final double priority;
++
++        public ChunkPriorityHolder(final int chunkX, final int chunkZ, final int manhattanDistanceToPlayer, final double priority) {
++            this.chunkX = chunkX;
++            this.chunkZ = chunkZ;
++            this.manhattanDistanceToPlayer = manhattanDistanceToPlayer;
++            this.priority = priority;
++        }
++    }
++
++    public static final class PlayerLoaderData {
++
++        protected static final float FOV = 110.0f;
++        protected static final double PRIORITISED_DISTANCE = 12.0 * 16.0;
++
++        // Player max sprint speed is approximately 8m/s
++        protected static final double LOOK_PRIORITY_SPEED_THRESHOLD = (10.0/20.0) * (10.0/20.0);
++        protected static final double LOOK_PRIORITY_YAW_DELTA_RECALC_THRESHOLD = 3.0f;
++
++        protected double lastLocX = Double.NEGATIVE_INFINITY;
++        protected double lastLocZ = Double.NEGATIVE_INFINITY;
++
++        protected int lastChunkX;
++        protected int lastChunkZ;
++
++        // this is corrected so that 0 is along the positive x-axis
++        protected float lastYaw = Float.NEGATIVE_INFINITY;
++
++        protected int lastSendDistance = Integer.MIN_VALUE;
++        protected int lastLoadDistance = Integer.MIN_VALUE;
++        protected int lastTickDistance = Integer.MIN_VALUE;
++        protected boolean usingLookingPriority;
++
++        protected final EntityPlayer player;
++        protected final PlayerChunkLoader loader;
++
++        // warning: modifications of this field must be aware that the loadQueue inside PlayerChunkLoader uses this field
++        // in a comparator!
++        protected final ArrayDeque<ChunkPriorityHolder> loadQueue = new ArrayDeque<>();
++        protected final LongOpenHashSet sentChunks = new LongOpenHashSet();
++
++        protected final TreeSet<ChunkPriorityHolder> sendQueue = new TreeSet<>((final ChunkPriorityHolder p1, final ChunkPriorityHolder p2) -> {
++            final int distanceCompare = Integer.compare(p1.manhattanDistanceToPlayer, p2.manhattanDistanceToPlayer);
++            if (distanceCompare != 0) {
++                return distanceCompare;
++            }
++
++            final int coordinateXCompare = Integer.compare(p1.chunkX, p2.chunkX);
++            if (coordinateXCompare != 0) {
++                return coordinateXCompare;
++            }
++
++            return Integer.compare(p1.chunkZ, p2.chunkZ);
++        });
++
++        protected int sendViewDistance = -1;
++        protected int loadViewDistance = -1;
++        protected int tickViewDistance = -1;
++
++        protected long nextChunkSendTarget;
++
++        public PlayerLoaderData(final EntityPlayer player, final PlayerChunkLoader loader) {
++            this.player = player;
++            this.loader = loader;
++        }
++
++        // these view distance methods are for api
++        public int getTargetSendViewDistance() {
++            final int tickViewDistance = this.tickViewDistance == -1 ? this.loader.getTickDistance() : this.tickViewDistance;
++            final int loadViewDistance = Math.max(tickViewDistance + 1, this.loadViewDistance == -1 ? this.loader.getLoadDistance() : this.loadViewDistance);
++            final int clientViewDistance = this.getClientViewDistance();
++            final int sendViewDistance = Math.min(loadViewDistance, this.sendViewDistance == -1 ? (!TuinityConfig.playerAutoConfigureSendViewDistance || clientViewDistance == -1 ? this.loader.getSendDistance() : clientViewDistance + 1) : this.sendViewDistance);
++            return sendViewDistance;
++        }
++
++        public void setTargetSendViewDistance(final int distance) {
++            if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE + 1)) {
++                throw new IllegalArgumentException(Integer.toString(distance));
++            }
++            this.sendViewDistance = distance;
++        }
++
++        public int getTargetNoTickViewDistance() {
++            return (this.loadViewDistance == -1 ? this.getLoadDistance() : this.loadViewDistance) - 1;
++        }
++
++        public void setTargetNoTickViewDistance(final int distance) {
++            if (distance != -1 && (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE)) {
++                throw new IllegalArgumentException(Integer.toString(distance));
++            }
++            this.loadViewDistance = distance == -1 ? -1 : distance + 1;
++        }
++
++        public int getTargetTickViewDistance() {
++            return this.tickViewDistance == -1 ? this.loader.getTickDistance() : this.tickViewDistance;
++        }
++
++        public void setTargetTickViewDistance(final int distance) {
++            if (distance < MIN_VIEW_DISTANCE || distance > MAX_VIEW_DISTANCE) {
++                throw new IllegalArgumentException(Integer.toString(distance));
++            }
++            this.tickViewDistance = distance;
++        }
++
++        protected int getLoadDistance() {
++            final int tickViewDistance = this.tickViewDistance == -1 ? this.loader.getTickDistance() : this.tickViewDistance;
++
++            return Math.max(tickViewDistance + 1, this.loadViewDistance == -1 ? this.loader.getLoadDistance() : this.loadViewDistance);
++        }
++
++        public boolean hasSentChunk(final int chunkX, final int chunkZ) {
++            return this.sentChunks.contains(MCUtil.getCoordinateKey(chunkX, chunkZ));
++        }
++
++        public void sendChunk(final int chunkX, final int chunkZ, final Runnable onChunkSend) {
++            if (this.sentChunks.add(MCUtil.getCoordinateKey(chunkX, chunkZ))) {
++                this.player.getWorldServer().getChunkProvider().playerChunkMap.sendChunk(this.player,
++                        new ChunkCoordIntPair(chunkX, chunkZ), new Packet[2], false, true); // unloaded, loaded
++                this.player.playerConnection.networkManager.execute(onChunkSend);
++            } else {
++                throw new IllegalStateException();
++            }
++        }
++
++        public void unloadChunk(final int chunkX, final int chunkZ) {
++            if (this.sentChunks.remove(MCUtil.getCoordinateKey(chunkX, chunkZ))) {
++                this.player.getWorldServer().getChunkProvider().playerChunkMap.sendChunk(this.player,
++                        new ChunkCoordIntPair(chunkX, chunkZ), null, true, false); // unloaded, loaded
++            }
++        }
++
++        protected static boolean triangleIntersects(final double p1x, final double p1z, // triangle point
++                                                    final double p2x, final double p2z, // triangle point
++                                                    final double p3x, final double p3z, // triangle point
++
++                                                    final double targetX, final double targetZ) { // point
++            // from barycentric coordinates:
++            // targetX = a*p1x + b*p2x + c*p3x
++            // targetZ = a*p1z + b*p2z + c*p3z
++            // 1.0     = a*1.0 + b*1.0 + c*1.0
++            // where a, b, c >= 0.0
++            // so, if any of a, b, c are less-than zero then there is no intersection.
++
++            // d = ((p2z - p3z)(p1x - p3x) + (p3x - p2x)(p1z - p3z))
++            // a = ((p2z - p3z)(targetX - p3x) + (p3x - p2x)(targetZ - p3z)) / d
++            // b = ((p3z - p1z)(targetX - p3x) + (p1x - p3x)(targetZ - p3z)) / d
++            // c = 1.0 - a - b
++
++            final double d = (p2z - p3z)*(p1x - p3x) + (p3x - p2x)*(p1z - p3z);
++            final double a = ((p2z - p3z)*(targetX - p3x) + (p3x - p2x)*(targetZ - p3z)) / d;
++
++            if (a < 0.0 || a > 1.0) {
++                return false;
++            }
++
++            final double b = ((p3z - p1z)*(targetX - p3x) + (p1x - p3x)*(targetZ - p3z)) / d;
++            if (b < 0.0 || b > 1.0) {
++                return false;
++            }
++
++            final double c = 1.0 - a - b;
++
++            return c >= 0.0 && c <= 1.0;
++        }
++
++        public void remove() {
++            this.loader.broadcastMap.remove(this.player);
++            this.loader.loadMap.remove(this.player);
++            this.loader.loadTicketCleanup.remove(this.player);
++            this.loader.tickMap.remove(this.player);
++        }
++
++        protected int getClientViewDistance() {
++            return this.player.clientViewDistance == null ? -1 : this.player.clientViewDistance.intValue();
++        }
++
++        public void update() {
++            final int tickViewDistance = this.tickViewDistance == -1 ? this.loader.getTickDistance() : this.tickViewDistance;
++            // load view cannot be less-than tick view + 1
++            final int loadViewDistance = Math.max(tickViewDistance + 1, this.loadViewDistance == -1 ? this.loader.getLoadDistance() : this.loadViewDistance);
++            // send view cannot be greater-than load view
++            final int clientViewDistance = this.getClientViewDistance();
++            final int sendViewDistance = Math.min(loadViewDistance, this.sendViewDistance == -1 ? (!TuinityConfig.playerAutoConfigureSendViewDistance || clientViewDistance == -1 ? this.loader.getSendDistance() : clientViewDistance + 1) : this.sendViewDistance);
++
++            final double posX = this.player.locX();
++            final double posZ = this.player.locZ();
++            final float yaw = MCUtil.normalizeYaw(this.player.yaw + 90.0f); // mc yaw 0 is along the positive z axis, but obviously this is really dumb - offset so we are at positive x-axis
++
++            // in general, we really only want to prioritise chunks in front if we know we're moving pretty fast into them.
++            final boolean useLookPriority = TuinityConfig.playerFrustumPrioritisation && (this.player.getMot().magnitudeXZSquared() > LOOK_PRIORITY_SPEED_THRESHOLD ||
++                    this.player.abilities.isFlying);
++
++            // make sure we're in the send queue
++            this.loader.chunkSendWaitQueue.add(this);
++
++            if (
++                // has view distance stayed the same?
++                    sendViewDistance == this.lastSendDistance
++                            && loadViewDistance == this.lastLoadDistance
++                            && tickViewDistance == this.lastTickDistance
++
++                            && (this.usingLookingPriority ? (
++                                    // has our block stayed the same (this also accounts for chunk change)?
++                                    MathHelper.floor(this.lastLocX) == MathHelper.floor(posX)
++                                    && MathHelper.floor(this.lastLocZ) == MathHelper.floor(posZ)
++                            ) : (
++                                    // has our chunk stayed the same
++                                    (MathHelper.floor(this.lastLocX) >> 4) == (MathHelper.floor(posX) >> 4)
++                                    && (MathHelper.floor(this.lastLocZ) >> 4) == (MathHelper.floor(posZ) >> 4)
++                            ))
++
++                            // has our decision about look priority changed?
++                            && this.usingLookingPriority == useLookPriority
++
++                            // if we are currently using look priority, has our yaw stayed within recalc threshold?
++                            && (!this.usingLookingPriority || Math.abs(yaw - this.lastYaw) <= LOOK_PRIORITY_YAW_DELTA_RECALC_THRESHOLD)
++            ) {
++                // nothing we care about changed, so we're not re-calculating
++                return;
++            }
++
++            final int centerChunkX = MathHelper.floor(posX) >> 4;
++            final int centerChunkZ = MathHelper.floor(posZ) >> 4;
++
++            this.player.needsChunkCenterUpdate = true;
++            this.loader.broadcastMap.addOrUpdate(this.player, centerChunkX, centerChunkZ, sendViewDistance);
++            this.player.needsChunkCenterUpdate = false;
++            this.loader.loadMap.addOrUpdate(this.player, centerChunkX, centerChunkZ, loadViewDistance);
++            this.loader.loadTicketCleanup.addOrUpdate(this.player, centerChunkX, centerChunkZ, loadViewDistance + 1);
++            this.loader.tickMap.addOrUpdate(this.player, centerChunkX, centerChunkZ, tickViewDistance);
++
++            if (sendViewDistance != this.lastSendDistance) {
++                // update the view radius for client
++                // note that this should be after the map calls because the client wont expect unload calls not in its VD
++                // and it's possible we decreased VD here
++                this.player.playerConnection.sendPacket(new PacketPlayOutViewDistance(sendViewDistance - 1)); // client already expects the 1 radius neighbours, so subtract 1.
++            }
++
++            this.lastLocX = posX;
++            this.lastLocZ = posZ;
++            this.lastYaw = yaw;
++            this.lastSendDistance = sendViewDistance;
++            this.lastLoadDistance = loadViewDistance;
++            this.lastTickDistance = tickViewDistance;
++            this.usingLookingPriority = useLookPriority;
++
++            this.lastChunkX = centerChunkX;
++            this.lastChunkZ = centerChunkZ;
++
++            // points for player "view" triangle:
++
++            // obviously, the player pos is a vertex
++            final double p1x = posX;
++            final double p1z = posZ;
++
++            // to the left of the looking direction
++            final double p2x = PRIORITISED_DISTANCE * Math.cos(Math.toRadians(yaw + (double)(FOV / 2.0))) // calculate rotated vector
++                    + p1x; // offset vector
++            final double p2z = PRIORITISED_DISTANCE * Math.sin(Math.toRadians(yaw + (double)(FOV / 2.0))) // calculate rotated vector
++                    + p1z; // offset vector
++
++            // to the right of the looking direction
++            final double p3x = PRIORITISED_DISTANCE * Math.cos(Math.toRadians(yaw - (double)(FOV / 2.0))) // calculate rotated vector
++                    + p1x; // offset vector
++            final double p3z = PRIORITISED_DISTANCE * Math.sin(Math.toRadians(yaw - (double)(FOV / 2.0))) // calculate rotated vector
++                    + p1z; // offset vector
++
++            // now that we have all of our points, we can recalculate the load queue
++
++            final List<ChunkPriorityHolder> loadQueue = new ArrayList<>();
++
++            // clear send queue, we are re-sorting
++            this.sendQueue.clear();
++
++            final int searchViewDistance = Math.max(loadViewDistance, sendViewDistance);
++
++            for (int dx = -searchViewDistance; dx <= searchViewDistance; ++dx) {
++                for (int dz = -searchViewDistance; dz <= searchViewDistance; ++dz) {
++                    final int chunkX = dx + centerChunkX;
++                    final int chunkZ = dz + centerChunkZ;
++                    final int squareDistance = Math.max(Math.abs(dx), Math.abs(dz));
++
++                    if (this.hasSentChunk(chunkX, chunkZ)) {
++                        // already sent (which means it is also loaded)
++                        continue;
++                    }
++
++                    final boolean loadChunk = squareDistance <= loadViewDistance;
++                    final boolean sendChunk = squareDistance <= sendViewDistance;
++
++                    final boolean prioritised = useLookPriority && triangleIntersects(
++                            // prioritisation triangle
++                            p1x, p1z, p2x, p2z, p3x, p3z,
++
++                            // center of chunk
++                            (double)((chunkX << 4) | 8), (double)((chunkZ << 4) | 8)
++                    );
++
++
++                    final int manhattanDistance = (Math.abs(dx) + Math.abs(dz));
++
++                    final double priority;
++
++                    if (squareDistance <= TuinityConfig.playerMinChunkLoadRadius) {
++                        // priority should be negative, and we also want to order it from center outwards
++                        // so we want (0,0) to be the smallest, and (minLoadedRadius,minLoadedRadius) to be the greatest
++                        priority = -((2 * TuinityConfig.playerMinChunkLoadRadius + 1) - (dx + dz));
++                    } else {
++                        if (prioritised) {
++                            // we don't prioritise these chunks above others because we also want to make sure some chunks
++                            // will be loaded if the player changes direction
++                            priority = (double)manhattanDistance / 6.0;
++                        } else {
++                            priority = (double)manhattanDistance;
++                        }
++                    }
++
++                    final ChunkPriorityHolder holder = new ChunkPriorityHolder(chunkX, chunkZ, manhattanDistance, priority);
++
++                    if (!this.loader.isChunkPlayerLoaded(chunkX, chunkZ)) {
++                        if (loadChunk) {
++                            loadQueue.add(holder);
++                        }
++                    } else {
++                        // loaded but not sent: so queue it!
++                        if (sendChunk) {
++                            this.sendQueue.add(holder);
++                        }
++                    }
++                }
++            }
++
++            loadQueue.sort((final ChunkPriorityHolder p1, final ChunkPriorityHolder p2) -> {
++                return Double.compare(p1.priority, p2.priority);
++            });
++
++            // we're modifying loadQueue, must remove
++            this.loader.chunkLoadQueue.remove(this);
++
++            this.loadQueue.clear();
++            this.loadQueue.addAll(loadQueue);
++
++            // must re-add
++            this.loader.chunkLoadQueue.add(this);
++        }
++    }
++}
+diff --git a/src/main/java/com/tuinity/tuinity/chunk/SingleThreadChunkRegionManager.java b/src/main/java/com/tuinity/tuinity/chunk/SingleThreadChunkRegionManager.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..6985b1df450a3b2b9e9c4696fef60652cb84fa2c
+--- /dev/null
++++ b/src/main/java/com/tuinity/tuinity/chunk/SingleThreadChunkRegionManager.java
+@@ -0,0 +1,477 @@
++package com.tuinity.tuinity.chunk;
++
 +import com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet;
 +import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 +import it.unimi.dsi.fastutil.objects.ReferenceLinkedOpenHashSet;
@@ -606,44 +1574,40 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +import net.minecraft.server.WorldServer;
 +import java.util.ArrayList;
 +import java.util.Arrays;
-+import java.util.EnumMap;
 +import java.util.Iterator;
 +import java.util.List;
-+import java.util.function.Function;
++import java.util.function.Supplier;
 +
-+public final class SingleThreadChunkRegionManager<T extends Enum<T> & SingleThreadChunkRegionManager.RegionDataCreator<T>> {
++public final class SingleThreadChunkRegionManager {
 +
-+    static final int REGION_SECTION_MERGE_RADIUS = 1;
-+    // if this becomes > 8, then the RegionSection needs to be properly modified (see bitset)
-+    public static final int REGION_CHUNK_SIZE = 32;
-+    public static final int REGION_CHUNK_SIZE_SHIFT = 5; // log2(REGION_CHUNK_SIZE)
++    protected final int regionSectionMergeRadius;
++    protected final int regionSectionChunkSize;
++    public final int regionChunkShift; // log2(REGION_CHUNK_SIZE)
 +
 +    public final WorldServer world;
-+    public final Class<T> dataClass;
 +    public final String name;
 +
-+    public final Timing addChunkTimings;
-+    public final Timing removeChunkTimings;
-+    public final Timing regionRecalculateTimings;
-+
-+    protected final Long2ObjectOpenHashMap<RegionSection<T>> regionsBySection = new Long2ObjectOpenHashMap<>();
-+    protected final ReferenceLinkedOpenHashSet<Region<T>> needsRecalculation = new ReferenceLinkedOpenHashSet<>();
++    protected final Long2ObjectOpenHashMap<RegionSection> regionsBySection = new Long2ObjectOpenHashMap<>();
++    protected final ReferenceLinkedOpenHashSet<Region> needsRecalculation = new ReferenceLinkedOpenHashSet<>();
 +    protected final int minSectionRecalcCount;
 +    protected final double maxDeadRegionPercent;
++    protected final Supplier<RegionData> regionDataSupplier;
++    protected final Supplier<RegionSectionData> regionSectionDataSupplier;
 +
-+    public SingleThreadChunkRegionManager(final WorldServer world, final Class<T> enumClass,
-+                                          final int minSectionRecalcCount, final double maxDeadRegionPercent,
-+                                          final String name) {
++    public SingleThreadChunkRegionManager(final WorldServer world, final int minSectionRecalcCount,
++                                          final double maxDeadRegionPercent, final int sectionMergeRadius,
++                                          final int regionSectionChunkShift,
++                                          final String name, final Supplier<RegionData> regionDataSupplier,
++                                          final Supplier<RegionSectionData> regionSectionDataSupplier) {
++        this.regionSectionMergeRadius = sectionMergeRadius;
++        this.regionSectionChunkSize = 1 << regionSectionChunkShift;
++        this.regionChunkShift = regionSectionChunkShift;
 +        this.world = world;
-+        this.dataClass = enumClass;
 +        this.name = name;
 +        this.minSectionRecalcCount = Math.max(2, minSectionRecalcCount);
 +        this.maxDeadRegionPercent = maxDeadRegionPercent;
-+
-+        String prefix = world.getWorld().getName() + " - Region Manager - " + name + " - ";
-+        this.addChunkTimings = MinecraftTimings.getInternalTaskName(prefix.concat("add"));
-+        this.removeChunkTimings = MinecraftTimings.getInternalTaskName(prefix.concat("remove"));
-+        this.regionRecalculateTimings = MinecraftTimings.getInternalTaskName(prefix.concat("recalculate"));
++        this.regionDataSupplier = regionDataSupplier;
++        this.regionSectionDataSupplier = regionSectionDataSupplier;
 +    }
 +
 +    // tested via https://gist.github.com/Spottedleaf/aa7ade3451c37b4cac061fc77074db2f
@@ -663,51 +1627,51 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +    }
 +    */
 +
-+    protected void addToRecalcQueue(final Region<T> region) {
++    protected void addToRecalcQueue(final Region region) {
 +        this.needsRecalculation.add(region);
 +    }
 +
-+    protected void removeFromRecalcQueue(final Region<T> region) {
++    protected void removeFromRecalcQueue(final Region region) {
 +        this.needsRecalculation.remove(region);
 +    }
 +
-+    public RegionSection<T> getRegionSection(final int chunkX, final int chunkZ) {
-+        return this.regionsBySection.get(MCUtil.getCoordinateKey(chunkX >> REGION_CHUNK_SIZE_SHIFT, chunkZ >> REGION_CHUNK_SIZE_SHIFT));
++    public RegionSection getRegionSection(final int chunkX, final int chunkZ) {
++        return this.regionsBySection.get(MCUtil.getCoordinateKey(chunkX >> this.regionChunkShift, chunkZ >> this.regionChunkShift));
 +    }
 +
-+    public Region<T> getRegion(final int chunkX, final int chunkZ) {
-+        final RegionSection<T> section = this.regionsBySection.get(MCUtil.getCoordinateKey(chunkX >> REGION_CHUNK_SIZE_SHIFT, chunkZ >> REGION_CHUNK_SIZE_SHIFT));
++    public Region getRegion(final int chunkX, final int chunkZ) {
++        final RegionSection section = this.regionsBySection.get(MCUtil.getCoordinateKey(chunkX >> regionChunkShift, chunkZ >> regionChunkShift));
 +        return section != null ? section.region : null;
 +    }
 +
-+    private final List<Region<T>> toMerge = new ArrayList<>((2 * REGION_SECTION_MERGE_RADIUS + 1) * (2 * REGION_SECTION_MERGE_RADIUS + 1));
++    private final List<Region> toMerge = new ArrayList<>();
 +
-+    protected RegionSection<T> getOrCreateAndMergeSection(final int sectionX, final int sectionZ, final RegionSection<T> force) {
++    protected RegionSection getOrCreateAndMergeSection(final int sectionX, final int sectionZ, final RegionSection force) {
 +        final long sectionKey = MCUtil.getCoordinateKey(sectionX, sectionZ);
 +
 +        if (force == null) {
-+            RegionSection<T> region = this.regionsBySection.get(sectionKey);
++            RegionSection region = this.regionsBySection.get(sectionKey);
 +            if (region != null) {
 +                return region;
 +            }
 +        }
 +
 +        int mergeCandidateSectionSize = -1;
-+        Region<T> mergeIntoCandidate = null;
++        Region mergeIntoCandidate = null;
 +
 +        // find optimal candidate to merge into
 +
-+        final int minX = sectionX - REGION_SECTION_MERGE_RADIUS;
-+        final int maxX = sectionX + REGION_SECTION_MERGE_RADIUS;
-+        final int minZ = sectionZ - REGION_SECTION_MERGE_RADIUS;
-+        final int maxZ = sectionZ + REGION_SECTION_MERGE_RADIUS;
++        final int minX = sectionX - this.regionSectionMergeRadius;
++        final int maxX = sectionX + this.regionSectionMergeRadius;
++        final int minZ = sectionZ - this.regionSectionMergeRadius;
++        final int maxZ = sectionZ + this.regionSectionMergeRadius;
 +        for (int currX = minX; currX <= maxX; ++currX) {
 +            for (int currZ = minZ; currZ <= maxZ; ++currZ) {
-+                final RegionSection<T> section = this.regionsBySection.get(MCUtil.getCoordinateKey(currX, currZ));
++                final RegionSection section = this.regionsBySection.get(MCUtil.getCoordinateKey(currX, currZ));
 +                if (section == null) {
 +                    continue;
 +                }
-+                final Region<T> region = section.region;
++                final Region region = section.region;
 +                if (region.dead) {
 +                    throw new IllegalStateException("Dead region should not be in live region manager state: " + region);
 +                }
@@ -724,7 +1688,7 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +        // merge
 +        if (mergeIntoCandidate != null) {
 +            for (int i = 0; i < this.toMerge.size(); ++i) {
-+                final Region<T> region = this.toMerge.get(i);
++                final Region region = this.toMerge.get(i);
 +                if (region.dead || mergeIntoCandidate == region) {
 +                    continue;
 +                }
@@ -732,14 +1696,14 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +            }
 +            this.toMerge.clear();
 +        } else {
-+            mergeIntoCandidate = new Region<>(this);
++            mergeIntoCandidate = new Region(this);
 +        }
 +
-+        final RegionSection<T> section;
++        final RegionSection section;
 +        if (force == null) {
-+            this.regionsBySection.put(sectionKey, section = new RegionSection<>(sectionKey, this));
++            this.regionsBySection.put(sectionKey, section = new RegionSection(sectionKey, this));
 +        } else {
-+            final RegionSection<T> existing = this.regionsBySection.putIfAbsent(sectionKey, force);
++            final RegionSection existing = this.regionsBySection.putIfAbsent(sectionKey, force);
 +            if (existing != null) {
 +                throw new IllegalStateException("Attempting to override section '" + existing.toStringWithRegion() +
 +                        ", with " + force.toStringWithRegion());
@@ -748,8 +1712,7 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +            section = force;
 +        }
 +
-+        section.region = mergeIntoCandidate;
-+        mergeIntoCandidate.sections.add(section);
++        mergeIntoCandidate.addRegionSection(section);
 +        //mergeIntoCandidate.check();
 +        //this.check();
 +
@@ -757,113 +1720,97 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +    }
 +
 +    public void addChunk(final int chunkX, final int chunkZ) {
-+        com.tuinity.tuinity.util.TickThread.ensureTickThread("async region manager add chunk"); // Tuinity
-+        this.addChunkTimings.startTiming();
-+        try {
-+            this.getOrCreateAndMergeSection(chunkX >> REGION_CHUNK_SIZE_SHIFT, chunkZ >> REGION_CHUNK_SIZE_SHIFT, null).addChunk(chunkX, chunkZ);
-+        } finally {
-+            this.addChunkTimings.stopTiming();
-+        }
++        this.getOrCreateAndMergeSection(chunkX >> this.regionChunkShift, chunkZ >> this.regionChunkShift, null).addChunk(chunkX, chunkZ);
 +    }
 +
 +    public void removeChunk(final int chunkX, final int chunkZ) {
-+        com.tuinity.tuinity.util.TickThread.ensureTickThread("async region manager remove chunk"); // Tuinity
-+        this.removeChunkTimings.startTiming();
-+        try {
-+            final RegionSection<T> section = this.regionsBySection.get(
-+                    MCUtil.getCoordinateKey(chunkX >> REGION_CHUNK_SIZE_SHIFT, chunkZ >> REGION_CHUNK_SIZE_SHIFT)
-+            );
-+            if (section != null) {
-+                section.removeChunk(chunkX, chunkZ);
-+            } else {
-+                throw new IllegalStateException("Cannot remove chunk at (" + chunkX + "," + chunkZ + ") from region state, section does not exist");
-+            }
-+        } finally {
-+            this.removeChunkTimings.stopTiming();
++        final RegionSection section = this.regionsBySection.get(
++                MCUtil.getCoordinateKey(chunkX >> this.regionChunkShift, chunkZ >> this.regionChunkShift)
++        );
++        if (section != null) {
++            section.removeChunk(chunkX, chunkZ);
++        } else {
++            throw new IllegalStateException("Cannot remove chunk at (" + chunkX + "," + chunkZ + ") from region state, section does not exist");
 +        }
 +    }
 +
 +    public void recalculateRegions() {
-+        com.tuinity.tuinity.util.TickThread.ensureTickThread("async region recalculation"); // Tuinity
 +        for (int i = 0, len = this.needsRecalculation.size(); i < len; ++i) {
-+            final Region<T> region = this.needsRecalculation.removeFirst();
++            final Region region = this.needsRecalculation.removeFirst();
 +
 +            this.recalculateRegion(region);
 +            //this.check();
 +        }
 +    }
 +
-+    protected void recalculateRegion(final Region<T> region) {
-+        this.regionRecalculateTimings.startTiming();
-+        try {
-+            region.markedForRecalc = false;
++    protected void recalculateRegion(final Region region) {
++        region.markedForRecalc = false;
++        //region.check();
++        // clear unused regions
++        for (final Iterator<RegionSection> iterator = region.deadSections.iterator(); iterator.hasNext();) {
++            final RegionSection deadSection = iterator.next();
++
++            if (deadSection.hasChunks()) {
++                throw new IllegalStateException("Dead section '" + deadSection.toStringWithRegion() + "' is marked dead but has chunks!");
++            }
++            if (!region.removeRegionSection(deadSection)) {
++                throw new IllegalStateException("Region " + region + " has inconsistent state, it should contain section " + deadSection);
++            }
++            if (!this.regionsBySection.remove(deadSection.regionCoordinate, deadSection)) {
++                throw new IllegalStateException("Cannot remove dead section '" +
++                        deadSection.toStringWithRegion() + "' from section state! State at section coordinate: " +
++                        this.regionsBySection.get(deadSection.regionCoordinate));
++            }
++        }
++        region.deadSections.clear();
++
++        // implicitly cover cases where size == 0
++        if (region.sections.size() < this.minSectionRecalcCount) {
 +            //region.check();
-+            // clear unused regions
-+            for (final Iterator<RegionSection<T>> iterator = region.deadSections.iterator(); iterator.hasNext();) {
-+                final RegionSection<T> deadSection = iterator.next();
++            return;
++        }
 +
-+                if (deadSection.hasChunks()) {
-+                    throw new IllegalStateException("Dead section '" + deadSection.toStringWithRegion() + "' is marked dead but has chunks!");
-+                }
-+                if (!region.sections.remove(deadSection)) {
-+                    throw new IllegalStateException("Region " + region + " has inconsistent state, it should contain section " + deadSection);
-+                }
-+                if (!this.regionsBySection.remove(deadSection.regionCoordinate, deadSection)) {
-+                    throw new IllegalStateException("Cannot remove dead section '" +
-+                            deadSection.toStringWithRegion() + "' from section state! State at section coordinate: " +
-+                            this.regionsBySection.get(deadSection.regionCoordinate));
-+                }
++        // run a test to see if we actually need to recalculate
++        // TODO
++
++        // destroy and rebuild the region
++        region.dead = true;
++
++        // destroy region state
++        for (final Iterator<RegionSection> iterator = region.sections.unsafeIterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
++            final RegionSection aliveSection = iterator.next();
++            if (!aliveSection.hasChunks()) {
++                throw new IllegalStateException("Alive section '" + aliveSection.toStringWithRegion() + "' has no chunks!");
 +            }
-+            region.deadSections.clear();
-+
-+            // implicitly cover cases where size == 0
-+            if (region.sections.size() < this.minSectionRecalcCount) {
-+                //region.check();
-+                return;
++            if (!this.regionsBySection.remove(aliveSection.regionCoordinate, aliveSection)) {
++                throw new IllegalStateException("Cannot remove alive section '" +
++                        aliveSection.toStringWithRegion() + "' from section state! State at section coordinate: " +
++                        this.regionsBySection.get(aliveSection.regionCoordinate));
 +            }
++        }
 +
-+            // run a test to see if we actually need to recalculate
-+            // TODO
-+
-+            // destroy and rebuild the region
-+            region.dead = true;
-+
-+            // destroy region state
-+            for (final Iterator<RegionSection<T>> iterator = region.sections.unsafeIterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
-+                final RegionSection<T> aliveSection = iterator.next();
-+                if (!aliveSection.hasChunks()) {
-+                    throw new IllegalStateException("Alive section '" + aliveSection.toStringWithRegion() + "' has no chunks!");
-+                }
-+                if (!this.regionsBySection.remove(aliveSection.regionCoordinate, aliveSection)) {
-+                    throw new IllegalStateException("Cannot remove alive section '" +
-+                            aliveSection.toStringWithRegion() + "' from section state! State at section coordinate: " +
-+                            this.regionsBySection.get(aliveSection.regionCoordinate));
-+                }
-+            }
-+
-+            // rebuild regions
-+            for (final Iterator<RegionSection<T>> iterator = region.sections.unsafeIterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
-+                final RegionSection<T> aliveSection = iterator.next();
-+                this.getOrCreateAndMergeSection(aliveSection.getSectionX(), aliveSection.getSectionZ(), aliveSection);
-+            }
-+        } finally {
-+            this.regionRecalculateTimings.stopTiming();
++        // rebuild regions
++        for (final Iterator<RegionSection> iterator = region.sections.unsafeIterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
++            final RegionSection aliveSection = iterator.next();
++            this.getOrCreateAndMergeSection(aliveSection.getSectionX(), aliveSection.getSectionZ(), aliveSection);
 +        }
 +    }
 +
-+    public static final class Region<T extends Enum<T> & SingleThreadChunkRegionManager.RegionDataCreator<T>> {
-+        protected final IteratorSafeOrderedReferenceSet<RegionSection<T>> sections = new IteratorSafeOrderedReferenceSet<>(true);
-+        protected final ReferenceOpenHashSet<RegionSection<T>> deadSections = new ReferenceOpenHashSet<>(16, 0.7f);
++    public static final class Region {
++        protected final IteratorSafeOrderedReferenceSet<RegionSection> sections = new IteratorSafeOrderedReferenceSet<>();
++        protected final ReferenceOpenHashSet<RegionSection> deadSections = new ReferenceOpenHashSet<>(16, 0.7f);
 +        protected boolean dead;
 +        protected boolean markedForRecalc;
 +
-+        public final SingleThreadChunkRegionManager<T> regionManager;
++        public final SingleThreadChunkRegionManager regionManager;
++        public final RegionData regionData;
 +
-+        protected Region(final SingleThreadChunkRegionManager<T> regionManager) {
++        protected Region(final SingleThreadChunkRegionManager regionManager) {
 +            this.regionManager = regionManager;
++            this.regionData = regionManager.regionDataSupplier.get();
 +        }
 +
-+        public IteratorSafeOrderedReferenceSet.Iterator<RegionSection<T>> getSections() {
++        public IteratorSafeOrderedReferenceSet.Iterator<RegionSection> getSections() {
 +            return this.sections.iterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS);
 +        }
 +
@@ -888,7 +1835,30 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +        }
 +        */
 +
-+        protected void mergeInto(final Region<T> mergeTarget) {
++        // note: it is not true that the region at this point is not in any region. use the region field on the section
++        // to see if it is currently in another region.
++        protected final boolean addRegionSection(final RegionSection section) {
++            if (!this.sections.add(section)) {
++                return false;
++            }
++
++            section.sectionData.addToRegion(section, section.region, this);
++
++            section.region = this;
++            return true;
++        }
++
++        protected final boolean removeRegionSection(final RegionSection section) {
++            if (!this.sections.remove(section)) {
++                return false;
++            }
++
++            section.sectionData.removeFromRegion(section, this);
++
++            return true;
++        }
++
++        protected void mergeInto(final Region mergeTarget) {
 +            if (this == mergeTarget) {
 +                throw new IllegalStateException("Cannot merge a region onto itself");
 +            }
@@ -902,17 +1872,15 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +                this.regionManager.removeFromRecalcQueue(this);
 +            }
 +
-+            for (final Iterator<RegionSection<T>> iterator = this.sections.unsafeIterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
-+                final RegionSection<T> section = iterator.next();
++            for (final Iterator<RegionSection> iterator = this.sections.unsafeIterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
++                final RegionSection section = iterator.next();
 +
-+                if (!mergeTarget.sections.add(section)) {
++                if (!mergeTarget.addRegionSection(section)) {
 +                    throw new IllegalStateException("Target cannot contain source's sections! Source " + this + ", target " + mergeTarget);
 +                }
-+
-+                section.region = mergeTarget;
 +            }
 +
-+            for (final RegionSection<T> deadSection : this.deadSections) {
++            for (final RegionSection deadSection : this.deadSections) {
 +                if (!this.sections.contains(deadSection)) {
 +                    throw new IllegalStateException("Source region does not even contain its own dead sections! Missing " + deadSection + " from region " + this);
 +                }
@@ -921,7 +1889,7 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +            //mergeTarget.check();
 +        }
 +
-+        protected void markSectionAlive(final RegionSection<T> section) {
++        protected void markSectionAlive(final RegionSection section) {
 +            this.deadSections.remove(section);
 +            if (this.markedForRecalc && (this.sections.size() < this.regionManager.minSectionRecalcCount || this.getDeadSectionPercent() < this.regionManager.maxDeadRegionPercent)) {
 +                this.regionManager.removeFromRecalcQueue(this);
@@ -929,7 +1897,7 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +            }
 +        }
 +
-+        protected void markSectionDead(final RegionSection<T> section) {
++        protected void markSectionDead(final RegionSection section) {
 +            this.deadSections.add(section);
 +            if (!this.markedForRecalc && (this.sections.size() >= this.regionManager.minSectionRecalcCount || this.sections.size() == this.deadSections.size()) && this.getDeadSectionPercent() >= this.regionManager.maxDeadRegionPercent) {
 +                this.regionManager.addToRecalcQueue(this);
@@ -947,8 +1915,8 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +
 +            ret.append("sectionCount=").append(this.sections.size()).append(',');
 +            ret.append("sections=[");
-+            for (final Iterator<RegionSection<T>> iterator = this.sections.unsafeIterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
-+                final RegionSection<T> section = iterator.next();
++            for (final Iterator<RegionSection> iterator = this.sections.unsafeIterator(IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
++                final RegionSection section = iterator.next();
 +                ret.append(section);
 +                if (iterator.hasNext()) {
 +                    ret.append(',');
@@ -961,23 +1929,20 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +        }
 +    }
 +
-+    public static final class RegionSection<T extends Enum<T> & SingleThreadChunkRegionManager.RegionDataCreator<T>> {
++    public static final class RegionSection {
 +        protected final long regionCoordinate;
-+        protected final long[] chunksBitset = new long[Math.max(1, REGION_CHUNK_SIZE * REGION_CHUNK_SIZE / Long.SIZE)];
++        protected final long[] chunksBitset;
 +        protected int chunkCount;
-+        protected Region<T> region;
-+        protected final EnumMap<T, Object> data;
-+        protected final Function<? super T, Object> createIfAbsentFunction;
++        protected Region region;
 +
-+        public final SingleThreadChunkRegionManager<T> regionManager;
++        public final SingleThreadChunkRegionManager regionManager;
++        public final RegionSectionData sectionData;
 +
-+        protected RegionSection(final long regionCoordinate, final SingleThreadChunkRegionManager<T> regionManager) {
++        protected RegionSection(final long regionCoordinate, final SingleThreadChunkRegionManager regionManager) {
 +            this.regionCoordinate = regionCoordinate;
-+            this.data = new EnumMap<>(regionManager.dataClass);
 +            this.regionManager = regionManager;
-+            this.createIfAbsentFunction = (final T keyInMap) -> {
-+                return keyInMap.createData(RegionSection.this, regionManager);
-+            };
++            this.chunksBitset = new long[Math.max(1, regionManager.regionSectionChunkSize * regionManager.regionSectionChunkSize / Long.SIZE)];
++            this.sectionData = regionManager.regionSectionDataSupplier.get();
 +        }
 +
 +        public int getSectionX() {
@@ -988,28 +1953,12 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +            return MCUtil.getCoordinateZ(this.regionCoordinate);
 +        }
 +
-+        public Region<T> getRegion() {
++        public Region getRegion() {
 +            return this.region;
 +        }
 +
-+        public Object getData(final T key) {
-+            return this.data.get(key);
-+        }
-+
-+        public Object getOrCreateData(final T key) {
-+            return this.data.computeIfAbsent(key, this.createIfAbsentFunction);
-+        }
-+
-+        public Object removeData(final T key) {
-+            return this.data.remove(key);
-+        }
-+
-+        public void setData(final T key, final Object data) {
-+            this.data.put(key, data);
-+        }
-+
-+        private static int getChunkIndex(final int chunkX, final int chunkZ) {
-+            return (chunkX & (REGION_CHUNK_SIZE - 1)) | ((chunkZ & (REGION_CHUNK_SIZE - 1)) << REGION_CHUNK_SIZE_SHIFT);
++        private int getChunkIndex(final int chunkX, final int chunkZ) {
++            return (chunkX & (this.regionManager.regionSectionChunkSize - 1)) | ((chunkZ & (this.regionManager.regionSectionChunkSize - 1)) << this.regionManager.regionChunkShift);
 +        }
 +
 +        protected boolean hasChunks() {
@@ -1017,7 +1966,7 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +        }
 +
 +        protected void addChunk(final int chunkX, final int chunkZ) {
-+            final int index = getChunkIndex(chunkX, chunkZ);
++            final int index = this.getChunkIndex(chunkX, chunkZ);
 +            final long bitset = this.chunksBitset[index >>> 6]; // index / Long.SIZE
 +            final long after = this.chunksBitset[index >>> 6] = bitset | (1L << (index & (Long.SIZE - 1)));
 +            if (after == bitset) {
@@ -1030,7 +1979,7 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +        }
 +
 +        protected void removeChunk(final int chunkX, final int chunkZ) {
-+            final int index = getChunkIndex(chunkX, chunkZ);
++            final int index = this.getChunkIndex(chunkX, chunkZ);
 +            final long before = this.chunksBitset[index >>> 6]; // index / Long.SIZE
 +            final long bitset = this.chunksBitset[index >>> 6] = before & ~(1L << (index & (Long.SIZE - 1)));
 +            if (before == bitset) {
@@ -1063,12 +2012,12 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +        }
 +
 +        private static String toString(final long[] array) {
-+            StringBuilder ret = new StringBuilder();
-+            for (long value : array) {
++            final StringBuilder ret = new StringBuilder();
++            for (final long value : array) {
 +                // zero pad the hex string
-+                char[] zeros = new char[Long.SIZE / 4];
++                final char[] zeros = new char[Long.SIZE / 4];
 +                Arrays.fill(zeros, '0');
-+                String string = Long.toHexString(value);
++                final String string = Long.toHexString(value);
 +                System.arraycopy(string.toCharArray(), 0, zeros, zeros.length - string.length(), string.length());
 +
 +                ret.append(zeros);
@@ -1078,10 +2027,17 @@ index 0000000000000000000000000000000000000000..cae06962d80cdd00962236891472ba81
 +        }
 +    }
 +
-+    public static interface RegionDataCreator<E extends Enum<E> & RegionDataCreator<E>> {
++    public static interface RegionData {
 +
-+        Object createData(final RegionSection<E> section,
-+                          final SingleThreadChunkRegionManager<E> regionManager);
++    }
++
++    public static interface RegionSectionData {
++
++        public void removeFromRegion(final RegionSection section, final Region from);
++
++        // removal from the old region is handled via removeFromRegion
++        public void addToRegion(final RegionSection section, final Region oldRegion, final Region newRegion);
++
 +    }
 +}
 \ No newline at end of file
@@ -4684,10 +5640,10 @@ index 0000000000000000000000000000000000000000..125f59826a9b0174039139ed0715a4ed
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..63dfad42c372a33b35c585aaa7ed24d8f16d44e0
+index 0000000000000000000000000000000000000000..d1308b8cbb9490f1ccdc5514763e62bc5d66981b
 --- /dev/null
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-@@ -0,0 +1,387 @@
+@@ -0,0 +1,406 @@
 +package com.tuinity.tuinity.config;
 +
 +import com.destroystokyo.paper.util.SneakyThrow;
@@ -4923,6 +5879,25 @@ index 0000000000000000000000000000000000000000..63dfad42c372a33b35c585aaa7ed24d8
 +
 +    private static void sendFullPosForHardCollidingEntities() {
 +        sendFullPosForHardCollidingEntities = TuinityConfig.getBoolean("send-full-pos-for-hard-colliding-entities", true);
++    }
++
++    public static int playerMinChunkLoadRadius;
++    public static double playerMaxConcurrentChunkSends;
++    public static double playerMaxConcurrentChunkLoads;
++    public static boolean playerAutoConfigureSendViewDistance;
++    public static boolean enableMC162253Workaround;
++    public static double playerTargetChunkSendRate;
++    public static boolean playerFrustumPrioritisation;
++
++    private static void newPlayerChunkManagement() {
++        playerMinChunkLoadRadius = TuinityConfig.getInt("player-chunks.min-load-radius", 2);
++        playerMaxConcurrentChunkSends = TuinityConfig.getDouble("player-chunks.max-concurrent-sends", 15.0);
++        playerMaxConcurrentChunkLoads = TuinityConfig.getDouble("player-chunks.max-concurrent-loads", -6.0);
++        playerAutoConfigureSendViewDistance = TuinityConfig.getBoolean("player-chunks.autoconfig-send-distance", true);
++        // this costs server bandwidth. latest phosphor or starlight on the client fixes mc162253 anyways.
++        enableMC162253Workaround = TuinityConfig.getBoolean("player-chunks.enable-mc162253-workaround", true);
++        playerTargetChunkSendRate = TuinityConfig.getDouble("player-chunks.target-chunk-send-rate", 81.0 * 20.0);
++        playerFrustumPrioritisation = TuinityConfig.getBoolean("player-chunks.enable-frustum-priority", false);
 +    }
 +
 +    public static final class WorldConfig {
@@ -5626,6 +6601,824 @@ index 0000000000000000000000000000000000000000..d2c7d2c7920324d7207225ed19484e80
 +        final int tail = this.tail;
 +
 +        return tail >= head ? (tail - head) : (tail + (this.times.length - head));
++    }
++}
+diff --git a/src/main/java/com/tuinity/tuinity/util/PoiAccess.java b/src/main/java/com/tuinity/tuinity/util/PoiAccess.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ef0b766709fd9369b5ae458148259291583fe565
+--- /dev/null
++++ b/src/main/java/com/tuinity/tuinity/util/PoiAccess.java
+@@ -0,0 +1,812 @@
++package com.tuinity.tuinity.util;
++
++import it.unimi.dsi.fastutil.doubles.Double2ObjectMap;
++import it.unimi.dsi.fastutil.doubles.Double2ObjectRBTreeMap;
++import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
++import net.minecraft.server.BlockPosition;
++import net.minecraft.server.MathHelper;
++import net.minecraft.server.SectionPosition;
++import net.minecraft.server.VillagePlace;
++import net.minecraft.server.VillagePlaceRecord;
++import net.minecraft.server.VillagePlaceSection;
++import net.minecraft.server.VillagePlaceType;
++import java.util.ArrayList;
++import java.util.HashSet;
++import java.util.Iterator;
++import java.util.List;
++import java.util.Map;
++import java.util.Optional;
++import java.util.Set;
++import java.util.function.Predicate;
++
++/**
++ * Provides optimised access to POI data. All returned values will be identical to vanilla.
++ */
++public final class PoiAccess {
++
++    public static final class SortedChunkSectionPos {
++
++        public final int relativeX;
++        public final int absoluteY;
++        public final int relativeZ;
++
++        public final double smallestDistanceToSection;
++
++        public SortedChunkSectionPos(int relativeX, int absoluteY, int relativeZ, double smallestDistanceToSection) {
++            this.relativeX = relativeX;
++            this.absoluteY = absoluteY;
++            this.relativeZ = relativeZ;
++            this.smallestDistanceToSection = smallestDistanceToSection;
++        }
++
++        protected double smallestDistanceAhead;
++
++    }
++
++    protected static double clamp(final double val, final double min, final double max) {
++        return (val < min ? min : (val > max ? max : val));
++    }
++
++    protected static double getSmallestDistanceSquared(final double boxMinX, final double boxMinY, final double boxMinZ,
++                                                       final double boxMaxX, final double boxMaxY, final double boxMaxZ,
++
++                                                       final double circleX, final double circleY, final double circleZ) {
++        // is the circle center inside the box?
++        if (circleX >= boxMinX && circleX <= boxMaxX && circleY >= boxMinY && circleY <= boxMaxY && circleZ >= boxMinZ && circleZ <= boxMaxZ) {
++            return 0.0;
++        }
++
++        final double boxWidthX = (boxMaxX - boxMinX) / 2.0;
++        final double boxWidthY = (boxMaxY - boxMinY) / 2.0;
++        final double boxWidthZ = (boxMaxZ - boxMinZ) / 2.0;
++
++        final double boxCenterX = (boxMinX + boxMaxX) / 2.0;
++        final double boxCenterY = (boxMinY + boxMaxY) / 2.0;
++        final double boxCenterZ = (boxMinZ + boxMaxZ) / 2.0;
++
++        double centerDiffX = circleX - boxCenterX;
++        double centerDiffY = circleY - boxCenterY;
++        double centerDiffZ = circleZ - boxCenterZ;
++
++        centerDiffX = circleX - (clamp(centerDiffX, -boxWidthX, boxWidthX) + boxCenterX);
++        centerDiffY = circleY - (clamp(centerDiffY, -boxWidthY, boxWidthY) + boxCenterY);
++        centerDiffZ = circleZ - (clamp(centerDiffZ, -boxWidthZ, boxWidthZ) + boxCenterZ);
++
++        return (centerDiffX * centerDiffX) + (centerDiffY * centerDiffY) + (centerDiffZ * centerDiffZ);
++    }
++
++
++    // key is:
++    //  upper 32 bits:
++    //   upper 16 bits: max y section
++    //   lower 16 bits: min y section
++    //  lower 32 bits:
++    //   upper 16 bits: section
++    //   lower 16 bits: radius
++    protected static long getKey(final int minSection, final int maxSection, final int section, final int radius) {
++        return (
++                (maxSection & 0xFFFFL) << (64 - 16)
++                | (minSection & 0xFFFFL) << (64 - 32)
++                | (section & 0xFFFFL) << (64 - 48)
++                | (radius & 0xFFFFL) << (64 - 64)
++                );
++    }
++
++    protected static final Long2ObjectOpenHashMap<List<SortedChunkSectionPos>> cachedSortedPositionsAddHalf =
++            new Long2ObjectOpenHashMap<>();
++    protected static final Long2ObjectOpenHashMap<List<SortedChunkSectionPos>> cachedSortedPositionsNoHalf =
++            new Long2ObjectOpenHashMap<>();
++
++    public static List<SortedChunkSectionPos> getSortedPositions(final BlockPosition center, final int radius, final boolean addHalfToSection) {
++        final Long2ObjectOpenHashMap<List<SortedChunkSectionPos>> map = addHalfToSection ? cachedSortedPositionsAddHalf : cachedSortedPositionsNoHalf;
++
++        final int section = center.getY() >> 4;
++        if (section < -16) {
++            return calculateSortedPositions(0, 15, section, radius, addHalfToSection);
++        } else if (section > (16 + 16)) {
++            return calculateSortedPositions(0, 15, section, radius, addHalfToSection);
++        }
++
++        final long key = getKey(0, 15, center.getY() >> 4, radius);
++        synchronized (map) {
++            List<SortedChunkSectionPos> existing = map.get(key);
++            if (existing != null) {
++                return existing;
++            }
++        }
++
++        final List<SortedChunkSectionPos> calculated = calculateSortedPositions(0, 15, section, radius, addHalfToSection);
++
++        synchronized (map) {
++            map.putIfAbsent(key, calculated);
++        }
++
++        return calculated;
++    }
++
++    protected static List<SortedChunkSectionPos> calculateSortedPositions(final int minSection, final int maxSection, final int section, final int radius, final boolean addHalfToSection) {
++        final List<SortedChunkSectionPos> ret = new ArrayList<>();
++
++        final double sourceX = 8.0;
++        final double sourceY = section * 16.0 + 8.0;
++        final double sourceZ = 8.0;
++        final double minSectionAdd = addHalfToSection ? 0.5 : 0.0;
++        final double maxSectionAdd = addHalfToSection ? 15.5 : 16.0;
++        for (int y = minSection; y <= maxSection; ++y) {
++            for (int dz = -radius; dz <= radius; ++dz) {
++                for (int dx = -radius; dx <= radius; ++dx) {
++                    double distanceSquared = getSmallestDistanceSquared(
++                            (double)(dx << 4) + minSectionAdd,
++                            (double)(y << 4) + minSectionAdd,
++                            (double)(dz << 4) + minSectionAdd,
++                            (double)(dx << 4) + maxSectionAdd,
++                            (double)(y << 4) + maxSectionAdd,
++                            (double)(dz << 4) + maxSectionAdd,
++
++                            sourceX, sourceY, sourceZ
++                    );
++                    // max additional distance (due to varying center point)
++                    final double a = (Math.sqrt(2*2*2))*(addHalfToSection ? 7.5 : 8.0);
++                    distanceSquared = Math.sqrt(distanceSquared) - a;
++                    distanceSquared *= distanceSquared;
++
++                    ret.add(new SortedChunkSectionPos(dx, y, dz, distanceSquared - 1.0e-3)); // account for floating point errors
++                }
++            }
++        }
++
++        final BlockPosition relativeCenter = new BlockPosition(8, (section << 4) | 8, 8);
++        ret.sort((s1, s2) -> {
++            return Double.compare(relativeCenter.distanceSquared((s1.relativeX << 4) + 8, (s1.absoluteY << 4) + 8, (s1.relativeZ << 4) + 8, false),
++                    relativeCenter.distanceSquared((s2.relativeX << 4) + 8, (s2.absoluteY << 4) + 8, (s2.relativeZ << 4) + 8, false));
++        });
++
++        double smallest = Double.MAX_VALUE;
++        for (int i = ret.size() - 1; i >= 0; --i) {
++            final SortedChunkSectionPos chunkPos = ret.get(i);
++            chunkPos.smallestDistanceAhead = smallest;
++            if (chunkPos.smallestDistanceToSection < smallest) {
++                smallest = chunkPos.smallestDistanceToSection;
++            }
++        }
++
++        // we set smallestDistanceAhead so that callers iterating over the list do not need to search any more sections
++        // than they need to (the intersects check for a sphere and a 3d box is seriously expensive, especially with
++        // how many sections there are).
++
++        return ret;
++    }
++
++    // only includes x/z axis
++    // finds the closest poi data by distance.
++    public static BlockPosition findClosestPoiDataPosition(final VillagePlace poiStorage,
++                                                           final Predicate<VillagePlaceType> villagePlaceType,
++                                                           // position predicate must not modify chunk POI
++                                                           final Predicate<BlockPosition> positionPredicate,
++                                                           final BlockPosition sourcePosition,
++                                                           final int range, // distance on x y z axis
++                                                           final double maxDistance,
++                                                           final VillagePlace.Occupancy occupancy,
++                                                           final boolean load) {
++        final VillagePlaceRecord ret = findClosestPoiDataRecord(
++                poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, maxDistance, occupancy, load
++        );
++
++        return ret == null ? null : ret.getPosition();
++    }
++
++    // only includes x/z axis
++    // finds the closest poi data by distance. if multiple match the same distance, then they all are returned.
++    public static void findClosestPoiDataPositions(final VillagePlace poiStorage,
++                                                   final Predicate<VillagePlaceType> villagePlaceType,
++                                                   // position predicate must not modify chunk POI
++                                                   final Predicate<BlockPosition> positionPredicate,
++                                                   final BlockPosition sourcePosition,
++                                                   final int range, // distance on x y z axis
++                                                   final double maxDistance,
++                                                   final VillagePlace.Occupancy occupancy,
++                                                   final boolean load,
++                                                   final Set<BlockPosition> ret) {
++        final Set<BlockPosition> positions = new HashSet<>();
++        // pos predicate is last thing that runs before adding to ret.
++        final Predicate<BlockPosition> newPredicate = (final BlockPosition pos) -> {
++            if (positionPredicate != null && !positionPredicate.test(pos)) {
++                return false;
++            }
++            return positions.add(pos.immutableCopy());
++        };
++
++        final List<VillagePlaceRecord> toConvert = new ArrayList<>();
++        findClosestPoiDataRecords(
++                poiStorage, villagePlaceType, newPredicate, sourcePosition, range, maxDistance, occupancy, load, toConvert
++        );
++
++        for (final VillagePlaceRecord record : toConvert) {
++            ret.add(record.getPosition());
++        }
++    }
++
++    // only includes x/z axis
++    // finds the closest poi data by distance.
++    public static VillagePlaceRecord findClosestPoiDataRecord(final VillagePlace poiStorage,
++                                                              final Predicate<VillagePlaceType> villagePlaceType,
++                                                              // position predicate must not modify chunk POI
++                                                              final Predicate<BlockPosition> positionPredicate,
++                                                              final BlockPosition sourcePosition,
++                                                              final int range, // distance on x y z axis
++                                                              final double maxDistance,
++                                                              final VillagePlace.Occupancy occupancy,
++                                                              final boolean load) {
++        final List<VillagePlaceRecord> ret = new ArrayList<>();
++        findClosestPoiDataRecords(
++                poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, maxDistance, occupancy, load, ret
++        );
++        return ret.isEmpty() ? null : ret.get(0);
++    }
++
++    // only includes x/z axis
++    // finds the closest poi data by distance. if multiple match the same distance, then they all are returned.
++    public static void findClosestPoiDataRecords(final VillagePlace poiStorage,
++                                                 final Predicate<VillagePlaceType> villagePlaceType,
++                                                 // position predicate must not modify chunk POI
++                                                 final Predicate<BlockPosition> positionPredicate,
++                                                 final BlockPosition sourcePosition,
++                                                 final int range, // distance on x y z axis
++                                                 final double maxDistance,
++                                                 final VillagePlace.Occupancy occupancy,
++                                                 final boolean load,
++                                                 final List<VillagePlaceRecord> ret) {
++        final Predicate<? super VillagePlaceRecord> occupancyFilter = occupancy.getPredicate();
++
++        final List<VillagePlaceRecord> closestRecords = new ArrayList<>();
++        double closestDistanceSquared = maxDistance * maxDistance;
++
++        final int lowerX = MathHelper.floor(sourcePosition.getX() - range) >> 4;
++        final int lowerZ = MathHelper.floor(sourcePosition.getZ() - range) >> 4;
++        final int upperX = MathHelper.floor(sourcePosition.getX() + range) >> 4;
++        final int upperZ = MathHelper.floor(sourcePosition.getZ() + range) >> 4;
++
++        final List<SortedChunkSectionPos> chunks = getSortedPositions(sourcePosition, (range + 15) >> 4, true);
++
++        final int centerX = sourcePosition.getX() >> 4;
++        final int centerY = sourcePosition.getY() >> 4;
++        final int centerZ = sourcePosition.getZ() >> 4;
++
++        for (final SortedChunkSectionPos relativeSection : chunks) {
++            if (relativeSection.smallestDistanceToSection > closestDistanceSquared) {
++                if (relativeSection.smallestDistanceAhead > closestDistanceSquared) {
++                    break;
++                }
++                continue;
++            }
++            final int sectionX = relativeSection.relativeX + centerX;
++            final int sectionY = relativeSection.absoluteY;
++            final int sectionZ = relativeSection.relativeZ + centerZ;
++
++            if (sectionX < lowerX || sectionX > upperX || sectionZ < lowerZ || sectionZ > upperZ) {
++                // out of bound chunk
++                continue;
++            }
++
++            final double sectionDistanceSquared = getSmallestDistanceSquared(
++                    (sectionX << 4) + 0.5,
++                    (sectionY << 4) + 0.5,
++                    (sectionZ << 4) + 0.5,
++                    (sectionX << 4) + 15.5,
++                    (sectionY << 4) + 15.5,
++                    (sectionZ << 4) + 15.5,
++                    (double)sourcePosition.getX(), (double)sourcePosition.getY(), (double)sourcePosition.getZ()
++            );
++            if (sectionDistanceSquared > closestDistanceSquared) {
++                continue;
++            }
++
++            final Optional<VillagePlaceSection> poiSectionOptional = load ? poiStorage.getOrLoad(SectionPosition.asLong(sectionX, sectionY, sectionZ))
++                    : poiStorage.getIfLoaded(SectionPosition.asLong(sectionX, sectionY, sectionZ));
++
++            if (poiSectionOptional == null || !poiSectionOptional.isPresent()) {
++                continue;
++            }
++
++            final VillagePlaceSection poiSection = poiSectionOptional.orElse(null);
++
++            final Map<VillagePlaceType, Set<VillagePlaceRecord>> sectionData = poiSection.getData();
++            if (sectionData.isEmpty()) {
++                continue;
++            }
++
++            // now we search the section data
++            for (final Map.Entry<VillagePlaceType, Set<VillagePlaceRecord>> entry : sectionData.entrySet()) {
++                if (!villagePlaceType.test(entry.getKey())) {
++                    // filter out by poi type
++                    continue;
++                }
++
++                // now we can look at the poi data
++                for (final VillagePlaceRecord poiData : entry.getValue()) {
++                    if (!occupancyFilter.test(poiData)) {
++                        // filter by occupancy
++                        continue;
++                    }
++
++                    final BlockPosition poiPosition = poiData.getPosition();
++
++                    if (Math.abs(poiPosition.getX() - sourcePosition.getX()) > range
++                            || Math.abs(poiPosition.getZ() - sourcePosition.getZ()) > range) {
++                        // out of range for square radius
++                        continue;
++                    }
++
++                    // it's important that it's poiPosition.distanceSquared(source) : the value actually is different IF the values are swapped!
++                    final double dataRange = poiPosition.distanceSquared(sourcePosition);
++
++                    if (dataRange > closestDistanceSquared) {
++                        // out of range for distance check
++                        continue;
++                    }
++
++                    if (positionPredicate != null && !positionPredicate.test(poiPosition)) {
++                        // filter by position
++                        continue;
++                    }
++
++                    if (dataRange < closestDistanceSquared) {
++                        closestRecords.clear();
++                        closestDistanceSquared = dataRange;
++                    }
++                    closestRecords.add(poiData);
++                }
++            }
++        }
++
++        // uh oh! we might have multiple records that match the distance sorting!
++        // we need to re-order our results by the way vanilla would have iterated over them.
++        closestRecords.sort((record1, record2) -> {
++            // vanilla iterates the same way we do for data inside sections, so we know the ordering inside a section
++            // is fine and should be preserved (this sort is stable so we're good there)
++            // but they iterate sections by x then by z (like the following)
++            // for (int x = -dx; x <= dx; ++x)
++            //     for (int z = -dz; z <= dz; ++z)
++            //  ....
++            // so we need to reorder such that records with lower chunk z, then lower chunk x come first
++            final BlockPosition pos1 = record1.getPosition();
++            final BlockPosition pos2 = record2.getPosition();
++
++            final int cx1 = pos1.getX() >> 4;
++            final int cz1 = pos1.getZ() >> 4;
++
++            final int cx2 = pos2.getX() >> 4;
++            final int cz2 = pos2.getZ() >> 4;
++
++            if (cz2 != cz1) {
++                // want smaller z
++                return Integer.compare(cz1, cz2);
++            }
++
++            if (cx2 != cx1) {
++                // want smaller x
++                return Integer.compare(cx1, cx2);
++            }
++
++            // same chunk
++            // once vanilla has the chunk, it will iterate from all of the chunk sections starting from smaller y
++            // so now we just compare section y, wanting smaller y
++
++            return Integer.compare(pos1.getY() >> 4, pos2.getY() >> 4);
++        });
++
++        // now we match perfectly what vanilla would have outputted, without having to search the whole radius (hopefully).
++        ret.addAll(closestRecords);
++    }
++
++    // finds the closest poi entry pos.
++    public static BlockPosition findNearestPoiPosition(final VillagePlace poiStorage,
++                                                       final Predicate<VillagePlaceType> villagePlaceType,
++                                                       // position predicate must not modify chunk POI
++                                                       final Predicate<BlockPosition> positionPredicate,
++                                                       final BlockPosition sourcePosition,
++                                                       final int range, // distance on x y z axis
++                                                       final double maxDistance,
++                                                       final VillagePlace.Occupancy occupancy,
++                                                       final boolean load) {
++        final VillagePlaceRecord ret = findNearestPoiRecord(
++                poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, maxDistance, occupancy, load
++        );
++        return ret == null ? null : ret.getPosition();
++    }
++
++    // finds the closest `max` poi entry positions.
++    public static void findNearestPoiPositions(final VillagePlace poiStorage,
++                                               final Predicate<VillagePlaceType> villagePlaceType,
++                                               // position predicate must not modify chunk POI
++                                               final Predicate<BlockPosition> positionPredicate,
++                                               final BlockPosition sourcePosition,
++                                               final int range, // distance on x y z axis
++                                               final double maxDistance,
++                                               final VillagePlace.Occupancy occupancy,
++                                               final boolean load,
++                                               final int max,
++                                               final List<BlockPosition> ret) {
++        final Set<BlockPosition> positions = new HashSet<>();
++        // pos predicate is last thing that runs before adding to ret.
++        final Predicate<BlockPosition> newPredicate = (final BlockPosition pos) -> {
++            if (positionPredicate != null && !positionPredicate.test(pos)) {
++                return false;
++            }
++            return positions.add(pos.immutableCopy());
++        };
++
++        final List<VillagePlaceRecord> toConvert = new ArrayList<>();
++        findNearestPoiRecords(
++                poiStorage, villagePlaceType, newPredicate, sourcePosition, range, maxDistance, occupancy, load, max, toConvert
++        );
++
++        for (final VillagePlaceRecord record : toConvert) {
++            ret.add(record.getPosition());
++        }
++    }
++
++    // finds the closest poi entry.
++    public static VillagePlaceRecord findNearestPoiRecord(final VillagePlace poiStorage,
++                                                          final Predicate<VillagePlaceType> villagePlaceType,
++                                                          // position predicate must not modify chunk POI
++                                                          final Predicate<BlockPosition> positionPredicate,
++                                                          final BlockPosition sourcePosition,
++                                                          final int range, // distance on x y z axis
++                                                          final double maxDistance,
++                                                          final VillagePlace.Occupancy occupancy,
++                                                          final boolean load) {
++        final List<VillagePlaceRecord> ret = new ArrayList<>();
++        findNearestPoiRecords(
++                poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, maxDistance, occupancy, load,
++                1, ret
++        );
++        return ret.isEmpty() ? null : ret.get(0);
++    }
++
++    // finds the closest `max` poi entries.
++    public static void findNearestPoiRecords(final VillagePlace poiStorage,
++                                             final Predicate<VillagePlaceType> villagePlaceType,
++                                             // position predicate must not modify chunk POI
++                                             final Predicate<BlockPosition> positionPredicate,
++                                             final BlockPosition sourcePosition,
++                                             final int range, // distance on x y z axis
++                                             final double maxDistance,
++                                             final VillagePlace.Occupancy occupancy,
++                                             final boolean load,
++                                             final int max,
++                                             final List<VillagePlaceRecord> ret) {
++        final Predicate<? super VillagePlaceRecord> occupancyFilter = occupancy.getPredicate();
++
++        final double maxDistanceSquared = maxDistance * maxDistance;
++        final Double2ObjectRBTreeMap<List<VillagePlaceRecord>> closestRecords = new Double2ObjectRBTreeMap<>();
++        int totalRecords = 0;
++        double furthestDistanceSquared = maxDistanceSquared;
++
++        final int lowerX = MathHelper.floor(sourcePosition.getX() - range) >> 4;
++        final int lowerZ = MathHelper.floor(sourcePosition.getZ() - range) >> 4;
++        final int upperX = MathHelper.floor(sourcePosition.getX() + range) >> 4;
++        final int upperZ = MathHelper.floor(sourcePosition.getZ() + range) >> 4;
++
++        final List<SortedChunkSectionPos> chunks = getSortedPositions(sourcePosition, (range + 15) >> 4, true);
++
++        final int centerX = sourcePosition.getX() >> 4;
++        final int centerY = sourcePosition.getY() >> 4;
++        final int centerZ = sourcePosition.getZ() >> 4;
++
++        for (final SortedChunkSectionPos relativeSection : chunks) {
++            if (relativeSection.smallestDistanceToSection > (totalRecords >= max ? furthestDistanceSquared : maxDistanceSquared)) {
++                if (relativeSection.smallestDistanceAhead > (totalRecords >= max ? furthestDistanceSquared : maxDistanceSquared)) {
++                    break;
++                }
++                continue;
++            }
++            final int sectionX = relativeSection.relativeX + centerX;
++            final int sectionY = relativeSection.absoluteY;
++            final int sectionZ = relativeSection.relativeZ + centerZ;
++
++            if (sectionX < lowerX || sectionX > upperX || sectionZ < lowerZ || sectionZ > upperZ) {
++                // out of bound chunk
++                continue;
++            }
++
++            final double sectionDistanceSquared = getSmallestDistanceSquared(
++                    (sectionX << 4) + 0.5,
++                    (sectionY << 4) + 0.5,
++                    (sectionZ << 4) + 0.5,
++                    (sectionX << 4) + 15.5,
++                    (sectionY << 4) + 15.5,
++                    (sectionZ << 4) + 15.5,
++                    (double) sourcePosition.getX(), (double) sourcePosition.getY(), (double) sourcePosition.getZ()
++            );
++
++            if (sectionDistanceSquared > (totalRecords >= max ? furthestDistanceSquared : maxDistanceSquared)) {
++                continue;
++            }
++
++            final Optional<VillagePlaceSection> poiSectionOptional = load ? poiStorage.getOrLoad(SectionPosition.asLong(sectionX, sectionY, sectionZ))
++                    : poiStorage.getIfLoaded(SectionPosition.asLong(sectionX, sectionY, sectionZ));
++
++            if (poiSectionOptional == null || !poiSectionOptional.isPresent()) {
++                continue;
++            }
++
++            final VillagePlaceSection poiSection = poiSectionOptional.orElse(null);
++
++            final Map<VillagePlaceType, Set<VillagePlaceRecord>> sectionData = poiSection.getData();
++            if (sectionData.isEmpty()) {
++                continue;
++            }
++
++            // now we search the section data
++            for (final Map.Entry<VillagePlaceType, Set<VillagePlaceRecord>> entry : sectionData.entrySet()) {
++                if (!villagePlaceType.test(entry.getKey())) {
++                    // filter out by poi type
++                    continue;
++                }
++
++                // now we can look at the poi data
++                for (final VillagePlaceRecord poiData : entry.getValue()) {
++                    if (!occupancyFilter.test(poiData)) {
++                        // filter by occupancy
++                        continue;
++                    }
++
++                    final BlockPosition poiPosition = poiData.getPosition();
++
++                    if (Math.abs(poiPosition.getX() - sourcePosition.getX()) > range
++                            || Math.abs(poiPosition.getZ() - sourcePosition.getZ()) > range) {
++                        // out of range for square radius
++                        continue;
++                    }
++
++                    // it's important that it's poiPosition.distanceSquared(source) : the value actually is different IF the values are swapped!
++                    final double dataRange = poiPosition.distanceSquared(sourcePosition);
++
++                    if (dataRange > maxDistanceSquared) {
++                        // out of range for distance check
++                        continue;
++                    }
++
++                    if (dataRange > furthestDistanceSquared && totalRecords >= max) {
++                        // out of range for distance check
++                        continue;
++                    }
++
++                    if (positionPredicate != null && !positionPredicate.test(poiPosition)) {
++                        // filter by position
++                        continue;
++                    }
++
++                    if (dataRange > furthestDistanceSquared) {
++                        // we know totalRecords < max, so this entry is now our furthest
++                        furthestDistanceSquared = dataRange;
++                    }
++
++                    closestRecords.computeIfAbsent(dataRange, (final double key) -> {
++                        return new ArrayList<>();
++                    }).add(poiData);
++
++                    if (++totalRecords >= max) {
++                        if (closestRecords.size() >= 2) {
++                            int entriesInClosest = 0;
++                            final Iterator<Double2ObjectMap.Entry<List<VillagePlaceRecord>>> iterator = closestRecords.double2ObjectEntrySet().iterator();
++                            double nextFurthestDistanceSquared = 0.0;
++
++                            for (int i = 0, len = closestRecords.size() - 1; i < len; ++i) {
++                                final Double2ObjectMap.Entry<List<VillagePlaceRecord>> recordEntry = iterator.next();
++                                entriesInClosest += recordEntry.getValue().size();
++                                nextFurthestDistanceSquared = recordEntry.getDoubleKey();
++                            }
++
++                            if (entriesInClosest >= max) {
++                                // the last set of entries at range wont even be considered for sure... nuke em
++                                final Double2ObjectMap.Entry<List<VillagePlaceRecord>> recordEntry = iterator.next();
++                                totalRecords -= recordEntry.getValue().size();
++                                iterator.remove();
++
++                                furthestDistanceSquared = nextFurthestDistanceSquared;
++                            }
++                        }
++                    }
++                }
++            }
++        }
++
++        final List<VillagePlaceRecord> closestRecordsUnsorted = new ArrayList<>();
++
++        // we're done here, so now just flatten the map and sort it.
++
++        for (final List<VillagePlaceRecord> records : closestRecords.values()) {
++            closestRecordsUnsorted.addAll(records);
++        }
++
++        // uh oh! we might have multiple records that match the distance sorting!
++        // we need to re-order our results by the way vanilla would have iterated over them.
++        closestRecordsUnsorted.sort((record1, record2) -> {
++            // vanilla iterates the same way we do for data inside sections, so we know the ordering inside a section
++            // is fine and should be preserved (this sort is stable so we're good there)
++            // but they iterate sections by x then by z (like the following)
++            // for (int x = -dx; x <= dx; ++x)
++            //     for (int z = -dz; z <= dz; ++z)
++            //  ....
++            // so we need to reorder such that records with lower chunk z, then lower chunk x come first
++            final BlockPosition pos1 = record1.getPosition();
++            final BlockPosition pos2 = record2.getPosition();
++
++            final int cx1 = pos1.getX() >> 4;
++            final int cz1 = pos1.getZ() >> 4;
++
++            final int cx2 = pos2.getX() >> 4;
++            final int cz2 = pos2.getZ() >> 4;
++
++            if (cz2 != cz1) {
++                // want smaller z
++                return Integer.compare(cz1, cz2);
++            }
++
++            if (cx2 != cx1) {
++                // want smaller x
++                return Integer.compare(cx1, cx2);
++            }
++
++            // same chunk
++            // once vanilla has the chunk, it will iterate from all of the chunk sections starting from smaller y
++            // so now we just compare section y, wanting smaller section y
++
++            return Integer.compare(pos1.getY() >> 4, pos2.getY() >> 4);
++        });
++
++        // trim out any entries exceeding our maximum
++        for (int i = closestRecordsUnsorted.size() - 1; i >= max; --i) {
++            closestRecordsUnsorted.remove(i);
++        }
++
++        // now we match perfectly what vanilla would have outputted, without having to search the whole radius (hopefully).
++        ret.addAll(closestRecordsUnsorted);
++    }
++
++    public static BlockPosition findAnyPoiPosition(final VillagePlace poiStorage,
++                                                   final Predicate<VillagePlaceType> villagePlaceType,
++                                                   final Predicate<BlockPosition> positionPredicate,
++                                                   final BlockPosition sourcePosition,
++                                                   final int range, // distance on x y z axis
++                                                   final VillagePlace.Occupancy occupancy,
++                                                   final boolean load) {
++        final VillagePlaceRecord ret = findAnyPoiRecord(
++                poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, occupancy, load
++        );
++
++        return ret == null ? null : ret.getPosition();
++    }
++
++    public static void findAnyPoiPositions(final VillagePlace poiStorage,
++                                           final Predicate<VillagePlaceType> villagePlaceType,
++                                           final Predicate<BlockPosition> positionPredicate,
++                                           final BlockPosition sourcePosition,
++                                           final int range, // distance on x y z axis
++                                           final VillagePlace.Occupancy occupancy,
++                                           final boolean load,
++                                           final int max,
++                                           final List<BlockPosition> ret) {
++        final Set<BlockPosition> positions = new HashSet<>();
++        // pos predicate is last thing that runs before adding to ret.
++        final Predicate<BlockPosition> newPredicate = (final BlockPosition pos) -> {
++            if (positionPredicate != null && !positionPredicate.test(pos)) {
++                return false;
++            }
++            return positions.add(pos.immutableCopy());
++        };
++
++        final List<VillagePlaceRecord> toConvert = new ArrayList<>();
++        findAnyPoiRecords(
++                poiStorage, villagePlaceType, newPredicate, sourcePosition, range, occupancy, load, max, toConvert
++        );
++
++        for (final VillagePlaceRecord record : toConvert) {
++            ret.add(record.getPosition());
++        }
++    }
++
++    public static VillagePlaceRecord findAnyPoiRecord(final VillagePlace poiStorage,
++                                                      final Predicate<VillagePlaceType> villagePlaceType,
++                                                      final Predicate<BlockPosition> positionPredicate,
++                                                      final BlockPosition sourcePosition,
++                                                      final int range, // distance on x y z axis
++                                                      final VillagePlace.Occupancy occupancy,
++                                                      final boolean load) {
++        final List<VillagePlaceRecord> ret = new ArrayList<>();
++        findAnyPoiRecords(poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, occupancy, load, 1, ret);
++        return ret.isEmpty() ? null : ret.get(0);
++    }
++
++    public static void findAnyPoiRecords(final VillagePlace poiStorage,
++                                         final Predicate<VillagePlaceType> villagePlaceType,
++                                         final Predicate<BlockPosition> positionPredicate,
++                                         final BlockPosition sourcePosition,
++                                         final int range, // distance on x y z axis
++                                         final VillagePlace.Occupancy occupancy,
++                                         final boolean load,
++                                         final int max,
++                                         final List<VillagePlaceRecord> ret) {
++        // the biggest issue with the original mojang implementation is that they chain so many streams together
++        // the amount of streams chained just rolls performance, even if nothing is iterated over
++        final Predicate<? super VillagePlaceRecord> occupancyFilter = occupancy.getPredicate();
++        final double rangeSquared = range * range;
++
++        int added = 0;
++
++        // First up, we need to iterate the chunks
++        // all the values here are in chunk sections
++        final int lowerX = MathHelper.floor(sourcePosition.getX() - range) >> 4;
++        final int lowerY = Math.max(0, MathHelper.floor(sourcePosition.getY() - range) >> 4);
++        final int lowerZ = MathHelper.floor(sourcePosition.getZ() - range) >> 4;
++        final int upperX = MathHelper.floor(sourcePosition.getX() + range) >> 4;
++        final int upperY = Math.min(15, MathHelper.floor(sourcePosition.getY() + range) >> 4);
++        final int upperZ = MathHelper.floor(sourcePosition.getZ() + range) >> 4;
++
++        // Vanilla iterates by x until max is reached then increases z
++        // vanilla also searches by increasing Y section value
++        for (int currZ = lowerZ; currZ <= upperZ; ++currZ) {
++            for (int currX = lowerX; currX <= upperX; ++currX) {
++                for (int currY = lowerY; currY <= upperY; ++currY) { // vanilla searches the entire chunk because they're actually stupid. just search the sections we need
++                    final Optional<VillagePlaceSection> poiSectionOptional = load ? poiStorage.getOrLoad(SectionPosition.asLong(currX, currY, currZ)) :
++                            poiStorage.getIfLoaded(SectionPosition.asLong(currX, currY, currZ));
++                    final VillagePlaceSection poiSection = poiSectionOptional == null ? null : poiSectionOptional.orElse(null);
++                    if (poiSection == null) {
++                        continue;
++                    }
++
++                    final Map<VillagePlaceType, Set<VillagePlaceRecord>> sectionData = poiSection.getData();
++                    if (sectionData.isEmpty()) {
++                        continue;
++                    }
++
++                    // now we search the section data
++                    for (final Map.Entry<VillagePlaceType, Set<VillagePlaceRecord>> entry : sectionData.entrySet()) {
++                        if (!villagePlaceType.test(entry.getKey())) {
++                            // filter out by poi type
++                            continue;
++                        }
++
++                        // now we can look at the poi data
++                        for (final VillagePlaceRecord poiData : entry.getValue()) {
++                            if (!occupancyFilter.test(poiData)) {
++                                // filter by occupancy
++                                continue;
++                            }
++
++                            final BlockPosition poiPosition = poiData.getPosition();
++
++                            if (Math.abs(poiPosition.getX() - sourcePosition.getX()) > range
++                                    || Math.abs(poiPosition.getZ() - sourcePosition.getZ()) > range) {
++                                // out of range for square radius
++                                continue;
++                            }
++
++                            if (poiPosition.distanceSquared(sourcePosition) > rangeSquared) {
++                                // out of range for distance check
++                                continue;
++                            }
++
++                            if (positionPredicate != null && !positionPredicate.test(poiPosition)) {
++                                // filter by position
++                                continue;
++                            }
++
++                            // found one!
++                            ret.add(poiData);
++                            if (++added >= max) {
++                                return;
++                            }
++                        }
++                    }
++                }
++            }
++        }
++    }
++
++    private PoiAccess() {
++        throw new RuntimeException();
 +    }
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/util/TickThread.java b/src/main/java/com/tuinity/tuinity/util/TickThread.java
@@ -7091,6 +8884,172 @@ index 0000000000000000000000000000000000000000..606417a8aeaca2682595f417bba8e9d4
 +        }
 +    }
 +}
+diff --git a/src/main/java/com/tuinity/tuinity/util/table/ZeroCollidingReferenceStateTable.java b/src/main/java/com/tuinity/tuinity/util/table/ZeroCollidingReferenceStateTable.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..298d09634effcb06cd2237a1f7f903e9e46ec78d
+--- /dev/null
++++ b/src/main/java/com/tuinity/tuinity/util/table/ZeroCollidingReferenceStateTable.java
+@@ -0,0 +1,160 @@
++package com.tuinity.tuinity.util.table;
++
++import com.google.common.collect.Table;
++import net.minecraft.server.IBlockDataHolder;
++import net.minecraft.server.IBlockState;
++import java.util.Collection;
++import java.util.HashSet;
++import java.util.Map;
++import java.util.Set;
++
++public final class ZeroCollidingReferenceStateTable {
++
++    // upper 32 bits: starting index
++    // lower 32 bits: bitset for contained ids
++    protected final long[] this_index_table;
++    protected final Comparable<?>[] this_table;
++    protected final IBlockDataHolder<?, ?> this_state;
++
++    protected long[] index_table;
++    protected IBlockDataHolder<?, ?>[][] value_table;
++
++    public ZeroCollidingReferenceStateTable(final IBlockDataHolder<?, ?> state, final Map<IBlockState<?>, Comparable<?>> this_map) {
++        this.this_state = state;
++        this.this_index_table = this.create_table(this_map.keySet());
++
++        int max_id = -1;
++        for (final IBlockState<?> property : this_map.keySet()) {
++            final int id = lookup_vindex(property, this.this_index_table);
++            if (id > max_id) {
++                max_id = id;
++            }
++        }
++
++        this.this_table = new Comparable[max_id + 1];
++        for (final Map.Entry<IBlockState<?>, Comparable<?>> entry : this_map.entrySet()) {
++            this.this_table[lookup_vindex(entry.getKey(), this.this_index_table)] = entry.getValue();
++        }
++    }
++
++    public void loadInTable(final Table<IBlockState<?>, Comparable<?>, IBlockDataHolder<?, ?>> table,
++                            final Map<IBlockState<?>, Comparable<?>> this_map) {
++        final Set<IBlockState<?>> combined = new HashSet<>(table.rowKeySet());
++        combined.addAll(this_map.keySet());
++
++        this.index_table = this.create_table(combined);
++
++        int max_id = -1;
++        for (final IBlockState<?> property : combined) {
++            final int id = lookup_vindex(property, this.index_table);
++            if (id > max_id) {
++                max_id = id;
++            }
++        }
++
++        this.value_table = new IBlockDataHolder[max_id + 1][];
++
++        final Map<IBlockState<?>, Map<Comparable<?>, IBlockDataHolder<?, ?>>> map = table.rowMap();
++        for (final IBlockState<?> property : map.keySet()) {
++            final Map<Comparable<?>, IBlockDataHolder<?, ?>> propertyMap = map.get(property);
++
++            final int id = lookup_vindex(property, this.index_table);
++            final IBlockDataHolder<?, ?>[] states = this.value_table[id] = new IBlockDataHolder[property.getValues().size()];
++
++            for (final Map.Entry<Comparable<?>, IBlockDataHolder<?, ?>> entry : propertyMap.entrySet()) {
++                if (entry.getValue() == null) {
++                    // TODO what
++                    continue;
++                }
++
++                states[((IBlockState)property).getIdFor(entry.getKey())] = entry.getValue();
++            }
++        }
++
++
++        for (final Map.Entry<IBlockState<?>, Comparable<?>> entry : this_map.entrySet()) {
++            final IBlockState<?> property = entry.getKey();
++            final int index = lookup_vindex(property, this.index_table);
++
++            if (this.value_table[index] == null) {
++                this.value_table[index] = new IBlockDataHolder[property.getValues().size()];
++            }
++
++            this.value_table[index][((IBlockState)property).getIdFor(entry.getValue())] = this.this_state;
++        }
++    }
++
++
++    protected long[] create_table(final Collection<IBlockState<?>> collection) {
++        int max_id = -1;
++        for (final IBlockState<?> property : collection) {
++            final int id = property.getId();
++            if (id > max_id) {
++                max_id = id;
++            }
++        }
++
++        final long[] ret = new long[((max_id + 1) + 31) >>> 5]; // ceil((max_id + 1) / 32)
++
++        for (final IBlockState<?> property : collection) {
++            final int id = property.getId();
++
++            ret[id >>> 5] |= (1L << (id & 31));
++        }
++
++        int total = 0;
++        for (int i = 1, len = ret.length; i < len; ++i) {
++            ret[i] |= (long)(total += Long.bitCount(ret[i - 1] & 0xFFFFFFFFL)) << 32;
++        }
++
++        return ret;
++    }
++
++    public Comparable<?> get(final IBlockState<?> state) {
++        final Comparable<?>[] table = this.this_table;
++        final int index = lookup_vindex(state, this.this_index_table);
++
++        if (index < 0 || index >= table.length) {
++            return null;
++        }
++        return table[index];
++    }
++
++    public IBlockDataHolder<?, ?> get(final IBlockState<?> property, final Comparable<?> with) {
++        final int withId = ((IBlockState)property).getIdFor(with);
++        if (withId < 0) {
++            return null;
++        }
++
++        final int index = lookup_vindex(property, this.index_table);
++        final IBlockDataHolder<?, ?>[][] table = this.value_table;
++        if (index < 0 || index >= table.length) {
++            return null;
++        }
++
++        final IBlockDataHolder<?, ?>[] values = table[index];
++
++        if (withId >= values.length) {
++            return null;
++        }
++
++        return values[withId];
++    }
++
++    protected static int lookup_vindex(final IBlockState<?> property, final long[] index_table) {
++        final int id = property.getId();
++        final long bitset_mask = (1L << (id & 31));
++        final long lower_mask = bitset_mask - 1;
++        final int index = id >>> 5;
++        if (index >= index_table.length) {
++            return -1;
++        }
++        final long index_value = index_table[index];
++        final long contains_check = ((index_value & bitset_mask) - 1) >> (Long.SIZE - 1); // -1L if doesn't contain
++
++        // index = total bits set in lower table values (upper 32 bits of index_value) plus total bits set in lower indices below id
++        // contains_check is 0 if the bitset had id set, else it's -1: so index is unaffected if contains_check == 0,
++        // otherwise it comes out as -1.
++        return (int)(((index_value >>> 32) + Long.bitCount(index_value & lower_mask)) | contains_check);
++    }
++}
 diff --git a/src/main/java/com/tuinity/tuinity/voxel/AABBVoxelShape.java b/src/main/java/com/tuinity/tuinity/voxel/AABBVoxelShape.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..002abb3cbf0f742e685f2f043d2600de03e37a19
@@ -8024,247 +9983,23 @@ index 65af976527133ee5c2f52e411e19c4f7f06df3ef..0b9d469a92decfb0632805791868ef7f
      private final int d;
      private final int e;
 diff --git a/src/main/java/net/minecraft/server/BehaviorFindPosition.java b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-index 63a761ebef80d4af09cdc2682e496d78492c4a3a..8d445e9c0875db6cf45e4d8bcfce7cd3d5094d94 100644
+index 63a761ebef80d4af09cdc2682e496d78492c4a3a..83702e07dff72b639af32c8ba9e831e58da92a10 100644
 --- a/src/main/java/net/minecraft/server/BehaviorFindPosition.java
 +++ b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-@@ -55,6 +55,227 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
-         }
-     }
- 
-+    // Tuinity - remove streams entirely for poi search
-+    // the only intentional vanilla diff is that this function will NOT load in poi data, anything else is a bug!
-+    protected static Set<BlockPosition> findNearestPoi(VillagePlace poiStorage,
-+                                                                          Predicate<VillagePlaceType> villagePlaceType,
-+                                                                          Predicate<BlockPosition> positionPredicate,
-+                                                                          BlockPosition sourcePosition,
-+                                                                          int range, // distance on x y z axis
-+                                                                          VillagePlace.Occupancy occupancy,
-+                                                                          int max) {
-+        java.util.TreeSet<BlockPosition> ret = new java.util.TreeSet<>((blockpos1, blockpos2) -> {
-+            // important to keep distanceSquared order: the param is the source
-+            return Double.compare(blockpos1.distanceSquared(sourcePosition), blockpos2.distanceSquared(sourcePosition));
-+        });
-+        findNearestPoi(poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, occupancy, max, ret);
-+        return new java.util.HashSet<>(ret);
-+    }
-+    protected static void findNearestPoi(VillagePlace poiStorage,
-+                                            Predicate<VillagePlaceType> villagePlaceType,
-+                                            Predicate<BlockPosition> positionPredicate,
-+                                            BlockPosition sourcePosition,
-+                                            int range, // distance on x y z axis
-+                                            VillagePlace.Occupancy occupancy,
-+                                            int max,
-+                                            java.util.SortedSet<BlockPosition> ret) {
-+        // the biggest issue with the original mojang implementation is that they chain so many streams together
-+        // the amount of streams chained just rolls performance, even if nothing is iterated over
-+        Predicate<? super VillagePlaceRecord> occupancyFilter = occupancy.getPredicate();
-+        double rangeSquared = range * range;
-+
-+        // First up, we need to iterate the chunks
-+        // all the values here are in chunk sections
-+        int lowerX = MathHelper.floor(sourcePosition.getX() - range) >> 4;
-+        int lowerY = Math.max(0, MathHelper.floor(sourcePosition.getY() - range) >> 4);
-+        int lowerZ = MathHelper.floor(sourcePosition.getZ() - range) >> 4;
-+        int upperX = MathHelper.floor(sourcePosition.getX() + range) >> 4;
-+        int upperY = Math.min(15, MathHelper.floor(sourcePosition.getY() + range) >> 4);
-+        int upperZ = MathHelper.floor(sourcePosition.getZ() + range) >> 4;
-+
-+        // Vanilla iterates by x until max is reached then increases z
-+        // vanilla also searches by increasing Y section value
-+        for (int currZ = lowerZ; currZ <= upperZ; ++currZ) {
-+            for (int currX = lowerX; currX <= upperX; ++currX) {
-+                for (int currY = lowerY; currY <= upperY; ++currY) { // vanilla searches the entire chunk because they're actually stupid. just search the sections we need
-+                    Optional<VillagePlaceSection> poiSectionOptional = poiStorage.getIfLoaded(SectionPosition.asLong(currX, currY, currZ));
-+                    VillagePlaceSection poiSection = poiSectionOptional == null ? null : poiSectionOptional.orElse(null);
-+                    if (poiSection == null) {
-+                        continue;
-+                    }
-+
-+                    java.util.Map<VillagePlaceType, Set<VillagePlaceRecord>> sectionData = poiSection.getData();
-+                    if (sectionData.isEmpty()) {
-+                        continue;
-+                    }
-+
-+                    // now we search the section data
-+                    for (java.util.Iterator<java.util.Map.Entry<VillagePlaceType, Set<VillagePlaceRecord>>> iterator = sectionData.entrySet().iterator();
-+                         iterator.hasNext();) {
-+                        java.util.Map.Entry<VillagePlaceType, Set<VillagePlaceRecord>> entry = iterator.next();
-+                        if (!villagePlaceType.test(entry.getKey())) {
-+                            // filter out by poi type
-+                            continue;
-+                        }
-+
-+                        // now we can look at the poi data
-+                        for (VillagePlaceRecord poiData : entry.getValue()) {
-+                            if (!occupancyFilter.test(poiData)) {
-+                                // filter by occupancy
-+                                continue;
-+                            }
-+
-+                            // vanilla code is pretty dumb about filtering by distance: first they filter out
-+                            // so that only values in the square radius of range are returned but then they
-+                            // filter out so that the distance is in range
-+                            // but there's a catch! distanceSquared, by default, will ADD 0.5 to ONLY ONE OF the
-+                            // block position parameters (itself, in this case the poi position)! So if we want to
-+                            // maintain exact vanilla behaviour, well shit we need to play dumb as well.
-+
-+                            BlockPosition poiPosition = poiData.getPosition();
-+
-+                            if (Math.abs(poiPosition.getX() - sourcePosition.getX()) > range
-+                                    || Math.abs(poiPosition.getZ() - sourcePosition.getZ()) > range) {
-+                                // out of range for square radius
-+                                continue;
-+                            }
-+
-+                            if (poiPosition.distanceSquared(sourcePosition) > rangeSquared) {
-+                                // out of range for distance check
-+                                continue;
-+                            }
-+
-+                            if (!positionPredicate.test(poiPosition)) {
-+                                // filter by position
-+                                continue;
-+                            }
-+
-+                            // found one!
-+                            ret.add(poiPosition);
-+                            if (ret.size() > max) {
-+                                ret.remove(ret.last());
-+                            }
-+                        }
-+                    }
-+                }
-+            }
-+        }
-+    }
-+
-+    protected static BlockPosition findAnyFirstPoi(VillagePlace poiStorage,
-+                                                   Predicate<VillagePlaceType> villagePlaceType,
-+                                                   Predicate<BlockPosition> positionPredicate,
-+                                                   BlockPosition sourcePosition,
-+                                                   int range, // distance on x y z axis
-+                                                   VillagePlace.Occupancy occupancy) {
-+        Set<BlockPosition> ret = new java.util.HashSet<>();
-+        findPoi(poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, occupancy, 1, ret);
-+        return ret.isEmpty() ? null : ret.iterator().next();
-+    }
-+
-+    protected static Set<BlockPosition> findPoi(VillagePlace poiStorage,
-+                                                Predicate<VillagePlaceType> villagePlaceType,
-+                                                Predicate<BlockPosition> positionPredicate,
-+                                                BlockPosition sourcePosition,
-+                                                int range, // distance on x y z axis
-+                                                VillagePlace.Occupancy occupancy,
-+                                                int max) {
-+        Set<BlockPosition> ret = new java.util.HashSet<>();
-+        findPoi(poiStorage, villagePlaceType, positionPredicate, sourcePosition, range, occupancy, max, ret);
-+        return ret;
-+    }
-+    protected static void findPoi(VillagePlace poiStorage,
-+                                                Predicate<VillagePlaceType> villagePlaceType,
-+                                                Predicate<BlockPosition> positionPredicate,
-+                                                BlockPosition sourcePosition,
-+                                                int range, // distance on x y z axis
-+                                                VillagePlace.Occupancy occupancy,
-+                                                int max,
-+                                                Set<BlockPosition> ret) {
-+        // the biggest issue with the original mojang implementation is that they chain so many streams together
-+        // the amount of streams chained just rolls performance, even if nothing is iterated over
-+        Predicate<? super VillagePlaceRecord> occupancyFilter = occupancy.getPredicate();
-+        double rangeSquared = range * range;
-+
-+        // First up, we need to iterate the chunks
-+        // all the values here are in chunk sections
-+        int lowerX = MathHelper.floor(sourcePosition.getX() - range) >> 4;
-+        int lowerY = Math.max(0, MathHelper.floor(sourcePosition.getY() - range) >> 4);
-+        int lowerZ = MathHelper.floor(sourcePosition.getZ() - range) >> 4;
-+        int upperX = MathHelper.floor(sourcePosition.getX() + range) >> 4;
-+        int upperY = Math.min(15, MathHelper.floor(sourcePosition.getY() + range) >> 4);
-+        int upperZ = MathHelper.floor(sourcePosition.getZ() + range) >> 4;
-+
-+        // Vanilla iterates by x until max is reached then increases z
-+        // vanilla also searches by increasing Y section value
-+        for (int currZ = lowerZ; currZ <= upperZ; ++currZ) {
-+            for (int currX = lowerX; currX <= upperX; ++currX) {
-+                for (int currY = lowerY; currY <= upperY; ++currY) { // vanilla searches the entire chunk because they're actually stupid. just search the sections we need
-+                    Optional<VillagePlaceSection> poiSectionOptional = poiStorage.getIfLoaded(SectionPosition.asLong(currX, currY, currZ));
-+                    VillagePlaceSection poiSection = poiSectionOptional == null ? null : poiSectionOptional.orElse(null);
-+                    if (poiSection == null) {
-+                        continue;
-+                    }
-+
-+                    java.util.Map<VillagePlaceType, Set<VillagePlaceRecord>> sectionData = poiSection.getData();
-+                    if (sectionData.isEmpty()) {
-+                        continue;
-+                    }
-+
-+                    // now we search the section data
-+                    for (java.util.Iterator<java.util.Map.Entry<VillagePlaceType, Set<VillagePlaceRecord>>> iterator = sectionData.entrySet().iterator();
-+                            iterator.hasNext();) {
-+                        java.util.Map.Entry<VillagePlaceType, Set<VillagePlaceRecord>> entry = iterator.next();
-+                        if (!villagePlaceType.test(entry.getKey())) {
-+                            // filter out by poi type
-+                            continue;
-+                        }
-+
-+                        // now we can look at the poi data
-+                        for (VillagePlaceRecord poiData : entry.getValue()) {
-+                            if (!occupancyFilter.test(poiData)) {
-+                                // filter by occupancy
-+                                continue;
-+                            }
-+
-+                            // vanilla code is pretty dumb about filtering by distance: first they filter out
-+                            // so that only values in the square radius of range are returned but then they
-+                            // filter out so that the distance is in range
-+                            // but there's a catch! distanceSquared, by default, will ADD 0.5 to ONLY ONE OF the
-+                            // block position parameters (itself, in this case the poi position)! So if we want to
-+                            // maintain exact vanilla behaviour, well shit we need to play dumb as well.
-+
-+                            BlockPosition poiPosition = poiData.getPosition();
-+
-+                            if (Math.abs(poiPosition.getX() - sourcePosition.getX()) > range
-+                                    || Math.abs(poiPosition.getZ() - sourcePosition.getZ()) > range) {
-+                                // out of range for square radius
-+                                continue;
-+                            }
-+
-+                            if (poiPosition.distanceSquared(sourcePosition) > rangeSquared) {
-+                                // out of range for distance check
-+                                continue;
-+                            }
-+
-+                            if (!positionPredicate.test(poiPosition)) {
-+                                // filter by position
-+                                continue;
-+                            }
-+
-+                            // found one!
-+                            ret.add(poiPosition);
-+                            if (ret.size() >= max) {
-+                                return;
-+                            }
-+                        }
-+                    }
-+                }
-+            }
-+        }
-+    }
-+    // Tuinity - remove streams entirely for poi search
-+
-     protected void a(WorldServer worldserver, EntityCreature entitycreature, long i) {
-         this.f = i + 20L + (long) worldserver.getRandom().nextInt(20);
-         VillagePlace villageplace = worldserver.y();
-@@ -74,7 +295,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+@@ -74,7 +74,11 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
                  return true;
              }
          };
 -        Set<BlockPosition> set = (Set) villageplace.b(this.b.c(), predicate, entitycreature.getChunkCoordinates(), 48, VillagePlace.Occupancy.HAS_SPACE).limit(5L).collect(Collectors.toSet());
-+        Set<BlockPosition> set = findNearestPoi(villageplace, this.b.c(), predicate, entitycreature.getChunkCoordinates(), 48, VillagePlace.Occupancy.HAS_SPACE, 5); // Tuinity - remove streams entirely for poi search
++        // Tuinity start - optimise POI access
++        java.util.List<BlockPosition> poiposes = new java.util.ArrayList<>();
++        com.tuinity.tuinity.util.PoiAccess.findNearestPoiPositions(villageplace, this.b.c(), predicate, entitycreature.getChunkCoordinates(), 48, 48*48, VillagePlace.Occupancy.HAS_SPACE, false, 5, poiposes);
++        Set<BlockPosition> set = new java.util.HashSet<>(poiposes);
++        // Tuinity end - optimise POI access
          PathEntity pathentity = entitycreature.getNavigation().a(set, this.b.d());
  
          if (pathentity != null && pathentity.j()) {
-@@ -84,7 +305,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+@@ -84,7 +88,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
                  villageplace.a(this.b.c(), (blockposition1) -> {
                      return blockposition1.equals(blockposition);
                  }, blockposition, 1);
@@ -8460,6 +10195,82 @@ index a33303c31881b6391723e16a06d7841d48679958..ce57e6a4acac97d6da82202094306e7e
      private boolean a(EntityLiving entityliving) {
          return this.b.equals(entityliving.getEntityType()) && this.d.test(entityliving);
      }
+diff --git a/src/main/java/net/minecraft/server/BiomeBase.java b/src/main/java/net/minecraft/server/BiomeBase.java
+index 0854ac9ef586b378420d9899f3afd2755e6f9f33..3fc101552e3c229076c91a1cfa45206b4cc7a04c 100644
+--- a/src/main/java/net/minecraft/server/BiomeBase.java
++++ b/src/main/java/net/minecraft/server/BiomeBase.java
+@@ -145,14 +145,33 @@ public final class BiomeBase {
+     }
+ 
+     public boolean a(IWorldReader iworldreader, BlockPosition blockposition, boolean flag) {
+-        if (this.getAdjustedTemperature(blockposition) >= 0.15F) {
++        // Tuinity start - add chunk parameter and lazily get biome
++        return canTurnWaterIntoIce(iworldreader, blockposition, flag, null, new BiomeBase[] { this });
++    }
++    public static boolean canTurnWaterIntoIce(IWorldReader iworldreader, BlockPosition blockposition, boolean flag, IChunkAccess chunk, BiomeBase[] biomeAbove) {
++        // Tuinity end - add chunk parameter and lazily get biome
++        if (false && biomeAbove[0].getAdjustedTemperature(blockposition) >= 0.15F) { // Tuinity - move this down, this check is expensive
+             return false;
+         } else {
+             if (blockposition.getY() >= 0 && blockposition.getY() < 256 && iworldreader.getBrightness(EnumSkyBlock.BLOCK, blockposition) < 10) {
+-                IBlockData iblockdata = iworldreader.getType(blockposition);
+-                Fluid fluid = iworldreader.getFluid(blockposition);
++                // Tuinity start - add chunk parameter
++                if (chunk == null) {
++                    chunk = iworldreader.getChunkAt(blockposition.getX() >> 4, blockposition.getZ() >> 4);
++                }
++                // Tuinity end - add chunk parameter
++                IBlockData iblockdata = chunk.getType(blockposition); // Tuinity - skip chunk lookup, we got the chunk
++                Fluid fluid = iblockdata.getFluid(); // Tuinity - skip another block lookup, we have the blockdata
+ 
+                 if (fluid.getType() == FluidTypes.WATER && iblockdata.getBlock() instanceof BlockFluids) {
++                    // Tuinity start - moved down from top, only run when we actually encounter water
++                    if (biomeAbove[0] == null) {
++                        // lazily-get biome
++                        biomeAbove[0] = iworldreader.getBiome(blockposition.up()); // TODO - avoid blockpos alloc
++                    }
++                    if (biomeAbove[0].getAdjustedTemperature(blockposition) >= 0.15F) {
++                        return false;
++                    }
++                    // Tuinity end - moved down from top, only run when we actually encounter water
+                     if (!flag) {
+                         return true;
+                     }
+@@ -170,13 +189,32 @@ public final class BiomeBase {
+     }
+ 
+     public boolean b(IWorldReader iworldreader, BlockPosition blockposition) {
+-        if (this.getAdjustedTemperature(blockposition) >= 0.15F) {
++        // Tuinity start - add chunk parameter and lazily get biome
++        return canTurnAirIntoSnow(iworldreader, blockposition, null, new BiomeBase[]{ this });
++    }
++    public static boolean canTurnAirIntoSnow(IWorldReader iworldreader, BlockPosition blockposition, IChunkAccess chunk, BiomeBase[] biomeAbove) {
++        // Tuinity end - add chunk parameter and lazily get biome
++        if (false && biomeAbove[0].getAdjustedTemperature(blockposition) >= 0.15F) { // Tuinity - move this down, this check is expensive
+             return false;
+         } else {
+             if (blockposition.getY() >= 0 && blockposition.getY() < 256 && iworldreader.getBrightness(EnumSkyBlock.BLOCK, blockposition) < 10) {
+-                IBlockData iblockdata = iworldreader.getType(blockposition);
++                // Tuinity start - add chunk parameter
++                if (chunk == null) {
++                    chunk = iworldreader.getChunkAt(blockposition.getX() >> 4, blockposition.getZ() >> 4);
++                }
++                // Tuinity end - add chunk parameter
++                IBlockData iblockdata = chunk.getType(blockposition); // Tuinity - skip chunk lookup, we got the chunk
+ 
+                 if (iblockdata.isAir() && Blocks.SNOW.getBlockData().canPlace(iworldreader, blockposition)) {
++                    // Tuinity start - moved down from top, only run when we actually encounter water
++                    if (biomeAbove[0] == null) {
++                        // lazily-get biome
++                        biomeAbove[0] = iworldreader.getBiome(blockposition.up()); // TODO - avoid blockpos alloc
++                    }
++                    if (biomeAbove[0].getAdjustedTemperature(blockposition) >= 0.15F) {
++                        return false;
++                    }
++                    // Tuinity end - moved down from top, only run when we actually encounter water
+                     return true;
+                 }
+             }
 diff --git a/src/main/java/net/minecraft/server/BlockBase.java b/src/main/java/net/minecraft/server/BlockBase.java
 index 1f334d63282bd5c23dc3b275a220f09e60c34537..829d4a7508e1656dbdc912096b7eafcf30cbb5b2 100644
 --- a/src/main/java/net/minecraft/server/BlockBase.java
@@ -8694,8 +10505,82 @@ index 2d887af902a33b0e28d8f0a6ac2e59c815a7856e..2291135eaef64c403183724cb6e413cd
  
          @Override
          public BlockPosition immutableCopy() {
+diff --git a/src/main/java/net/minecraft/server/BlockStateBoolean.java b/src/main/java/net/minecraft/server/BlockStateBoolean.java
+index 4ca8db630434915de4eaeac6c4ecd60714d7f5d9..d6c8ae638b3993ce55be91087de09a300405e075 100644
+--- a/src/main/java/net/minecraft/server/BlockStateBoolean.java
++++ b/src/main/java/net/minecraft/server/BlockStateBoolean.java
+@@ -12,6 +12,13 @@ public class BlockStateBoolean extends IBlockState<Boolean> {
+         super(s, Boolean.class);
+     }
+ 
++    // Tuinity start - optimise iblockdata state lookup
++    @Override
++    public final int getIdFor(final Boolean value) {
++        return value.booleanValue() ? 1 : 0;
++    }
++    // Tuinity end - optimise iblockdata state lookup
++
+     @Override
+     public Collection<Boolean> getValues() {
+         return this.a;
+diff --git a/src/main/java/net/minecraft/server/BlockStateEnum.java b/src/main/java/net/minecraft/server/BlockStateEnum.java
+index 8dc620b22bb904aa6a82e2127aa9da861986525c..e6663281481a48fe1b838339160565fbf4c6a65a 100644
+--- a/src/main/java/net/minecraft/server/BlockStateEnum.java
++++ b/src/main/java/net/minecraft/server/BlockStateEnum.java
+@@ -17,6 +17,15 @@ public class BlockStateEnum<T extends Enum<T> & INamable> extends IBlockState<T>
+     private final ImmutableSet<T> a;
+     private final Map<String, T> b = Maps.newHashMap();
+ 
++    // Tuinity start - optimise iblockdata state lookup
++    private int[] idLookupTable;
++
++    @Override
++    public final int getIdFor(final T value) {
++        return this.idLookupTable[value.ordinal()];
++    }
++    // Tuinity end - optimise iblockdata state lookup
++
+     protected BlockStateEnum(String s, Class<T> oclass, Collection<T> collection) {
+         super(s, oclass);
+         this.a = ImmutableSet.copyOf(collection);
+@@ -32,6 +41,14 @@ public class BlockStateEnum<T extends Enum<T> & INamable> extends IBlockState<T>
+ 
+             this.b.put(s1, t0);
+         }
++        // Tuinity start - optimise iblockdata state lookup
++        int id = 0;
++        this.idLookupTable = new int[oclass.getEnumConstants().length];
++        java.util.Arrays.fill(this.idLookupTable, -1);
++        for (final T value : this.getValues()) {
++            this.idLookupTable[value.ordinal()] = id++;
++        }
++        // Tuinity end - optimise iblockdata state lookup
+ 
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/BlockStateInteger.java b/src/main/java/net/minecraft/server/BlockStateInteger.java
+index 36b84446e96faefad3b783f73df74e0f3bce8255..acae5fe0bff44d2bc3921c8e078b2f261de3a035 100644
+--- a/src/main/java/net/minecraft/server/BlockStateInteger.java
++++ b/src/main/java/net/minecraft/server/BlockStateInteger.java
+@@ -13,6 +13,16 @@ public class BlockStateInteger extends IBlockState<Integer> {
+     public final int min;
+     public final int max;
+ 
++    // Tuinity start - optimise iblockdata state lookup
++    @Override
++    public final int getIdFor(final Integer value) {
++        final int val = value.intValue();
++        final int ret = val - this.min;
++
++        return ret | ((this.max - ret) >> 31);
++    }
++    // Tuinity end - optimise iblockdata state lookup
++
+     protected BlockStateInteger(String s, int i, int j) {
+         super(s, Integer.class);
+         this.min = i;
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 3bcd63a754538ccfc5965207a8fc79faa31925c0..8fda4702764e80dae93ef9c0eb53abc198642ab1 100644
+index 3bcd63a754538ccfc5965207a8fc79faa31925c0..8e59a794f6190930cb7bb81a2fe1a1d374dacce7 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -91,6 +91,158 @@ public class Chunk implements IChunkAccess {
@@ -8865,7 +10750,56 @@ index 3bcd63a754538ccfc5965207a8fc79faa31925c0..8fda4702764e80dae93ef9c0eb53abc1
      }
  
      public org.bukkit.Chunk bukkitChunk;
-@@ -298,6 +451,12 @@ public class Chunk implements IChunkAccess {
+@@ -207,12 +360,12 @@ public class Chunk implements IChunkAccess {
+         PlayerChunkMap chunkMap = chunkProviderServer.playerChunkMap;
+         // this code handles the addition of ticking tickets - the distance map handles the removal
+         if (!areNeighboursLoaded(bitsetBefore, 2) && areNeighboursLoaded(bitsetAfter, 2)) {
+-            if (chunkMap.playerViewDistanceTickMap.getObjectsInRange(this.coordinateKey) != null) {
++            if (chunkMap.playerChunkManager.tickMap.getObjectsInRange(this.coordinateKey) != null) { // Tuinity - replace old player chunk loading system
+                 // now we're ready for entity ticking
+                 chunkProviderServer.serverThreadQueue.execute(() -> {
+                     // double check that this condition still holds.
+-                    if (Chunk.this.areNeighboursLoaded(2) && chunkMap.playerViewDistanceTickMap.getObjectsInRange(Chunk.this.coordinateKey) != null) {
+-                        chunkProviderServer.addTicketAtLevel(TicketType.PLAYER, Chunk.this.loc, 31, Chunk.this.loc); // 31 -> entity ticking, TODO check on update
++                    if (Chunk.this.areNeighboursLoaded(2) && chunkMap.playerChunkManager.tickMap.getObjectsInRange(Chunk.this.coordinateKey) != null) { // Tuinity - replace old player chunk loading system
++                        chunkMap.playerChunkManager.onChunkPlayerTickReady(this.loc.x, this.loc.z); // Tuinity - replace old player chunk loading system
+                     }
+                 });
+             }
+@@ -220,31 +373,7 @@ public class Chunk implements IChunkAccess {
+ 
+         // this code handles the chunk sending
+         if (!areNeighboursLoaded(bitsetBefore, 1) && areNeighboursLoaded(bitsetAfter, 1)) {
+-            if (chunkMap.playerViewDistanceBroadcastMap.getObjectsInRange(this.coordinateKey) != null) {
+-                // now we're ready to send
+-                chunkMap.mailboxMain.a(ChunkTaskQueueSorter.a(chunkMap.getUpdatingChunk(this.coordinateKey), (() -> { // Copied frm PlayerChunkMap
+-                    // double check that this condition still holds.
+-                    if (!Chunk.this.areNeighboursLoaded(1)) {
+-                        return;
+-                    }
+-                    com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> inRange = chunkMap.playerViewDistanceBroadcastMap.getObjectsInRange(Chunk.this.coordinateKey);
+-                    if (inRange == null) {
+-                        return;
+-                    }
+-
+-                    // broadcast
+-                    Object[] backingSet = inRange.getBackingSet();
+-                    Packet[] chunkPackets = new Packet[10];
+-                    for (int index = 0, len = backingSet.length; index < len; ++index) {
+-                        Object temp = backingSet[index];
+-                        if (!(temp instanceof EntityPlayer)) {
+-                            continue;
+-                        }
+-                        EntityPlayer player = (EntityPlayer)temp;
+-                        chunkMap.sendChunk(player, chunkPackets, Chunk.this);
+-                    }
+-                })));
+-            }
++            chunkMap.playerChunkManager.onChunkSendReady(this.loc.x, this.loc.z); // Tuinity - replace old player chunk loading system
+         }
+         // Paper end - no-tick view distance
+     }
+@@ -298,6 +427,12 @@ public class Chunk implements IChunkAccess {
  
      public Chunk(World world, ProtoChunk protochunk) {
          this(world, protochunk.getPos(), protochunk.getBiomeIndex(), protochunk.p(), protochunk.n(), protochunk.o(), protochunk.getInhabitedTime(), protochunk.getSections(), (Consumer) null);
@@ -8878,7 +10812,7 @@ index 3bcd63a754538ccfc5965207a8fc79faa31925c0..8fda4702764e80dae93ef9c0eb53abc1
          Iterator iterator = protochunk.y().iterator();
  
          while (iterator.hasNext()) {
-@@ -594,8 +753,9 @@ public class Chunk implements IChunkAccess {
+@@ -594,8 +729,9 @@ public class Chunk implements IChunkAccess {
          entity.chunkX = this.loc.x;
          entity.chunkY = k;
          entity.chunkZ = this.loc.z;
@@ -8890,7 +10824,7 @@ index 3bcd63a754538ccfc5965207a8fc79faa31925c0..8fda4702764e80dae93ef9c0eb53abc1
          // Paper start
          if (entity instanceof EntityItem) {
              itemCounts[k]++;
-@@ -633,7 +793,8 @@ public class Chunk implements IChunkAccess {
+@@ -633,7 +769,8 @@ public class Chunk implements IChunkAccess {
              entity.entitySlice = null;
              entity.inChunk = false;
          }
@@ -8900,7 +10834,15 @@ index 3bcd63a754538ccfc5965207a8fc79faa31925c0..8fda4702764e80dae93ef9c0eb53abc1
              return;
          }
          if (entity instanceof EntityItem) {
-@@ -876,116 +1037,18 @@ public class Chunk implements IChunkAccess {
+@@ -812,6 +949,7 @@ public class Chunk implements IChunkAccess {
+         // Paper end - neighbour cache
+         org.bukkit.Server server = this.world.getServer();
+         ((WorldServer)this.world).getChunkProvider().addLoadedChunk(this); // Paper
++        ((WorldServer)this.world).getChunkProvider().playerChunkMap.playerChunkManager.onChunkLoad(this.loc.x, this.loc.z); // Tuinity - rewrite player chunk management
+         if (server != null) {
+             /*
+              * If it's a new world, the first few chunks are generated inside
+@@ -876,116 +1014,18 @@ public class Chunk implements IChunkAccess {
      }
  
      public void a(@Nullable Entity entity, AxisAlignedBB axisalignedbb, List<Entity> list, @Nullable Predicate<? super Entity> predicate) {
@@ -9203,18 +11145,21 @@ index 097cb9896c525a605c50e83548f828e0c71ab3d5..17cf00dfe8b24adf2fb66eca4710ab78
          i = event.getRadius();
          flag = event.shouldFindUnexplored();
 diff --git a/src/main/java/net/minecraft/server/ChunkMapDistance.java b/src/main/java/net/minecraft/server/ChunkMapDistance.java
-index 76f9bb728def91744910d0b680b73e753f1a2b26..7f3887b0894aca0f972922f434382646a6ad6174 100644
+index 76f9bb728def91744910d0b680b73e753f1a2b26..5973c3a89ca5d57629376247a7636e694048a0fd 100644
 --- a/src/main/java/net/minecraft/server/ChunkMapDistance.java
 +++ b/src/main/java/net/minecraft/server/ChunkMapDistance.java
-@@ -31,7 +31,7 @@ public abstract class ChunkMapDistance {
+@@ -31,9 +31,9 @@ public abstract class ChunkMapDistance {
      private static final int b = 33 + ChunkStatus.a(ChunkStatus.FULL) - 2;
      private final Long2ObjectMap<ObjectSet<EntityPlayer>> c = new Long2ObjectOpenHashMap();
      public final Long2ObjectOpenHashMap<ArraySetSorted<Ticket<?>>> tickets = new Long2ObjectOpenHashMap();
 -    private final ChunkMapDistance.a ticketLevelTracker = new ChunkMapDistance.a();
 +    private final ChunkMapDistance.a ticketLevelTracker = new ChunkMapDistance.a(); final ChunkMapDistance.a getTicketTracker() { return this.ticketLevelTracker; } // Tuinity - OBFHELPER
      public static final int MOB_SPAWN_RANGE = 8; // private final ChunkMapDistance.b f = new ChunkMapDistance.b(8); // Paper - no longer used
-     private final ChunkMapDistance.c g = new ChunkMapDistance.c(33);
+-    private final ChunkMapDistance.c g = new ChunkMapDistance.c(33);
++    //private final ChunkMapDistance.c g = new ChunkMapDistance.c(33); // Tuinity - no longer used
      // Paper start use a queue, but still keep unique requirement
+     public final java.util.Queue<PlayerChunk> pendingChunkUpdates = new java.util.ArrayDeque<PlayerChunk>() {
+         @Override
 @@ -53,6 +53,47 @@ public abstract class ChunkMapDistance {
  
      PlayerChunkMap chunkMap; // Paper
@@ -9313,14 +11258,18 @@ index 76f9bb728def91744910d0b680b73e753f1a2b26..7f3887b0894aca0f972922f434382646
          }
  
      }
-@@ -98,6 +163,7 @@ public abstract class ChunkMapDistance {
+@@ -98,9 +163,10 @@ public abstract class ChunkMapDistance {
      protected abstract PlayerChunk a(long i, int j, @Nullable PlayerChunk playerchunk, int k);
  
      public boolean a(PlayerChunkMap playerchunkmap) {
 +        com.tuinity.tuinity.util.TickThread.softEnsureTickThread("Cannot tick ChunkMapDistance off of the main-thread");// Tuinity
          //this.f.a(); // Paper - no longer used
          AsyncCatcher.catchOp("DistanceManagerTick"); // Paper
-         this.g.a();
+-        this.g.a();
++        //this.g.a(); // Tuinity - no longer used
+         int i = Integer.MAX_VALUE - this.ticketLevelTracker.a(Integer.MAX_VALUE);
+         boolean flag = i != 0;
+ 
 @@ -176,27 +242,11 @@ public abstract class ChunkMapDistance {
          boolean removed = false; // CraftBukkit
          if (arraysetsorted.remove(ticket)) {
@@ -9353,6 +11302,15 @@ index 76f9bb728def91744910d0b680b73e753f1a2b26..7f3887b0894aca0f972922f434382646
          }
  
          if (arraysetsorted.isEmpty()) {
+@@ -263,7 +313,7 @@ public abstract class ChunkMapDistance {
+         AsyncCatcher.catchOp("ChunkMapDistance::addPriorityTicket");
+         long pair = coords.pair();
+         PlayerChunk chunk = chunkMap.getUpdatingChunk(pair);
+-        boolean needsTicket = chunkMap.playerViewDistanceNoTickMap.getObjectsInRange(pair) != null && !hasPlayerTicket(coords, 33);
++        boolean needsTicket = false; // Tuinity - replace old loader system
+ 
+         if (needsTicket) {
+             Ticket<?> ticket = new Ticket<>(TicketType.PLAYER, 33, coords);
 @@ -370,6 +420,7 @@ public abstract class ChunkMapDistance {
      }
  
@@ -9361,7 +11319,7 @@ index 76f9bb728def91744910d0b680b73e753f1a2b26..7f3887b0894aca0f972922f434382646
          return (ArraySetSorted) this.tickets.computeIfAbsent(i, (j) -> {
              return ArraySetSorted.a(4);
          });
-@@ -387,6 +438,7 @@ public abstract class ChunkMapDistance {
+@@ -387,16 +438,18 @@ public abstract class ChunkMapDistance {
      }
  
      public void a(SectionPosition sectionposition, EntityPlayer entityplayer) {
@@ -9369,7 +11327,11 @@ index 76f9bb728def91744910d0b680b73e753f1a2b26..7f3887b0894aca0f972922f434382646
          long i = sectionposition.r().pair();
  
          ((ObjectSet) this.c.computeIfAbsent(i, (j) -> {
-@@ -397,6 +449,7 @@ public abstract class ChunkMapDistance {
+             return new ObjectOpenHashSet();
+         })).add(entityplayer);
+         //this.f.update(i, 0, true); // Paper - no longer used
+-        this.g.update(i, 0, true);
++        //this.g.update(i, 0, true); // Tuinity - no longer used
      }
  
      public void b(SectionPosition sectionposition, EntityPlayer entityplayer) {
@@ -9377,6 +11339,24 @@ index 76f9bb728def91744910d0b680b73e753f1a2b26..7f3887b0894aca0f972922f434382646
          long i = sectionposition.r().pair();
          ObjectSet<EntityPlayer> objectset = (ObjectSet) this.c.get(i);
          if (objectset == null) return; // CraftBukkit - SPIGOT-6208
+@@ -405,7 +458,7 @@ public abstract class ChunkMapDistance {
+         if (objectset == null || objectset.isEmpty()) { // Paper
+             this.c.remove(i);
+             //this.f.update(i, Integer.MAX_VALUE, false); // Paper - no longer used
+-            this.g.update(i, Integer.MAX_VALUE, false);
++            //this.g.update(i, Integer.MAX_VALUE, false); // Tuinity - no longer used
+         }
+ 
+     }
+@@ -424,7 +477,7 @@ public abstract class ChunkMapDistance {
+     }
+ 
+     protected void setNoTickViewDistance(int i) { // Paper - force abi breakage on usage change
+-        this.g.a(i);
++        throw new UnsupportedOperationException(); // Tuinity - no longer relevant
+     }
+ 
+     public int b() {
 @@ -447,6 +500,7 @@ public abstract class ChunkMapDistance {
  
      // CraftBukkit start
@@ -9385,8 +11365,24 @@ index 76f9bb728def91744910d0b680b73e753f1a2b26..7f3887b0894aca0f972922f434382646
          Ticket<T> target = new Ticket<>(ticketType, ticketLevel, ticketIdentifier);
  
          for (java.util.Iterator<Entry<ArraySetSorted<Ticket<?>>>> iterator = this.tickets.long2ObjectEntrySet().fastIterator(); iterator.hasNext();) {
+@@ -510,6 +564,7 @@ public abstract class ChunkMapDistance {
+         }
+     }
+ 
++    /* Tuinity - replace old loader system
+     class c extends ChunkMapDistance.b {
+ 
+         private int e = 0;
+@@ -724,6 +779,7 @@ public abstract class ChunkMapDistance {
+             return i <= this.e - 2;
+         }
+     }
++    */ // Tuinity - replace old loader system
+ 
+     class b extends ChunkMap {
+ 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..e26389d8d9ee4fedb32767fce3aed071af412304 100644
+index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..b55f7dece329dbb3ff27d57a39c32c69e5baea74 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -22,6 +22,12 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap; // Paper
@@ -9669,7 +11665,7 @@ index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..e26389d8d9ee4fedb32767fce3aed071
          this.world.getMethodProfiler().enter("purge");
          this.chunkMapDistance.purgeTickets();
          this.tickDistanceManager();
-@@ -734,7 +916,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -734,17 +916,18 @@ public class ChunkProviderServer extends IChunkProvider {
          this.world.getMethodProfiler().enter("purge");
          this.world.timings.doChunkMap.startTiming(); // Spigot
          this.chunkMapDistance.purgeTickets();
@@ -9678,7 +11674,10 @@ index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..e26389d8d9ee4fedb32767fce3aed071
          this.tickDistanceManager();
          this.world.timings.doChunkMap.stopTiming(); // Spigot
          this.world.getMethodProfiler().exitEnter("chunks");
-@@ -744,7 +926,7 @@ public class ChunkProviderServer extends IChunkProvider {
+         this.world.timings.chunks.startTiming(); // Paper - timings
++        this.playerChunkMap.playerChunkManager.tick(); // Tuinity - this is mostly is to account for view distance changes
+         this.tickChunks();
+         this.world.timings.chunks.stopTiming(); // Paper - timings
          this.world.timings.doChunkUnload.startTiming(); // Spigot
          this.world.getMethodProfiler().exitEnter("unload");
          this.playerChunkMap.unloadChunks(booleansupplier);
@@ -9687,7 +11686,16 @@ index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..e26389d8d9ee4fedb32767fce3aed071
          this.world.timings.doChunkUnload.stopTiming(); // Spigot
          this.world.getMethodProfiler().exit();
          this.clearCache();
-@@ -816,24 +998,30 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -809,31 +992,37 @@ public class ChunkProviderServer extends IChunkProvider {
+                 for (EntityPlayer player : this.world.players) {
+                     Arrays.fill(player.mobCounts, 0);
+                 }
+-                spawnercreature_d = SpawnerCreature.countMobs(l, this.world.A(), this::a, true);
++                spawnercreature_d = SpawnerCreature.countMobs(l, this.world.A(), this::a, true, this); // Tuinity
+             } else {
+-                spawnercreature_d = SpawnerCreature.countMobs(l, this.world.A(), this::a, false);
++                spawnercreature_d = SpawnerCreature.countMobs(l, this.world.A(), this::a, false, this); // Tuinity
+             }
              // Paper end
              this.world.timings.countNaturalMobs.stopTiming(); // Paper - timings
  
@@ -9726,7 +11734,7 @@ index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..e26389d8d9ee4fedb32767fce3aed071
                          ChunkCoordIntPair chunkcoordintpair = playerchunk.i();
  
                          if (!this.playerChunkMap.isOutsideOfRange(playerchunk, chunkcoordintpair, false)) { // Paper - optimise isOutsideOfRange
-@@ -845,11 +1033,15 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -845,11 +1034,15 @@ public class ChunkProviderServer extends IChunkProvider {
                              this.world.timings.chunkTicks.startTiming(); // Spigot // Paper
                              this.world.a(chunk, k);
                              this.world.timings.chunkTicks.stopTiming(); // Spigot // Paper
@@ -9744,7 +11752,7 @@ index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..e26389d8d9ee4fedb32767fce3aed071
              this.world.getMethodProfiler().enter("customSpawners");
              if (flag1) {
                  try (co.aikar.timings.Timing ignored = this.world.timings.miscMobSpawning.startTiming()) { // Paper - timings
-@@ -861,7 +1053,25 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -861,7 +1054,25 @@ public class ChunkProviderServer extends IChunkProvider {
              this.world.getMethodProfiler().exit();
          }
  
@@ -9770,7 +11778,7 @@ index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..e26389d8d9ee4fedb32767fce3aed071
      }
  
      private void a(long i, Consumer<Chunk> consumer) {
-@@ -1001,51 +1211,18 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -1001,51 +1212,19 @@ public class ChunkProviderServer extends IChunkProvider {
              ChunkProviderServer.this.world.getMethodProfiler().c("runTask");
              super.executeTask(runnable);
          }
@@ -9814,6 +11822,7 @@ index 0ea1b25bf98d71c251351807fa92d4d08eb6b06e..e26389d8d9ee4fedb32767fce3aed071
          @Override
          protected boolean executeNext() {
 +            com.tuinity.tuinity.util.TickThread.softEnsureTickThread("Cannot execute chunk tasks off-main thread");// Tuinity
++            ChunkProviderServer.this.playerChunkMap.playerChunkManager.tickMidTick(); // Tuinity
          // CraftBukkit start - process pending Chunk loadCallback() and unloadCallback() after each run task
          try {
              boolean execChunkTask = com.destroystokyo.paper.io.chunk.ChunkTaskManager.pollChunkWaitQueue() || ChunkProviderServer.this.world.asyncChunkTaskManager.pollNextChunkTask(); // Paper
@@ -10567,6 +12576,22 @@ index 8bc8dcf7dfe79c5522bc715ad60aeaab4b1d85da..675083e3952779e43bf8cc3175ad7045
              this.setCatType(10);
              this.setPersistent();
          }
+diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
+index 7289d6c706b6c845584bac616c9babea80f8e885..50b93c93cfede2d64a996a22b811994b352149af 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
++++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
+@@ -576,9 +576,9 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
+             if (this.deathAnimationTicks == 1 && !this.isSilent()) {
+                 // CraftBukkit start - Use relative location for far away sounds
+                 // this.world.b(1028, this.getChunkCoordinates(), 0);
+-                int viewDistance = ((WorldServer) this.world).getServer().getViewDistance() * 16; // Paper - updated to use worlds actual view distance incase we have to uncomment this due to removal of player view distance API
++                // int viewDistance = ((WorldServer) this.world).getServer().getViewDistance() * 16; // Paper - updated to use worlds actual view distance incase we have to uncomment this due to removal of player view distance API // Tuinity - apply view distance patch
+                 for (EntityPlayer player : (List<EntityPlayer>) ((WorldServer)world).getPlayers()) {
+-                    // final int viewDistance = player.getViewDistance(); // TODO apply view distance api patch
++                    final int viewDistance = player.getBukkitEntity().getViewDistance(); // Tuinity - apply view distance patch
+                     // Paper end
+                     double deltaX = this.locX() - player.locX();
+                     double deltaZ = this.locZ() - player.locZ();
 diff --git a/src/main/java/net/minecraft/server/EntityFireball.java b/src/main/java/net/minecraft/server/EntityFireball.java
 index 0840fdf3585407ec317f0326359619220c64db78..6b9b64539d2272070b523ed6b927de02d2b00af5 100644
 --- a/src/main/java/net/minecraft/server/EntityFireball.java
@@ -10659,6 +12684,21 @@ index 5dfb54e17fcfe6bd30e6b2a449944606e1a0ef17..9a8b7e06f14f17dfea08d7031c83f774
              // encode/decode from PacketPlayOutEntity
              x = MathHelper.floorLong(x * 4096.0D) * (1 / 4096.0D);
              y = MathHelper.floorLong(y * 4096.0D) * (1 / 4096.0D);
+diff --git a/src/main/java/net/minecraft/server/EntityLightning.java b/src/main/java/net/minecraft/server/EntityLightning.java
+index 5200b0396ee41edb42ff727c78cf3b5fce091d6b..239f504430b6c59923fd677d1be0121be5022604 100644
+--- a/src/main/java/net/minecraft/server/EntityLightning.java
++++ b/src/main/java/net/minecraft/server/EntityLightning.java
+@@ -61,8 +61,9 @@ public class EntityLightning extends Entity {
+             // CraftBukkit start - Use relative location for far away sounds
+             // this.world.playSound((EntityHuman) null, this.locX(), this.locY(), this.locZ(), SoundEffects.ENTITY_LIGHTNING_BOLT_THUNDER, SoundCategory.WEATHER, 10000.0F, 0.8F + this.random.nextFloat() * 0.2F);
+             float pitch = 0.8F + this.random.nextFloat() * 0.2F;
+-            int viewDistance = ((WorldServer) this.world).getServer().getViewDistance() * 16;
++            //int viewDistance = ((WorldServer) this.world).getServer().getViewDistance() * 16; // Tuinity - apply view distance patch
+             for (EntityPlayer player : (List<EntityPlayer>) (List) this.world.getPlayers()) {
++                final int viewDistance = player.getBukkitEntity().getViewDistance(); // Tuinity - apply view distance patch
+                 double deltaX = this.locX() - player.locX();
+                 double deltaZ = this.locZ() - player.locZ();
+                 double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
 index 9a79371b40803947ed5deef68c50d45683aaae52..d568db532de83a85d5c387121cec151c160f36bf 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
@@ -10701,9 +12741,18 @@ index 7636a51a7ef0aa05b5b2aaa9d17e7b551dedac96..480a02a8f6ec7110f9af8f2037fdc09a
  
          double d0 = this.locX() + vec3d.x;
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index d51925612bc3d37164a8e821833ef1721b6e6976..f40c24b6e2f7bea21d1cb2b58ed3da45ffcfc866 100644
+index d51925612bc3d37164a8e821833ef1721b6e6976..c086579073c785b3b7cd556bbb629b91560bd449 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -131,7 +131,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+ 
+     double lastEntitySpawnRadiusSquared; // Paper - optimise isOutsideRange, this field is in blocks
+ 
+-    boolean needsChunkCenterUpdate; // Paper - no-tick view distance
++    public boolean needsChunkCenterUpdate; // Paper - no-tick view distance // Tuinity - package-private -> public
+     public org.bukkit.event.player.PlayerQuitEvent.QuitReason quitReason = null; // Paper - there are a lot of changes to do if we change all methods leading to the event
+ 
+     public EntityPlayer(MinecraftServer minecraftserver, WorldServer worldserver, GameProfile gameprofile, PlayerInteractManager playerinteractmanager) {
 @@ -531,6 +531,185 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
                  }
              }
@@ -10955,6 +13004,22 @@ index f2a9396c2ec64c79391782249db7507f12a69a9e..2402c18e6a18221a43bea9fc68278da9
                          if ((!flag2 || !flag3) && !(this.tracker instanceof EntityArrow)) {
                              if (flag2) {
                                  packet1 = new PacketPlayOutEntity.PacketPlayOutRelEntityMove(this.tracker.getId(), (short) ((int) k), (short) ((int) l), (short) ((int) i1), this.tracker.isOnGround());
+diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
+index b1159f0258eca2bee52ec0939ba86792d24a1f99..3230c5454ccc39a2e3c89fdf8ca015cf7a15f380 100644
+--- a/src/main/java/net/minecraft/server/EntityWither.java
++++ b/src/main/java/net/minecraft/server/EntityWither.java
+@@ -214,9 +214,9 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
+                 if (!this.isSilent()) {
+                     // CraftBukkit start - Use relative location for far away sounds
+                     // this.world.b(1023, new BlockPosition(this), 0);
+-                    int viewDistance = ((WorldServer) this.world).getServer().getViewDistance() * 16; // Paper - updated to use worlds actual view distance incase we have to uncomment this due to removal of player view distance API
++                    //int viewDistance = ((WorldServer) this.world).getServer().getViewDistance() * 16; // Paper - updated to use worlds actual view distance incase we have to uncomment this due to removal of player view distance API // Tuinity - apply view distance patch
+                     for (EntityPlayer player : (List<EntityPlayer>)this.world.getPlayers()) {
+-                        // final int viewDistance = player.getViewDistance(); // TODO apply view distance api patch
++                        final int viewDistance = player.getBukkitEntity().getViewDistance(); // Tuinity - apply view distance patch
+                         double deltaX = this.locX() - player.locX();
+                         double deltaZ = this.locZ() - player.locZ();
+                         double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/net/minecraft/server/EnumDirection.java b/src/main/java/net/minecraft/server/EnumDirection.java
 index 05b0090ae36cf61f67e26aad478df30c89f31941..30ba21ac1bced18a9d0946b7c3ed55971ada48bb 100644
 --- a/src/main/java/net/minecraft/server/EnumDirection.java
@@ -11014,6 +13079,106 @@ index c4a83448ed4513f6e4ab179d1d43e5bb0cb13641..5ccf6b483fe15d4ad12ce2d3d11e9440
              Vec3D vec3d = raytrace1.b();
              Vec3D vec3d1 = raytrace1.a();
              VoxelShape voxelshape = raytrace1.a(iblockdata, this, blockposition);
+diff --git a/src/main/java/net/minecraft/server/IBlockDataHolder.java b/src/main/java/net/minecraft/server/IBlockDataHolder.java
+index b19c694cf01bc868dd7c4ec6432b613d19f2ca40..06d2dd7584253a406aa77867fac5543aa01020fd 100644
+--- a/src/main/java/net/minecraft/server/IBlockDataHolder.java
++++ b/src/main/java/net/minecraft/server/IBlockDataHolder.java
+@@ -39,11 +39,13 @@ public abstract class IBlockDataHolder<O, S> {
+     private final ImmutableMap<IBlockState<?>, Comparable<?>> b;
+     private Table<IBlockState<?>, Comparable<?>, S> e;
+     protected final MapCodec<S> d;
++    protected com.tuinity.tuinity.util.table.ZeroCollidingReferenceStateTable optimisedTable; // Tuinity - optimise state lookup
+ 
+     protected IBlockDataHolder(O o0, ImmutableMap<IBlockState<?>, Comparable<?>> immutablemap, MapCodec<S> mapcodec) {
+         this.c = o0;
+         this.b = immutablemap;
+         this.d = mapcodec;
++        this.optimisedTable = new com.tuinity.tuinity.util.table.ZeroCollidingReferenceStateTable(this, immutablemap); // Tuinity - optimise state lookup
+     }
+ 
+     public <T extends Comparable<T>> S a(IBlockState<T> iblockstate) {
+@@ -85,11 +87,11 @@ public abstract class IBlockDataHolder<O, S> {
+ 
+     public <T extends Comparable<T>> boolean contains(IBlockState<T> iblockstate) { return this.b(iblockstate); } // Paper - OBFHELPER
+     public <T extends Comparable<T>> boolean b(IBlockState<T> iblockstate) {
+-        return this.b.containsKey(iblockstate);
++        return this.optimisedTable.get(iblockstate) != null; // Tuinity - optimise state lookup
+     }
+ 
+     public <T extends Comparable<T>> T get(IBlockState<T> iblockstate) {
+-        Comparable<?> comparable = (Comparable) this.b.get(iblockstate);
++        final Comparable<?> comparable = this.optimisedTable.get(iblockstate); // Tuinity - optimise state lookup
+ 
+         if (comparable == null) {
+             throw new IllegalArgumentException("Cannot get property " + iblockstate + " as it does not exist in " + this.c);
+@@ -99,27 +101,21 @@ public abstract class IBlockDataHolder<O, S> {
+     }
+ 
+     public <T extends Comparable<T>> Optional<T> d(IBlockState<T> iblockstate) {
+-        Comparable<?> comparable = (Comparable) this.b.get(iblockstate);
++        final Comparable<?> comparable = this.optimisedTable.get(iblockstate); // Tuinity - optimise state lookup
+ 
+         return comparable == null ? Optional.empty() : Optional.of(iblockstate.getType().cast(comparable));
+     }
+ 
+     public <T extends Comparable<T>, V extends T> S set(IBlockState<T> iblockstate, V v0) {
+-        Comparable<?> comparable = (Comparable) this.b.get(iblockstate);
++        // Tuinity start - optimise state lookup
++        final S ret = (S)this.optimisedTable.get(iblockstate, v0);
+ 
+-        if (comparable == null) {
+-            throw new IllegalArgumentException("Cannot set property " + iblockstate + " as it does not exist in " + this.c);
+-        } else if (comparable == v0) {
+-            return (S) this; // Paper - decompile error
+-        } else {
+-            S s0 = this.e.get(iblockstate, v0);
+-
+-            if (s0 == null) {
+-                throw new IllegalArgumentException("Cannot set property " + iblockstate + " to " + v0 + " on " + this.c + ", it is not an allowed value");
+-            } else {
+-                return s0;
+-            }
++        if (ret == null) {
++            throw new IllegalArgumentException("Cannot set property " + iblockstate + " to " + v0 + " on " + this.c + ", it is not an allowed value");
+         }
++
++        return ret;
++        // Tuinity end - optimise state lookup
+     }
+ 
+     public void a(Map<Map<IBlockState<?>, Comparable<?>>, S> map) {
+@@ -143,7 +139,8 @@ public abstract class IBlockDataHolder<O, S> {
+                 }
+             }
+ 
+-            this.e = (Table) (table.isEmpty() ? table : ArrayTable.create(table));
++            this.e = (Table) (table.isEmpty() ? table : ArrayTable.create(table)); this.optimisedTable.loadInTable((Table)this.e, this.b); // Tuinity - optimise state lookup
++
+         }
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/IBlockState.java b/src/main/java/net/minecraft/server/IBlockState.java
+index 6550b55067db31dbbc903fe17a13849383651c5a..30344d1e5703690d97ecb889af24fa5e7b35f895 100644
+--- a/src/main/java/net/minecraft/server/IBlockState.java
++++ b/src/main/java/net/minecraft/server/IBlockState.java
+@@ -15,6 +15,17 @@ public abstract class IBlockState<T extends Comparable<T>> {
+     private final Codec<T> d;
+     private final Codec<IBlockState.a<T>> e;
+ 
++    // Tuinity start - optimise iblockdata state lookup
++    private static final java.util.concurrent.atomic.AtomicInteger ID_GENERATOR = new java.util.concurrent.atomic.AtomicInteger();
++    private final int id = ID_GENERATOR.getAndIncrement();
++
++    public final int getId() {
++        return this.id;
++    }
++
++    public abstract int getIdFor(final T value);
++    // Tuinity end - optimise state lookup
++
+     protected IBlockState(String s, Class<T> oclass) {
+         this.d = Codec.STRING.comapFlatMap((s1) -> this.b(s1).map(DataResult::success).orElseGet(() -> { // Paper - decompile error
+             return DataResult.error("Unable to read property: " + this + " with value: " + s1);
 diff --git a/src/main/java/net/minecraft/server/IChunkAccess.java b/src/main/java/net/minecraft/server/IChunkAccess.java
 index 180b6b58dc5663158db84b6f1257591439b48c31..eb0d794b7275af7f860e7c7b85a9e3b2aa4a863f 100644
 --- a/src/main/java/net/minecraft/server/IChunkAccess.java
@@ -11236,6 +13401,22 @@ index bbc089b41fcbe0141f13591db2cb44b9e688cac4..dc9f2a1a132b3a7925bd62aa1da0512a
          MovingObjectPosition.EnumMovingObjectType movingobjectposition_enummovingobjecttype = movingobjectposition.getType();
  
          if (movingobjectposition_enummovingobjecttype == MovingObjectPosition.EnumMovingObjectType.ENTITY) {
+diff --git a/src/main/java/net/minecraft/server/ItemEnderEye.java b/src/main/java/net/minecraft/server/ItemEnderEye.java
+index 3296d888a66e8d0ad861ed093cd62b0d2da6ff0b..bc6e2d7dda6c85e89967d06649558aafd8f2624b 100644
+--- a/src/main/java/net/minecraft/server/ItemEnderEye.java
++++ b/src/main/java/net/minecraft/server/ItemEnderEye.java
+@@ -36,9 +36,10 @@ public class ItemEnderEye extends Item {
+ 
+                     // CraftBukkit start - Use relative location for far away sounds
+                     // world.b(1038, blockposition1.b(1, 0, 1), 0);
+-                    int viewDistance = world.getServer().getViewDistance() * 16;
++                    //int viewDistance = world.getServer().getViewDistance() * 16; // Tuinity - apply view distance patch
+                     BlockPosition soundPos = blockposition1.b(1, 0, 1);
+                     for (EntityPlayer player : world.getServer().getServer().getPlayerList().players) {
++                        final int viewDistance = player.getBukkitEntity().getViewDistance(); // Tuinity - apply view distance patch
+                         double deltaX = soundPos.getX() - player.locX();
+                         double deltaZ = soundPos.getZ() - player.locZ();
+                         double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/net/minecraft/server/LightEngineGraphSection.java b/src/main/java/net/minecraft/server/LightEngineGraphSection.java
 index 13d067f48647dea63ef1bf3a2a3e0868074ba75f..04afd7f285db2f281a038e0be6f557b8a692936b 100644
 --- a/src/main/java/net/minecraft/server/LightEngineGraphSection.java
@@ -11717,7 +13898,7 @@ index 6be12b7ae8501c22a7c544638c44fc6faedd5b07..2b4ac8d1f3218e89b73fb9e1d3eed8cb
              throw new IllegalStateException("Protocol error", cryptographyexception);
          }
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index ff74be14512a947e81b62d53e616131ca7d7f609..e79e773f2219f9a9ae076fcbc8108b792201b11a 100644
+index ff74be14512a947e81b62d53e616131ca7d7f609..7438ed7671acb181fe88abd2db415cb09873db4f 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -38,6 +38,7 @@ import java.util.function.Consumer;
@@ -11792,8 +13973,17 @@ index ff74be14512a947e81b62d53e616131ca7d7f609..e79e773f2219f9a9ae076fcbc8108b79
      // assumes the sets have the same comparator, and if this comparator is null then assume T is Comparable
      public static <T> void mergeSortedSets(final java.util.function.Consumer<T> consumer, final java.util.Comparator<? super T> comparator, final java.util.SortedSet<T>...sets) {
          final ObjectRBTreeSet<T> all = new ObjectRBTreeSet<>(comparator);
+@@ -622,7 +680,7 @@ public final class MCUtil {
+ 
+             worldData.addProperty("name", world.getWorld().getName());
+             worldData.addProperty("view-distance", world.getChunkProvider().playerChunkMap.getEffectiveViewDistance());
+-            worldData.addProperty("no-view-distance", world.getChunkProvider().playerChunkMap.getRawNoTickViewDistance());
++            worldData.addProperty("no-view-distance", world.getChunkProvider().playerChunkMap.playerChunkManager.getTargetNoTickViewDistance()); // Tuinity - replace old player chunk management
+             worldData.addProperty("keep-spawn-loaded", world.keepSpawnInMemory);
+             worldData.addProperty("keep-spawn-loaded-range", world.paperConfig.keepLoadedRange);
+             worldData.addProperty("visible-chunk-count", visibleChunks.size());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c572ef2830f2653e2b30622bbac0a3b072bacd7a..7ac34a8959a797bf2af96f3f402fa65cffe3d666 100644
+index c572ef2830f2653e2b30622bbac0a3b072bacd7a..afc22e545df03a38c801362d308d135df90361e2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -155,6 +155,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -11998,7 +14188,7 @@ index c572ef2830f2653e2b30622bbac0a3b072bacd7a..7ac34a8959a797bf2af96f3f402fa65c
          MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
          // Send time updates to everyone, it will get the right time from the world the player is in.
          // Paper start - optimize time updates
-@@ -1359,11 +1421,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1359,11 +1421,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.methodProfiler.enter("tick");
  
              try {
@@ -12006,14 +14196,18 @@ index c572ef2830f2653e2b30622bbac0a3b072bacd7a..7ac34a8959a797bf2af96f3f402fa65c
 +                // Tuinity - replace logic
                  worldserver.timings.doTick.startTiming(); // Spigot
                  worldserver.doTick(booleansupplier);
-+                worldserver.getChunkProvider().playerChunkMap.dataRegionManager.recalculateRegions(); // Tuinity
++                // Tuinity start
++                for (final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager regionManager : worldserver.getChunkProvider().playerChunkMap.regionManagers) {
++                    regionManager.recalculateRegions();
++                }
++                // Tuinity end
                  worldserver.timings.doTick.stopTiming(); // Spigot
 -                midTickLoadChunks(); // Paper
 +                // Tuinity - replace logic
              } catch (Throwable throwable) {
                  // Spigot Start
                  CrashReport crashreport;
-@@ -1457,7 +1520,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1457,7 +1524,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {
@@ -12023,9 +14217,18 @@ index c572ef2830f2653e2b30622bbac0a3b072bacd7a..7ac34a8959a797bf2af96f3f402fa65c
  
      public CrashReport b(CrashReport crashreport) {
 diff --git a/src/main/java/net/minecraft/server/NavigationAbstract.java b/src/main/java/net/minecraft/server/NavigationAbstract.java
-index 1558c5f8256f50be6850f1d7f70eee3e8ec76496..b92ca4a6de01f3f86367fb8dfe3591b08a3e9218 100644
+index 1558c5f8256f50be6850f1d7f70eee3e8ec76496..6aec5098d346c1b7498fd8b800154cd31ce08a97 100644
 --- a/src/main/java/net/minecraft/server/NavigationAbstract.java
 +++ b/src/main/java/net/minecraft/server/NavigationAbstract.java
+@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
+ 
+ public abstract class NavigationAbstract {
+ 
+-    protected final EntityInsentient a; public Entity getEntity() { return a; } // Paper - OBFHELPER
++    protected final EntityInsentient a; public final EntityInsentient getEntity() { return a; } // Paper - OBFHELPER // Tuinity - match types
+     protected final World b;
+     @Nullable
+     protected PathEntity c; protected final PathEntity getCurrentPath() { return this.c; } // Paper - OBFHELPER
 @@ -21,7 +21,7 @@ public abstract class NavigationAbstract {
      protected long j;
      protected double k;
@@ -12049,15 +14252,6 @@ index 1558c5f8256f50be6850f1d7f70eee3e8ec76496..b92ca4a6de01f3f86367fb8dfe3591b0
      public NavigationAbstract(EntityInsentient entityinsentient, World world) {
          this.g = Vec3D.ORIGIN;
          this.h = BaseBlockPosition.ZERO;
-@@ -85,7 +92,7 @@ public abstract class NavigationAbstract {
- 
-     @Nullable
-     public PathEntity a(Stream<BlockPosition> stream, int i) {
--        return this.a((Set) stream.collect(Collectors.toSet()), 8, false, i);
-+        return this.a((Set) stream.collect(Collectors.toSet()), 8, false, i); // Tuinity - diff on change, inlined into SensorNearestBed
-     }
- 
-     @Nullable
 @@ -393,7 +400,7 @@ public abstract class NavigationAbstract {
      }
  
@@ -12068,7 +14262,7 @@ index 1558c5f8256f50be6850f1d7f70eee3e8ec76496..b92ca4a6de01f3f86367fb8dfe3591b0
              Vec3D vec3d = new Vec3D(((double) pathpoint.a + this.a.locX()) / 2.0D, ((double) pathpoint.b + this.a.locY()) / 2.0D, ((double) pathpoint.c + this.a.locZ()) / 2.0D);
  
 diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
-index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e03941173565074ea0e 100644
+index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..d93634391501da01cb1afe70fedd5247c654e8fc 100644
 --- a/src/main/java/net/minecraft/server/NetworkManager.java
 +++ b/src/main/java/net/minecraft/server/NetworkManager.java
 @@ -27,6 +27,8 @@ import org.apache.logging.log4j.Logger;
@@ -12080,7 +14274,7 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
  public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
  
      private static final Logger LOGGER = LogManager.getLogger();
-@@ -71,6 +73,39 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -71,6 +73,61 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
      EnumProtocol protocol;
      // Paper end
  
@@ -12116,11 +14310,33 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
 +        }
 +    }
 +    // Tuinity end - allow controlled flushing
++    // Tuinity start - add pending task queue
++    private final Queue<Runnable> pendingTasks = new java.util.concurrent.ConcurrentLinkedQueue<>();
++    public void execute(final Runnable run) {
++        if (!this.channel.isRegistered()) {
++            run.run();
++            return;
++        }
++        final boolean queue = !this.packetQueue.isEmpty();
++        if (!queue) {
++            this.channel.eventLoop().execute(run);
++        } else {
++            this.pendingTasks.add(run);
++            if (this.packetQueue.isEmpty()) {
++                // something flushed async, dump tasks now
++                Runnable r;
++                while ((r = this.pendingTasks.poll()) != null) {
++                    this.channel.eventLoop().execute(r);
++                }
++            }
++        }
++    }
++    // Tuinity end - add pending task queue
 +
      public NetworkManager(EnumProtocolDirection enumprotocoldirection) {
          this.h = enumprotocoldirection;
      }
-@@ -145,8 +180,63 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -145,8 +202,63 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
          if (MinecraftServer.getServer().isDebugging()) throwable.printStackTrace(); // Spigot
      }
  
@@ -12184,7 +14400,7 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
              try {
                  a(packet, this.packetListener);
              } catch (CancelledPacketHandleException cancelledpackethandleexception) {
-@@ -222,7 +312,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -222,7 +334,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
              MCUtil.isMainThread() && packet.isReady() && this.packetQueue.isEmpty() &&
              (packet.getExtraPackets() == null || packet.getExtraPackets().isEmpty())
          ))) {
@@ -12193,7 +14409,7 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
              return;
          }
          // write the packets to the queue, then flush - antixray hooks there already
-@@ -248,6 +338,14 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -248,6 +360,14 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
  
      private void dispatchPacket(Packet<?> packet, @Nullable GenericFutureListener<? extends Future<? super Void>> genericFutureListener) { this.b(packet, genericFutureListener); } // Paper - OBFHELPER
      private void b(Packet<?> packet, @Nullable GenericFutureListener<? extends Future<? super Void>> genericfuturelistener) {
@@ -12208,7 +14424,7 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
          EnumProtocol enumprotocol = EnumProtocol.a(packet);
          EnumProtocol enumprotocol1 = (EnumProtocol) this.channel.attr(NetworkManager.c).get();
  
-@@ -270,7 +368,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -270,7 +390,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
              try {
                  // Paper end
  
@@ -12217,7 +14433,7 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
  
              if (genericfuturelistener != null) {
                  channelfuture.addListener(genericfuturelistener);
-@@ -290,39 +388,83 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -290,39 +410,83 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
              }
              // Paper end
          } else {
@@ -12331,16 +14547,18 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
          }
  
      }
-@@ -345,6 +487,8 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -344,7 +508,10 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+         return false;
      }
      private boolean processQueue() {
++        try { // Tuinity - add pending task queue
          if (this.packetQueue.isEmpty()) return true;
 +        final boolean needsFlush = this.canFlush; // Tuinity - make only one flush call per sendPacketQueue() call
 +        boolean hasWrotePacket = false;
          // If we are on main, we are safe here in that nothing else should be processing queue off main anymore
          // But if we are not on main due to login/status, the parent is synchronized on packetQueue
          java.util.Iterator<QueuedPacket> iterator = this.packetQueue.iterator();
-@@ -352,16 +496,22 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -352,19 +519,31 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
              NetworkManager.QueuedPacket queued = iterator.next(); // poll -> peek
  
              // Fix NPE (Spigot bug caused by handleDisconnection())
@@ -12365,7 +14583,16 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
              }
          }
          return true;
-@@ -387,7 +537,14 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
++        } finally { // Tuinity start - add pending task queue
++            Runnable r;
++            while ((r = this.pendingTasks.poll()) != null) {
++                this.channel.eventLoop().execute(r);
++            }
++        } // Tuinity end - add pending task queue
+     }
+     // Paper end
+ 
+@@ -387,7 +566,14 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
          }
  
          if (this.packetListener instanceof PlayerConnection) {
@@ -12380,7 +14607,7 @@ index fb1e3c705b8abee13695762cdfd0e9f1bfdb5ad8..65de374d485f31f8cd6f4e0394117356
          }
  
          if (this.channel != null) {
-@@ -438,10 +595,16 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -438,10 +624,16 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
          return this.channel instanceof LocalChannel || this.channel instanceof LocalServerChannel;
      }
  
@@ -12927,28 +15154,6 @@ index fb37f5b500c52f915b4536e5ec35552b75056046..52a2d3db7da3596bfdd6fd51147cc93b
      private final float y;
  
      private PathType(float f) {
-diff --git a/src/main/java/net/minecraft/server/PathfinderGoalMoveThroughVillage.java b/src/main/java/net/minecraft/server/PathfinderGoalMoveThroughVillage.java
-index 475c0764b97b056f17720f37b1ca3eb1a2375334..9f48d476c05dbeabbfe3c650ce4ad33ec691a56a 100644
---- a/src/main/java/net/minecraft/server/PathfinderGoalMoveThroughVillage.java
-+++ b/src/main/java/net/minecraft/server/PathfinderGoalMoveThroughVillage.java
-@@ -50,7 +50,7 @@ public class PathfinderGoalMoveThroughVillage extends PathfinderGoal {
-                         if (!worldserver.a_(blockposition1)) {
-                             return Double.NEGATIVE_INFINITY;
-                         } else {
--                            Optional<BlockPosition> optional = worldserver.y().c(VillagePlaceType.b, this::a, blockposition1, 10, VillagePlace.Occupancy.IS_OCCUPIED);
-+                            Optional<BlockPosition> optional = Optional.ofNullable(BehaviorFindPosition.findAnyFirstPoi(worldserver.y(), VillagePlaceType.b, this::a, blockposition1, 10, VillagePlace.Occupancy.IS_OCCUPIED)); // Tuinity - remove streams here
- 
-                             return !optional.isPresent() ? Double.NEGATIVE_INFINITY : -((BlockPosition) optional.get()).j(blockposition);
-                         }
-@@ -59,7 +59,7 @@ public class PathfinderGoalMoveThroughVillage extends PathfinderGoal {
-                     if (vec3d == null) {
-                         return false;
-                     } else {
--                        Optional<BlockPosition> optional = worldserver.y().c(VillagePlaceType.b, this::a, new BlockPosition(vec3d), 10, VillagePlace.Occupancy.IS_OCCUPIED);
-+                        Optional<BlockPosition> optional = Optional.ofNullable(BehaviorFindPosition.findAnyFirstPoi(worldserver.y(), VillagePlaceType.b, this::a, new BlockPosition(vec3d), 10, VillagePlace.Occupancy.IS_OCCUPIED)); // Tuinity - remove streams here
- 
-                         if (!optional.isPresent()) {
-                             return false;
 diff --git a/src/main/java/net/minecraft/server/PathfinderNormal.java b/src/main/java/net/minecraft/server/PathfinderNormal.java
 index 74e81e1e4aea6f74b14a84231ddeb7f2fb845ae7..33804e68931e8b4145b896eedeab79bde78779f2 100644
 --- a/src/main/java/net/minecraft/server/PathfinderNormal.java
@@ -13043,10 +15248,18 @@ index 253377c6238594de1f76cafcbf8223592e4d3f6b..3ebe3d0dc4c2c6aee6ea349006a74cbe
          if (entityliving == entityliving1) {
              return false;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac87b7f4fa0 100644
+index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..dcf13e62264f97384fb2f6c30cbc183a63cf3f97 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
-@@ -56,6 +56,12 @@ public class PlayerChunk {
+@@ -3,6 +3,7 @@ package net.minecraft.server;
+ import com.mojang.datafixers.util.Either;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap; // Paper
+ import it.unimi.dsi.fastutil.shorts.ShortArraySet;
++import it.unimi.dsi.fastutil.shorts.ShortOpenHashSet; // Tuinity
+ import it.unimi.dsi.fastutil.shorts.ShortSet;
+ import java.util.List;
+ import java.util.Optional;
+@@ -56,6 +57,12 @@ public class PlayerChunk {
          long key = net.minecraft.server.MCUtil.getCoordinateKey(this.location);
          this.playersInMobSpawnRange = this.chunkMap.playerMobSpawnMap.getObjectsInRange(key);
          this.playersInChunkTickRange = this.chunkMap.playerChunkTickRangeMap.getObjectsInRange(key);
@@ -13059,7 +15272,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
      }
      // Paper end - optimise isOutsideOfRange
      // Paper start - optimize chunk status progression without jumping through thread pool
-@@ -366,7 +372,7 @@ public class PlayerChunk {
+@@ -366,13 +373,13 @@ public class PlayerChunk {
          if (!blockposition.isValidLocation()) return; // Paper - SPIGOT-6086 for all invalid locations; avoid acquiring locks
          Chunk chunk = this.getSendingChunk(); // Paper - no-tick view distance
  
@@ -13068,7 +15281,14 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
              byte b0 = (byte) SectionPosition.a(blockposition.getY());
  
              if (b0 < 0 || b0 >= this.dirtyBlocks.length) return; // CraftBukkit - SPIGOT-6086, SPIGOT-6296
-@@ -381,13 +387,14 @@ public class PlayerChunk {
+             if (this.dirtyBlocks[b0] == null) {
+                 this.p = true;
+-                this.dirtyBlocks[b0] = new ShortArraySet();
++                this.dirtyBlocks[b0] = new ShortOpenHashSet(); // Tuinity - use a set to make setting constant-time
+             }
+ 
+             this.dirtyBlocks[b0].add(SectionPosition.b(blockposition));
+@@ -381,13 +388,14 @@ public class PlayerChunk {
  
      public void a(EnumSkyBlock enumskyblock, int i) {
          Chunk chunk = this.getSendingChunk(); // Paper - no-tick view distance
@@ -13085,7 +15305,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
              }
  
          }
-@@ -425,7 +432,7 @@ public class PlayerChunk {
+@@ -425,7 +433,7 @@ public class PlayerChunk {
                          this.a(world, blockposition, iblockdata);
                      } else {
                          ChunkSection chunksection = chunk.getSections()[sectionposition.getY()];
@@ -13094,7 +15314,32 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
                          PacketPlayOutMultiBlockChange packetplayoutmultiblockchange = new PacketPlayOutMultiBlockChange(sectionposition, shortset, chunksection, this.x);
  
                          this.a(packetplayoutmultiblockchange, false);
-@@ -508,6 +515,7 @@ public class PlayerChunk {
+@@ -467,7 +475,7 @@ public class PlayerChunk {
+         // Paper start - per player view distance
+         // there can be potential desync with player's last mapped section and the view distance map, so use the
+         // view distance map here.
+-        com.destroystokyo.paper.util.misc.PlayerAreaMap viewDistanceMap = this.chunkMap.playerViewDistanceBroadcastMap;
++        com.destroystokyo.paper.util.misc.PlayerAreaMap viewDistanceMap = this.chunkMap.playerChunkManager.broadcastMap; // Tuinity - replace old player chunk manager
+         com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> players = viewDistanceMap.getObjectsInRange(this.location);
+         if (players == null) {
+             return;
+@@ -481,6 +489,7 @@ public class PlayerChunk {
+                     continue;
+                 }
+                 EntityPlayer player = (EntityPlayer)temp;
++                if (!this.chunkMap.playerChunkManager.isChunkSent(player, this.location.x, this.location.z)) continue; // Tuinity - replace player chunk management
+ 
+                 int viewDistance = viewDistanceMap.getLastViewDistance(player);
+                 long lastPosition = viewDistanceMap.getLastCoordinate(player);
+@@ -500,6 +509,7 @@ public class PlayerChunk {
+                     continue;
+                 }
+                 EntityPlayer player = (EntityPlayer)temp;
++                if (!this.chunkMap.playerChunkManager.isChunkSent(player, this.location.x, this.location.z)) continue; // Tuinity - replace player chunk management
+                 player.playerConnection.sendPacket(packet);
+             }
+         }
+@@ -508,6 +518,7 @@ public class PlayerChunk {
          // Paper end - per player view distance
      }
  
@@ -13102,7 +15347,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> a(ChunkStatus chunkstatus, PlayerChunkMap playerchunkmap) {
          int i = chunkstatus.c();
          CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> completablefuture = (CompletableFuture) this.statusFutures.get(i);
-@@ -563,6 +571,7 @@ public class PlayerChunk {
+@@ -563,6 +574,7 @@ public class PlayerChunk {
      }
  
      protected void a(PlayerChunkMap playerchunkmap) {
@@ -13110,7 +15355,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
          ChunkStatus chunkstatus = getChunkStatus(this.oldTicketLevel);
          ChunkStatus chunkstatus1 = getChunkStatus(this.ticketLevel);
          boolean flag = this.oldTicketLevel <= PlayerChunkMap.GOLDEN_TICKET;
-@@ -572,7 +581,8 @@ public class PlayerChunk {
+@@ -572,7 +584,8 @@ public class PlayerChunk {
          // CraftBukkit start
          // ChunkUnloadEvent: Called before the chunk is unloaded: isChunkLoaded is still true and chunk can still be modified by plugins.
          if (playerchunk_state.isAtLeast(PlayerChunk.State.BORDER) && !playerchunk_state1.isAtLeast(PlayerChunk.State.BORDER)) {
@@ -13120,7 +15365,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
                  Chunk chunk = (Chunk)either.left().orElse(null);
                  if (chunk != null) {
                      playerchunkmap.callbackExecutor.execute(() -> {
-@@ -637,7 +647,8 @@ public class PlayerChunk {
+@@ -637,7 +650,8 @@ public class PlayerChunk {
          if (!flag2 && flag3) {
              // Paper start - cache ticking ready status
              int expectCreateCount = ++this.fullChunkCreateCount;
@@ -13130,7 +15375,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
                  if (either.left().isPresent() && PlayerChunk.this.fullChunkCreateCount == expectCreateCount) {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      Chunk fullChunk = either.left().get();
-@@ -668,7 +679,8 @@ public class PlayerChunk {
+@@ -668,7 +682,8 @@ public class PlayerChunk {
  
          if (!flag4 && flag5) {
              // Paper start - cache ticking ready status
@@ -13140,7 +15385,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
                  if (either.left().isPresent()) {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      Chunk tickingChunk = either.left().get();
-@@ -678,6 +690,9 @@ public class PlayerChunk {
+@@ -678,6 +693,9 @@ public class PlayerChunk {
                      // Paper start - rewrite ticklistserver
                      PlayerChunk.this.chunkMap.world.onChunkSetTicking(PlayerChunk.this.location.x, PlayerChunk.this.location.z);
                      // Paper end - rewrite ticklistserver
@@ -13150,7 +15395,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
  
                  }
              });
-@@ -688,6 +703,12 @@ public class PlayerChunk {
+@@ -688,6 +706,12 @@ public class PlayerChunk {
          if (flag4 && !flag5) {
              this.tickingFuture.complete(PlayerChunk.UNLOADED_CHUNK); this.isTickingReady = false; // Paper - cache chunk ticking stage
              this.tickingFuture = PlayerChunk.UNLOADED_CHUNK_FUTURE;
@@ -13163,7 +15408,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
          }
  
          boolean flag6 = playerchunk_state.isAtLeast(PlayerChunk.State.ENTITY_TICKING);
-@@ -699,13 +720,16 @@ public class PlayerChunk {
+@@ -699,13 +723,16 @@ public class PlayerChunk {
              }
  
              // Paper start - cache ticking ready status
@@ -13182,7 +15427,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
  
  
                  }
-@@ -717,6 +741,12 @@ public class PlayerChunk {
+@@ -717,6 +744,12 @@ public class PlayerChunk {
          if (flag6 && !flag7) {
              this.entityTickingFuture.complete(PlayerChunk.UNLOADED_CHUNK); this.isEntityTickingReady = false; // Paper - cache chunk ticking stage
              this.entityTickingFuture = PlayerChunk.UNLOADED_CHUNK_FUTURE;
@@ -13195,7 +15440,7 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
          }
  
          // Paper start - raise IO/load priority if priority changes, use our preferred priority
-@@ -742,7 +772,8 @@ public class PlayerChunk {
+@@ -742,7 +775,8 @@ public class PlayerChunk {
          // CraftBukkit start
          // ChunkLoadEvent: Called after the chunk is loaded: isChunkLoaded returns true and chunk is ready to be modified by plugins.
          if (!playerchunk_state.isAtLeast(PlayerChunk.State.BORDER) && playerchunk_state1.isAtLeast(PlayerChunk.State.BORDER)) {
@@ -13206,10 +15451,18 @@ index 904c6a7d0a36b57bb4f693fc4fd0dd5b17adcbac..3127fc9dd87e82243e167862cae83ac8
                  if (chunk != null) {
                      playerchunkmap.callbackExecutor.execute(() -> {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f974812be7152 100644
+index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..3e0bf6df7c4608a5b19024612db52558fd722f4b 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -122,31 +122,28 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
+ import java.util.stream.Stream;
+ import javax.annotation.Nullable;
+ import it.unimi.dsi.fastutil.objects.ObjectRBTreeSet; // Paper
++import it.unimi.dsi.fastutil.objects.Reference2BooleanOpenHashMap; // Tuinity
+ import org.apache.commons.lang3.mutable.MutableBoolean;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+@@ -122,31 +123,28 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      // CraftBukkit start - recursion-safe executor for Chunk loadCallback() and unloadCallback()
      public final CallbackExecutor callbackExecutor = new CallbackExecutor();
      public static final class CallbackExecutor implements java.util.concurrent.Executor, Runnable {
@@ -13252,9 +15505,25 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
                  task.run();
              }
          }
-@@ -199,8 +196,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-     public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerViewDistanceTickMap;
-     public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerViewDistanceNoTickMap;
+@@ -184,23 +182,17 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerChunkTickRangeMap;
+     // Paper end - optimise PlayerChunkMap#isOutsideRange
+     // Paper start - no-tick view distance
+-    int noTickViewDistance;
+-    public final int getRawNoTickViewDistance() {
+-        return this.noTickViewDistance;
+-    }
+-    public final int getEffectiveNoTickViewDistance() {
+-        return this.noTickViewDistance == -1 ? this.getEffectiveViewDistance() : this.noTickViewDistance;
+-    }
+-    public final int getLoadViewDistance() {
+-        return Math.max(this.getEffectiveViewDistance(), this.getEffectiveNoTickViewDistance());
+-    }
+-
+-    public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerViewDistanceBroadcastMap;
+-    public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerViewDistanceTickMap;
+-    public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerViewDistanceNoTickMap;
++    public final com.tuinity.tuinity.chunk.PlayerChunkLoader playerChunkManager = new com.tuinity.tuinity.chunk.PlayerChunkLoader(this, this.pooledLinkedPlayerHashSets); // Tuinity - replace chunk loader
      // Paper end - no-tick view distance
 +    // Tuinity start - optimise checkDespawn
 +    public static final int GENERAL_AREA_MAP_SQUARE_RADIUS = 38;
@@ -13268,9 +15537,30 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
          int chunkX = MCUtil.getChunkCoordinate(player.locX());
          int chunkZ = MCUtil.getChunkCoordinate(player.locZ());
          // Note: players need to be explicitly added to distance maps before they can be updated
-@@ -228,9 +232,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-         this.playerViewDistanceBroadcastMap.add(player, chunkX, chunkZ, effectiveNoTickViewDistance + 1); // clients need an extra neighbour to render the full view distance configured
-         player.needsChunkCenterUpdate = false;
+@@ -209,28 +201,22 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             com.destroystokyo.paper.util.misc.PlayerAreaMap trackMap = this.playerEntityTrackerTrackMaps[i];
+             int trackRange = this.entityTrackerTrackRanges[i];
+ 
+-            trackMap.add(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveViewDistance()));
++            trackMap.add(player, chunkX, chunkZ, Math.min(trackRange, player.getBukkitEntity().getViewDistance())); // Tuinity - per player view distances
+         }
+         // Paper end - use distance map to optimise entity tracker
+         // Paper start - optimise PlayerChunkMap#isOutsideRange
+         this.playerChunkTickRangeMap.add(player, chunkX, chunkZ, ChunkMapDistance.MOB_SPAWN_RANGE);
+         // Paper end - optimise PlayerChunkMap#isOutsideRange
+         // Paper start - no-tick view distance
+-        int effectiveTickViewDistance = this.getEffectiveViewDistance();
+-        int effectiveNoTickViewDistance = Math.max(this.getEffectiveNoTickViewDistance(), effectiveTickViewDistance);
+-
+-        if (!this.cannotLoadChunks(player)) {
+-            this.playerViewDistanceTickMap.add(player, chunkX, chunkZ, effectiveTickViewDistance);
+-            this.playerViewDistanceNoTickMap.add(player, chunkX, chunkZ, effectiveNoTickViewDistance + 2); // clients need chunk 1 neighbour, and we need another 1 for sending those extra neighbours (as we require neighbours to send)
+-        }
+-
+-        player.needsChunkCenterUpdate = true;
+-        this.playerViewDistanceBroadcastMap.add(player, chunkX, chunkZ, effectiveNoTickViewDistance + 1); // clients need an extra neighbour to render the full view distance configured
+-        player.needsChunkCenterUpdate = false;
++        this.playerChunkManager.addPlayer(player); // Tuinity - replace chunk loader
          // Paper end - no-tick view distance
 +        // Tuinity start - optimise checkDespawn
 +        this.playerGeneralAreaMap.add(player, chunkX, chunkZ, GENERAL_AREA_MAP_SQUARE_RADIUS);
@@ -13282,9 +15572,14 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
          // Paper start - use distance map to optimise tracker
          for (int i = 0, len = TRACKING_RANGE_TYPES.length; i < len; ++i) {
              this.playerEntityTrackerTrackMaps[i].remove(player);
-@@ -245,9 +253,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-         this.playerViewDistanceTickMap.remove(player);
-         this.playerViewDistanceNoTickMap.remove(player);
+@@ -241,13 +227,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         this.playerChunkTickRangeMap.remove(player);
+         // Paper end - optimise PlayerChunkMap#isOutsideRange
+         // Paper start - no-tick view distance
+-        this.playerViewDistanceBroadcastMap.remove(player);
+-        this.playerViewDistanceTickMap.remove(player);
+-        this.playerViewDistanceNoTickMap.remove(player);
++        this.playerChunkManager.removePlayer(player); // Tuinity - replace chunk loader
          // Paper end - no-tick view distance
 +        // Tuinity start - optimise checkDespawn
 +        this.playerGeneralAreaMap.remove(player);
@@ -13296,43 +15591,143 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
          int chunkX = MCUtil.getChunkCoordinate(player.locX());
          int chunkZ = MCUtil.getChunkCoordinate(player.locZ());
          // Note: players need to be explicitly added to distance maps before they can be updated
-@@ -275,9 +287,35 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-         this.playerViewDistanceBroadcastMap.update(player, chunkX, chunkZ, effectiveNoTickViewDistance + 1); // clients need an extra neighbour to render the full view distance configured
-         player.needsChunkCenterUpdate = false;
-         // Paper end - no-tick view distance
+@@ -256,27 +244,124 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             com.destroystokyo.paper.util.misc.PlayerAreaMap trackMap = this.playerEntityTrackerTrackMaps[i];
+             int trackRange = this.entityTrackerTrackRanges[i];
+ 
+-            trackMap.update(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveViewDistance()));
++            trackMap.update(player, chunkX, chunkZ, Math.min(trackRange, player.getBukkitEntity().getViewDistance())); // Tuinity - per player view distances
+         }
+         // Paper end - use distance map to optimise entity tracker
+         // Paper start - optimise PlayerChunkMap#isOutsideRange
+         this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, ChunkMapDistance.MOB_SPAWN_RANGE);
+         // Paper end - optimise PlayerChunkMap#isOutsideRange
+         // Paper start - no-tick view distance
+-        int effectiveTickViewDistance = this.getEffectiveViewDistance();
+-        int effectiveNoTickViewDistance = Math.max(this.getEffectiveNoTickViewDistance(), effectiveTickViewDistance);
++        this.playerChunkManager.updatePlayer(player); // Tuinity - replace chunk loader
++        // Paper end - no-tick view distance
 +        // Tuinity start - optimise checkDespawn
 +        this.playerGeneralAreaMap.update(player, chunkX, chunkZ, GENERAL_AREA_MAP_SQUARE_RADIUS);
 +        // Tuinity end - optimise checkDespawn
-     }
-     // Paper end
- 
++    }
++    // Paper end
++
 +    // Tuinity start
-+    public static enum RegionData implements com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionDataCreator<RegionData> {
++    protected final List<com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager> regionManagers = new java.util.ArrayList<>();
++    public final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager dataRegionManager;
++
++    public static final class DataRegionData implements com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionData {
+ 
+-        if (!this.cannotLoadChunks(player)) {
+-            this.playerViewDistanceTickMap.update(player, chunkX, chunkZ, effectiveTickViewDistance);
+-            this.playerViewDistanceNoTickMap.update(player, chunkX, chunkZ, effectiveNoTickViewDistance + 2); // clients need chunk 1 neighbour, and we need another 1 for sending those extra neighbours (as we require neighbours to send)
 +        // Tuinity start - optimise notify()
-+        PATHING_NAVIGATORS() {
-+            @Override
-+            public Object createData(com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection<RegionData> section,
-+                    com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager<RegionData> regionManager) {
-+                return new com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<>(true);
++        private com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<EntityInsentient> navigators;
++
++        public com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<EntityInsentient> getNavigators() {
++            return this.navigators;
+         }
+ 
+-        player.needsChunkCenterUpdate = true;
+-        this.playerViewDistanceBroadcastMap.update(player, chunkX, chunkZ, effectiveNoTickViewDistance + 1); // clients need an extra neighbour to render the full view distance configured
+-        player.needsChunkCenterUpdate = false;
+-        // Paper end - no-tick view distance
++        public boolean addToNavigators(final EntityInsentient navigator) {
++            if (this.navigators == null) {
++                this.navigators = new com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<>();
 +            }
++            return this.navigators.add(navigator);
++        }
++
++        public boolean removeFromNavigators(final EntityInsentient navigator) {
++            if (this.navigators == null) {
++                return false;
++            }
++            return this.navigators.remove(navigator);
 +        }
 +        // Tuinity end - optimise notify()
-+        ;
++
+     }
+-    // Paper end
++
++    public static final class DataRegionSectionData implements com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSectionData {
++
++        // Tuinity start - optimise notify()
++        private com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<EntityInsentient> navigators;
++
++        public com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<EntityInsentient> getNavigators() {
++            return this.navigators;
++        }
++
++        public boolean addToNavigators(final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection section, final EntityInsentient navigator) {
++            if (this.navigators == null) {
++                this.navigators = new com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<>();
++            }
++            final boolean ret = this.navigators.add(navigator);
++            if (ret) {
++                final DataRegionData data = (DataRegionData)section.getRegion().regionData;
++                if (!data.addToNavigators(navigator)) {
++                    throw new IllegalStateException();
++                }
++            }
++            return ret;
++        }
++
++        public boolean removeFromNavigators(final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection section, final EntityInsentient navigator) {
++            if (this.navigators == null) {
++                return false;
++            }
++            final boolean ret = this.navigators.remove(navigator);
++            if (ret) {
++                final DataRegionData data = (DataRegionData)section.getRegion().regionData;
++                if (!data.removeFromNavigators(navigator)) {
++                    throw new IllegalStateException();
++                }
++            }
++            return ret;
++        }
++        // Tuinity end - optimise notify()
 +
 +        @Override
-+        public Object createData(com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection<RegionData> section,
-+                                 com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager<RegionData> regionManager) {
-+            throw new AbstractMethodError();
++        public void removeFromRegion(final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection section,
++                                     final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.Region from) {
++            final DataRegionSectionData sectionData = (DataRegionSectionData)section.sectionData;
++            final DataRegionData fromData = (DataRegionData)from.regionData;
++            // Tuinity start - optimise notify()
++            if (sectionData.navigators != null) {
++                for (final Iterator<EntityInsentient> iterator = sectionData.navigators.unsafeIterator(com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
++                    if (!fromData.removeFromNavigators(iterator.next())) {
++                        throw new IllegalStateException();
++                    }
++                }
++            }
++            // Tuinity end - optimise notify()
++        }
++
++        @Override
++        public void addToRegion(final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection section,
++                                final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.Region oldRegion,
++                                final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.Region newRegion) {
++            final DataRegionSectionData sectionData = (DataRegionSectionData)section.sectionData;
++            final DataRegionData oldRegionData = oldRegion == null ? null : (DataRegionData)oldRegion.regionData;
++            final DataRegionData newRegionData = (DataRegionData)newRegion.regionData;
++            // Tuinity start - optimise notify()
++            if (sectionData.navigators != null) {
++                for (final Iterator<EntityInsentient> iterator = sectionData.navigators.unsafeIterator(com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet.ITERATOR_FLAG_SEE_ADDITIONS); iterator.hasNext();) {
++                    if (!newRegionData.addToNavigators(iterator.next())) {
++                        throw new IllegalStateException();
++                    }
++                }
++            }
++            // Tuinity end - optimise notify()
 +        }
 +    }
-+
-+    public final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager<RegionData> dataRegionManager;
 +    // Tuiniy end
-+
+ 
      private final java.util.concurrent.ExecutorService lightThread;
      public PlayerChunkMap(WorldServer worldserver, Convertable.ConversionSession convertable_conversionsession, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, IAsyncTaskHandler<Runnable> iasynctaskhandler, ILightAccess ilightaccess, ChunkGenerator chunkgenerator, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier, int i, boolean flag) {
-         super(new File(convertable_conversionsession.a(worldserver.getDimensionKey()), "region"), datafixer, flag);
-@@ -311,9 +349,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -311,9 +396,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
          this.worldLoadListener = worldloadlistener;
          // Paper start - use light thread
@@ -13344,34 +15739,97 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
              thread.setDaemon(true);
              thread.setPriority(Thread.NORM_PRIORITY+1);
              return thread;
-@@ -445,6 +484,26 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-                 PlayerChunkMap.this.sendChunk(player, new ChunkCoordIntPair(rangeX, rangeZ), null, true, false); // unloaded, loaded
-             });
-         // Paper end - no-tick view distance
+@@ -403,48 +489,29 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         // Paper end - optimise PlayerChunkMap#isOutsideRange
+         // Paper start - no-tick view distance
+         this.setNoTickViewDistance(this.world.paperConfig.noTickViewDistance);
+-        this.playerViewDistanceTickMap = new com.destroystokyo.paper.util.misc.PlayerAreaMap(this.pooledLinkedPlayerHashSets,
++        // Tuinity - replace chunk loading system
++        // Paper end - no-tick view distance
 +        // Tuinity start
-+        this.dataRegionManager = new com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager<>(this.world, RegionData.class, 2, (1.0 / 3.0), "Data");
++        this.dataRegionManager = new com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager(this.world, 2, (1.0 / 3.0), 1, 6, "Data", DataRegionData::new, DataRegionSectionData::new);
++        this.regionManagers.add(this.dataRegionManager);
 +        // Tuinity end
 +        // Tuinity start - optimise checkDespawn
 +        this.playerGeneralAreaMap = new com.destroystokyo.paper.util.misc.PlayerAreaMap(this.pooledLinkedPlayerHashSets,
-+            (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
-+             com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
+             (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
+              com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
+-                checkHighPriorityChunks(player);
+-                if (newState.size() != 1) {
+-                    return;
 +                Chunk chunk = PlayerChunkMap.this.world.getChunkProvider().getChunkAtIfCachedImmediately(rangeX, rangeZ);
 +                if (chunk != null) {
 +                    chunk.updateGeneralAreaCache(newState);
-+                }
-+            },
-+            (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
-+             com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
+                 }
+-                Chunk chunk = PlayerChunkMap.this.world.getChunkProvider().getChunkAtIfLoadedMainThreadNoCache(rangeX, rangeZ);
+-                if (chunk == null || !chunk.areNeighboursLoaded(2)) {
+-                    return;
+-                }
+-
+-                ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(rangeX, rangeZ);
+-                PlayerChunkMap.this.world.getChunkProvider().addTicketAtLevel(TicketType.PLAYER, chunkPos, 31, chunkPos); // entity ticking level, TODO check on update
+             },
+             (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
+              com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
+-                if (newState != null) {
+-                    return;
+-                }
+-                ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(rangeX, rangeZ);
+-                PlayerChunkMap.this.world.getChunkProvider().removeTicketAtLevel(TicketType.PLAYER, chunkPos, 31, chunkPos); // entity ticking level, TODO check on update
+-                PlayerChunkMap.this.world.getChunkProvider().clearPriorityTickets(chunkPos);
+-            }, (player, prevPos, newPos) -> {
+-            player.lastHighPriorityChecked = -1; // reset and recheck
+-            checkHighPriorityChunks(player);
+-        });
+-        this.playerViewDistanceNoTickMap = new com.destroystokyo.paper.util.misc.PlayerAreaMap(this.pooledLinkedPlayerHashSets);
+-        this.playerViewDistanceBroadcastMap = new com.destroystokyo.paper.util.misc.PlayerAreaMap(this.pooledLinkedPlayerHashSets,
+-            (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
+-             com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
+-                if (player.needsChunkCenterUpdate) {
+-                    player.needsChunkCenterUpdate = false;
+-                    player.playerConnection.sendPacket(new PacketPlayOutViewCentre(currPosX, currPosZ));
 +                Chunk chunk = PlayerChunkMap.this.world.getChunkProvider().getChunkAtIfCachedImmediately(rangeX, rangeZ);
 +                if (chunk != null) {
 +                    chunk.updateGeneralAreaCache(newState);
-+                }
-+            });
+                 }
+-                PlayerChunkMap.this.sendChunk(player, new ChunkCoordIntPair(rangeX, rangeZ), new Packet[2], false, true); // unloaded, loaded
+-            },
+-            (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
+-             com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
+-                PlayerChunkMap.this.sendChunk(player, new ChunkCoordIntPair(rangeX, rangeZ), null, true, false); // unloaded, loaded
+             });
+-        // Paper end - no-tick view distance
 +        // Tuinity end - optimise checkDespawn
      }
      // Paper start - Chunk Prioritization
      public void queueHolderUpdate(PlayerChunk playerchunk) {
-@@ -757,6 +816,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -477,6 +544,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     }
+ 
+     public void checkHighPriorityChunks(EntityPlayer player) {
++        if (true) return; // Tuinity - replace player chunk loader
+         int currentTick = MinecraftServer.currentTick;
+         if (currentTick - player.lastHighPriorityChecked < 20 || !player.isRealPlayer) { // weed out fake players
+             return;
+@@ -484,7 +552,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         player.lastHighPriorityChecked = currentTick;
+         Long2IntOpenHashMap priorities = new Long2IntOpenHashMap();
+ 
+-        int viewDistance = getEffectiveNoTickViewDistance();
++        int viewDistance = 10;//int viewDistance = getEffectiveNoTickViewDistance(); // Tuinity - replace player chunk loader
+         BlockPosition.MutableBlockPosition pos = new BlockPosition.MutableBlockPosition();
+ 
+         // Prioritize circular near
+@@ -550,7 +618,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     }
+ 
+     private boolean shouldSkipPrioritization(ChunkCoordIntPair coord) {
+-        if (playerViewDistanceNoTickMap.getObjectsInRange(coord.pair()) == null) return true;
++        if (true) return true; // Tuinity - replace player chunk loader - unused outside paper player loader logic
+         PlayerChunk chunk = getUpdatingChunk(coord.pair());
+         return chunk != null && (chunk.isFullChunkReady());
+     }
+@@ -757,6 +825,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      @Nullable
      private PlayerChunk a(long i, int j, @Nullable PlayerChunk playerchunk, int k) {
@@ -13380,17 +15838,21 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
          if (k > PlayerChunkMap.GOLDEN_TICKET && j > PlayerChunkMap.GOLDEN_TICKET) {
              return playerchunk;
          } else {
-@@ -779,7 +840,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -779,7 +849,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      playerchunk.a(j);
                  } else {
                      playerchunk = new PlayerChunk(new ChunkCoordIntPair(i), j, this.lightEngine, this.p, this);
-+                    this.dataRegionManager.addChunk(playerchunk.location.x, playerchunk.location.z); // Tuinity
++                    // Tuinity start
++                    for (int index = 0, len = this.regionManagers.size(); index < len; ++index) {
++                        this.regionManagers.get(index).addChunk(playerchunk.location.x, playerchunk.location.z);
++                    }
++                    // Tuinity end
                  }
 +                this.getVillagePlace().dequeueUnload(playerchunk.location.pair()); // Tuinity - unload POI data
  
                  this.updatingChunks.put(i, playerchunk);
                  this.updatingChunksModified = true;
-@@ -905,7 +968,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -905,7 +981,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -13399,7 +15861,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
  
      protected void unloadChunks(BooleanSupplier booleansupplier) {
          GameProfilerFiller gameprofilerfiller = this.world.getMethodProfiler();
-@@ -971,7 +1034,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -971,7 +1047,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          }
  
          com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE.scheduleSave(this.world, chunkPos.x, chunkPos.z,
@@ -13408,7 +15870,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
  
          if (!chunk.isNeedsSaving()) {
              return;
-@@ -1005,7 +1068,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1005,7 +1081,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              asyncSaveData = ChunkRegionLoader.getAsyncSaveData(this.world, chunk);
          }
  
@@ -13417,7 +15879,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
              asyncSaveData, chunk);
  
          chunk.setLastSaved(this.world.getTime());
-@@ -1013,6 +1076,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1013,6 +1089,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
      // Paper end
  
@@ -13426,7 +15888,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
      private void a(long i, PlayerChunk playerchunk) {
          CompletableFuture<IChunkAccess> completablefuture = playerchunk.getChunkSave();
          Consumer<IChunkAccess> consumer = (ichunkaccess) -> { // CraftBukkit - decompile error
-@@ -1021,7 +1086,17 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1021,7 +1099,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              if (completablefuture1 != completablefuture) {
                  this.a(i, playerchunk);
              } else {
@@ -13440,25 +15902,33 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
 +                // Tuinity start
 +                boolean removed;
 +                if ((removed = this.pendingUnload.remove(i, playerchunk)) && ichunkaccess != null) { // Tuinity end
-+                    this.dataRegionManager.removeChunk(playerchunk.location.x, playerchunk.location.z); // Tuinity
++                    // Tuinity start
++                    for (int index = 0, len = this.regionManagers.size(); index < len; ++index) {
++                        this.regionManagers.get(index).removeChunk(playerchunk.location.x, playerchunk.location.z);
++                    }
++                    // Tuinity end
 +                    this.getVillagePlace().queueUnload(playerchunk.location.pair(), MinecraftServer.currentTickLong + 1); // Tuinity - unload POI data
                      if (ichunkaccess instanceof Chunk) {
                          ((Chunk) ichunkaccess).setLoaded(false);
                      }
-@@ -1044,7 +1119,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1044,7 +1136,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      this.lightEngine.a(ichunkaccess.getPos());
                      this.lightEngine.queueUpdate();
                      this.worldLoadListener.a(ichunkaccess.getPos(), (ChunkStatus) null);
 -                }
 +                } else if (removed) { // Tuinity start
-+                    this.dataRegionManager.removeChunk(playerchunk.location.x, playerchunk.location.z);
++                    // Tuinity start
++                    for (int index = 0, len = this.regionManagers.size(); index < len; ++index) {
++                        this.regionManagers.get(index).removeChunk(playerchunk.location.x, playerchunk.location.z);
++                    }
++                    // Tuinity end
 +                    this.getVillagePlace().queueUnload(playerchunk.location.pair(), MinecraftServer.currentTickLong + 1); // Tuinity - unload POI data
 +                } // Tuinity end
 +                } finally { this.unloadingPlayerChunk = unloadingBefore; } // Tuinity - do not allow ticket level changes while unloading chunks
  
              }
          };
-@@ -1060,6 +1139,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1060,6 +1160,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      protected boolean b() {
@@ -13466,7 +15936,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
          if (!this.updatingChunksModified) {
              return false;
          } else {
-@@ -1135,6 +1215,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1135,6 +1236,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                  this.getVillagePlace().loadInData(chunkcoordintpair, chunkHolder.poiData);
                  chunkHolder.tasks.forEach(Runnable::run);
@@ -13474,7 +15944,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
                  // Paper end
  
                  if (chunkHolder.protoChunk != null) {try (Timing ignored2 = this.world.timings.chunkLoadLevelTimer.startTimingIfSync()) { // Paper start - timings // Paper - chunk is created async
-@@ -1247,9 +1328,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1247,9 +1349,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
              // Paper end
              this.mailboxWorldGen.a(ChunkTaskQueueSorter.a(playerchunk, runnable));
@@ -13489,7 +15959,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
      protected void c(ChunkCoordIntPair chunkcoordintpair) {
          this.executor.a(SystemUtils.a(() -> {
              this.chunkDistanceManager.b(TicketType.LIGHT, chunkcoordintpair, 33 + ChunkStatus.a(ChunkStatus.FEATURES), chunkcoordintpair);
-@@ -1416,9 +1501,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1416,9 +1522,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  chunk.B();
                  return chunk;
              });
@@ -13500,7 +15970,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
      }
  
      public int c() {
-@@ -1499,6 +1582,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1499,39 +1603,27 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public void setViewDistance(int i) { // Paper - public
@@ -13508,15 +15978,44 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
          int j = MathHelper.clamp(i + 1, 3, 33); // Paper - diff on change, these make the lower view distance limit 2 and the upper 32
  
          if (j != this.viewDistance) {
-@@ -1512,6 +1596,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             int k = this.viewDistance;
+ 
+             this.viewDistance = j;
+-            this.setNoTickViewDistance(this.getRawNoTickViewDistance()); //Paper - no-tick view distance - propagate changes to no-tick, which does the actual chunk loading/sending
++            this.playerChunkManager.setTickDistance(MathHelper.clamp(i, 2, 32)); // Tuinity - replace player loader system
+         }
+ 
+     }
  
      // Paper start - no-tick view distance
      public final void setNoTickViewDistance(int viewDistance) {
 +        com.tuinity.tuinity.util.TickThread.softEnsureTickThread("Cannot update view distance off of the main thread"); // Tuinity
          viewDistance = viewDistance == -1 ? -1 : MathHelper.clamp(viewDistance, 2, 32);
+-
+-        this.noTickViewDistance = viewDistance;
+-        int loadViewDistance = this.getLoadViewDistance();
+-        this.chunkDistanceManager.setNoTickViewDistance(loadViewDistance + 2 + 2); // add 2 to account for the change to 31 -> 33 tickets // see notes in the distance map updating for the other + 2
+-
+-        if (this.world != null && this.world.players != null) { // this can be called from constructor, where these aren't set
+-            for (EntityPlayer player : this.world.players) {
+-                PlayerConnection connection = player.playerConnection;
+-                if (connection != null) {
+-                    // moved in from PlayerList
+-                    connection.sendPacket(new PacketPlayOutViewDistance(loadViewDistance));
+-                }
+-                this.updateMaps(player);
+-            }
+-        }
++        this.playerChunkManager.setLoadDistance(viewDistance == -1 ? -1 : viewDistance + 1); // Tuinity - replace player loader system - add 1 here, we need an extra one to send to clients for chunks in this viewDistance to render
+     }
+     // Paper end - no-tick view distance
  
-         this.noTickViewDistance = viewDistance;
-@@ -1627,7 +1712,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+-    protected void sendChunk(EntityPlayer entityplayer, ChunkCoordIntPair chunkcoordintpair, Packet<?>[] apacket, boolean flag, boolean flag1) {
++    public void sendChunk(EntityPlayer entityplayer, ChunkCoordIntPair chunkcoordintpair, Packet<?>[] apacket, boolean flag, boolean flag1) { // Tuinity - protected -> public
+         if (entityplayer.world == this.world) {
+             if (flag1 && !flag) {
+                 PlayerChunk playerchunk = this.getVisibleChunk(chunkcoordintpair.pair());
+@@ -1627,7 +1719,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          if (Thread.currentThread() != com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE) {
              com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE.scheduleSave(
                  this.world, chunkcoordintpair.x, chunkcoordintpair.z, null, nbttagcompound,
@@ -13525,7 +16024,7 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
              return;
          }
          super.write(chunkcoordintpair, nbttagcompound);
-@@ -1711,6 +1796,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1711,6 +1803,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return chunkHolder == null ? null : chunkHolder.getAvailableChunkNow();
      }
      // Paper end
@@ -13537,7 +16036,44 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
  
  
      // Paper start - async io
-@@ -2038,22 +2128,25 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1920,6 +2017,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         }*/ // Paper end - replaced by distance map
+ 
+         this.updateMaps(entityplayer); // Paper - distance maps
++        this.playerChunkManager.updatePlayer(entityplayer); // Tuinity - respond to movement immediately
+ 
+     }
+ 
+@@ -1928,7 +2026,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         // Paper start - per player view distance
+         // there can be potential desync with player's last mapped section and the view distance map, so use the
+         // view distance map here.
+-        com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> inRange = this.playerViewDistanceBroadcastMap.getObjectsInRange(chunkcoordintpair);
++        com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> inRange = this.playerChunkManager.broadcastMap.getObjectsInRange(chunkcoordintpair); // Tuinity - replace player chunk loader system
+ 
+         if (inRange == null) {
+             return Stream.empty();
+@@ -1944,8 +2042,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                     continue;
+                 }
+                 EntityPlayer player = (EntityPlayer)temp;
+-                int viewDistance = this.playerViewDistanceBroadcastMap.getLastViewDistance(player);
+-                long lastPosition = this.playerViewDistanceBroadcastMap.getLastCoordinate(player);
++                if (!this.playerChunkManager.isChunkSent(player, chunkcoordintpair.x, chunkcoordintpair.z)) continue; // Tuinity - replace player chunk management
++                int viewDistance = this.playerChunkManager.broadcastMap.getLastViewDistance(player); // Tuinity - replace player chunk loader system
++                long lastPosition = this.playerChunkManager.broadcastMap.getLastCoordinate(player); // Tuinity - replace player chunk loader system
+ 
+                 int distX = Math.abs(MCUtil.getCoordinateX(lastPosition) - chunkcoordintpair.x);
+                 int distZ = Math.abs(MCUtil.getCoordinateZ(lastPosition) - chunkcoordintpair.z);
+@@ -1960,6 +2059,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                     continue;
+                 }
+                 EntityPlayer player = (EntityPlayer)temp;
++                if (!this.playerChunkManager.isChunkSent(player, chunkcoordintpair.x, chunkcoordintpair.z)) continue; // Tuinity - replace player chunk management
+                 players.add(player);
+             }
+         }
+@@ -2038,22 +2138,25 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      private final void processTrackQueue() {
          this.world.timings.tracker1.startTiming();
          try {
@@ -13576,7 +16112,65 @@ index 00d0a5fd7c5d2db19756f3c6cfb2381868af51fd..285e976d4a655fb61e70883ae89f9748
          }
      }
      // Paper end - optimised tracker
-@@ -2453,7 +2546,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2175,6 +2278,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+             apacket[1] = new PacketPlayOutLightUpdate(chunk.getPos(), this.lightEngine, true);
+ 
+             // Paper start - Fix MC-162253
++            if (com.tuinity.tuinity.config.TuinityConfig.enableMC162253Workaround) { // Tuinity - hide behind config option, this logic has undesirable network effects
+             final int lightMask = getLightMask(chunk);
+             int i = 1;
+             for (int x = -1; x <= 1; x++) {
+@@ -2199,10 +2303,12 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+                     apacket[i] = new PacketPlayOutLightUpdate(new ChunkCoordIntPair(chunk.getPos().x + x, chunk.getPos().z + z), lightEngine, updateLightMask, 0, true);
+                 }
+             }
++        } // Tuinity - hide behind config option, this logic has undesirable network effects
+         }
+ 
+-        final int viewDistance = playerViewDistanceBroadcastMap.getLastViewDistance(entityplayer);
+-        final long lastPosition = playerViewDistanceBroadcastMap.getLastCoordinate(entityplayer);
++        if (com.tuinity.tuinity.config.TuinityConfig.enableMC162253Workaround) { // Tuinity - hide behind config option, this logic has undesirable network effects
++        final int viewDistance = this.playerChunkManager.broadcastMap.getLastViewDistance(entityplayer); // Tuinity - replace player chunk loader
++        final long lastPosition = this.playerChunkManager.broadcastMap.getLastCoordinate(entityplayer); // Tuinity - replace player chunk loader
+ 
+         int j = 1;
+         for (int x = -1; x <= 1; x++) {
+@@ -2227,6 +2333,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+                 entityplayer.playerConnection.sendPacket(packet);
+             }
+         }
++        } // Tuinity - hide behind config option, this logic has undesirable network effects
+         // Paper end - Fix MC-162253
+ 
+         entityplayer.a(chunk.getPos(), apacket[0], apacket[1]);
+@@ -2302,7 +2409,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+         // Paper start
+         // Replace trackedPlayers Set with a Map. The value is true until the player receives
+         // their first update (which is forced to have absolute coordinates), false afterward.
+-        public java.util.Map<EntityPlayer, Boolean> trackedPlayerMap = new java.util.HashMap<>();
++        public java.util.Map<EntityPlayer, Boolean> trackedPlayerMap = new Reference2BooleanOpenHashMap<>(); // Tuinity - optimise map impl
+         public Set<EntityPlayer> trackedPlayers = trackedPlayerMap.keySet();
+ 
+         public EntityTracker(Entity entity, int i, int j, boolean flag) {
+@@ -2403,7 +2510,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+                 double vec3d_dy = entityplayer.locY() - this.tracker.locY();
+                 double vec3d_dz = entityplayer.locZ() - this.tracker.locZ();
+                 // Paper end - remove allocation of Vec3D here
+-                int i = Math.min(this.b(), (PlayerChunkMap.this.viewDistance - 1) * 16);
++                int i = Math.min(this.b(), (entityplayer.getBukkitEntity().getViewDistance()) * 16); // Tuinity - per player view distance
+                 boolean flag = vec3d_dx >= (double) (-i) && vec3d_dx <= (double) i && vec3d_dz >= (double) (-i) && vec3d_dz <= (double) i && this.tracker.a(entityplayer); // Paper - remove allocation of Vec3D here
+ 
+                 if (flag) {
+@@ -2413,7 +2520,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+                         ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(this.tracker.chunkX, this.tracker.chunkZ);
+                         PlayerChunk playerchunk = PlayerChunkMap.this.getVisibleChunk(chunkcoordintpair.pair());
+ 
+-                        if (playerchunk != null && playerchunk.getSendingChunk() != null) { // Paper - no-tick view distance
++                        if (playerchunk != null && playerchunk.getSendingChunk() != null && PlayerChunkMap.this.playerChunkManager.isChunkSent(entityplayer, MathHelper.floor(this.tracker.locX()) >> 4, MathHelper.floor(this.tracker.locZ()) >> 4)) { // Paper - no-tick view distance // Tuinity - don't broadcast in chunks the player hasn't received
+                             flag1 = PlayerChunkMap.b(chunkcoordintpair, entityplayer, false) <= PlayerChunkMap.this.viewDistance;
+                         }
+                     }
+@@ -2453,7 +2560,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                  int j = entity.getEntityType().getChunkRange() * 16;
                  j = org.spigotmc.TrackingRange.getEntityTrackingRange(entity, j); // Paper
  
@@ -13952,7 +16546,7 @@ index d57784c5dd44cc110b7c863ffff82263178e7d9a..967443a44106563fe71a528703751ff0
              this.player.playerConnection.sendPacket(new PacketPlayOutBlockChange(this.world, blockposition)); // CraftBukkit - SPIGOT-5196
          }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 184a0d30f4a1d4a6a07449fdd1375a8582da9332..d03d0c13cca1762078617744253a9757b388958f 100644
+index 184a0d30f4a1d4a6a07449fdd1375a8582da9332..a12e58668e74f2287ddff5bedc00daf2b0a416c1 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -96,6 +96,7 @@ public abstract class PlayerList {
@@ -13963,6 +16557,15 @@ index 184a0d30f4a1d4a6a07449fdd1375a8582da9332..d03d0c13cca1762078617744253a9757
          EntityPlayer prev = pendingPlayers.put(entityplayer.getUniqueID(), entityplayer);// Paper
          if (prev != null) {
              disconnectPendingPlayer(prev);
+@@ -184,7 +185,7 @@ public abstract class PlayerList {
+         boolean flag1 = gamerules.getBoolean(GameRules.REDUCED_DEBUG_INFO);
+ 
+         // Spigot - view distance
+-        playerconnection.sendPacket(new PacketPlayOutLogin(entityplayer.getId(), entityplayer.playerInteractManager.getGameMode(), entityplayer.playerInteractManager.c(), BiomeManager.a(worldserver1.getSeed()), worlddata.isHardcore(), this.server.F(), this.s, worldserver1.getDimensionManager(), worldserver1.getDimensionKey(), this.getMaxPlayers(), worldserver1.getChunkProvider().playerChunkMap.getLoadViewDistance(), flag1, !flag, worldserver1.isDebugWorld(), worldserver1.isFlatWorld())); // Paper - no-tick view distance
++        playerconnection.sendPacket(new PacketPlayOutLogin(entityplayer.getId(), entityplayer.playerInteractManager.getGameMode(), entityplayer.playerInteractManager.c(), BiomeManager.a(worldserver1.getSeed()), worlddata.isHardcore(), this.server.F(), this.s, worldserver1.getDimensionManager(), worldserver1.getDimensionKey(), this.getMaxPlayers(), worldserver1.getChunkProvider().playerChunkMap.playerChunkManager.getLoadDistance(), flag1, !flag, worldserver1.isDebugWorld(), worldserver1.isFlatWorld())); // Paper - no-tick view distance // Tuinity - replace old player chunk management
+         entityplayer.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
+         playerconnection.sendPacket(new PacketPlayOutCustomPayload(PacketPlayOutCustomPayload.a, (new PacketDataSerializer(Unpooled.buffer())).a(this.getServer().getServerModName())));
+         playerconnection.sendPacket(new PacketPlayOutServerDifficulty(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
 @@ -636,7 +637,7 @@ public abstract class PlayerList {
          SocketAddress socketaddress = loginlistener.networkManager.getSocketAddress();
  
@@ -13972,6 +16575,73 @@ index 184a0d30f4a1d4a6a07449fdd1375a8582da9332..d03d0c13cca1762078617744253a9757
          Player player = entity.getBukkitEntity();
          PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.networkManager.getRawAddress()).getAddress());
  
+@@ -856,7 +857,7 @@ public abstract class PlayerList {
+         // CraftBukkit start
+         WorldData worlddata = worldserver1.getWorldData();
+         entityplayer1.playerConnection.sendPacket(new PacketPlayOutRespawn(worldserver1.getDimensionManager(), worldserver1.getDimensionKey(), BiomeManager.a(worldserver1.getSeed()), entityplayer1.playerInteractManager.getGameMode(), entityplayer1.playerInteractManager.c(), worldserver1.isDebugWorld(), worldserver1.isFlatWorld(), flag));
+-        entityplayer1.playerConnection.sendPacket(new PacketPlayOutViewDistance(worldserver1.getChunkProvider().playerChunkMap.getLoadViewDistance())); // Spigot // Paper - no-tick view distance
++        entityplayer1.playerConnection.sendPacket(new PacketPlayOutViewDistance(worldserver1.getChunkProvider().playerChunkMap.playerChunkManager.getLoadDistance())); // Spigot // Paper - no-tick view distance // Tuinity - replace old player chunk management
+         entityplayer1.spawnIn(worldserver1);
+         entityplayer1.dead = false;
+         entityplayer1.playerConnection.teleport(new Location(worldserver1.getWorld(), entityplayer1.locX(), entityplayer1.locY(), entityplayer1.locZ(), entityplayer1.yaw, entityplayer1.pitch));
+@@ -1125,7 +1126,7 @@ public abstract class PlayerList {
+             // Really shouldn't happen...
+             backingSet = world != null ? world.players.toArray() : players.toArray();
+         } else {
+-            com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> nearbyPlayers = chunkMap.playerViewDistanceBroadcastMap.getObjectsInRange(MCUtil.fastFloor(d0) >> 4, MCUtil.fastFloor(d2) >> 4);
++            com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> nearbyPlayers = chunkMap.playerChunkManager.broadcastMap.getObjectsInRange(MCUtil.fastFloor(d0) >> 4, MCUtil.fastFloor(d2) >> 4); // Tuinity - replace old player chunk management
+             if (nearbyPlayers == null) {
+                 return;
+             }
+diff --git a/src/main/java/net/minecraft/server/PortalTravelAgent.java b/src/main/java/net/minecraft/server/PortalTravelAgent.java
+index e10995ec30dd9a10d781b3c1709fd2db5a9becdd..77aa805267497f91231d63067d62ad3f10508216 100644
+--- a/src/main/java/net/minecraft/server/PortalTravelAgent.java
++++ b/src/main/java/net/minecraft/server/PortalTravelAgent.java
+@@ -22,16 +22,34 @@ public class PortalTravelAgent {
+         // int i = flag ? 16 : 128;
+         // CraftBukkit end
+ 
+-        villageplace.a(this.world, blockposition, i);
+-        Optional<VillagePlaceRecord> optional = villageplace.b((villageplacetype) -> {
+-            return villageplacetype == VillagePlaceType.v;
+-        }, blockposition, i, VillagePlace.Occupancy.ANY).sorted(Comparator.comparingDouble((VillagePlaceRecord villageplacerecord) -> { // CraftBukkit - decompile error
+-            return villageplacerecord.f().j(blockposition);
+-        }).thenComparingInt((villageplacerecord) -> {
+-            return villageplacerecord.f().getY();
+-        })).filter((villageplacerecord) -> {
+-            return this.world.getType(villageplacerecord.f()).b(BlockProperties.E);
+-        }).findFirst();
++        // Tuinity start - optimise portals
++        //villageplace.a(this.world, blockposition, i);
++        Optional<VillagePlaceRecord> optional;
++        java.util.List<VillagePlaceRecord> records = new java.util.ArrayList<>();
++        com.tuinity.tuinity.util.PoiAccess.findClosestPoiDataRecords(villageplace,
++                (VillagePlaceType villageplacetype) -> {
++                    return villageplacetype == VillagePlaceType.v; // this should break this entire diff on update if it changes, so TODO check that on diff break
++                },
++                (BlockPosition pos) -> {
++                    IChunkAccess lowest = this.world.getChunkAt(pos.getX() >> 4, pos.getZ() >> 4, ChunkStatus.EMPTY);
++                    if (!lowest.getChunkStatus().isAtLeastStatus(ChunkStatus.FULL)) {
++                        // why would we generate the chunk?
++                        return false;
++                    }
++                    return lowest.getType(pos).contains(BlockProperties.E); // this should break this entire diff on update if it changes, so TODO check that on diff break
++                }, blockposition, i, Double.MAX_VALUE, VillagePlace.Occupancy.ANY, true, records);
++        // this gets us most of the way there, but we bias towards lower y values.
++        VillagePlaceRecord lowestYRecord = null;
++        for (VillagePlaceRecord record : records) {
++            if (lowestYRecord == null) {
++                lowestYRecord = record;
++            } else if (lowestYRecord.getPosition().getY() > record.getPosition().getY()) {
++                lowestYRecord = record;
++            }
++        }
++        // now we're done
++        optional = Optional.ofNullable(lowestYRecord);
++        // Tuinity end - optimise portals
+ 
+         return optional.map((villageplacerecord) -> {
+             BlockPosition blockposition1 = villageplacerecord.f();
 diff --git a/src/main/java/net/minecraft/server/ProtoChunk.java b/src/main/java/net/minecraft/server/ProtoChunk.java
 index 5b0cd414ca1949ab53b289f7159f18da07d21f14..d8b759874545293764690b2ba08a4bd7605c76ae 100644
 --- a/src/main/java/net/minecraft/server/ProtoChunk.java
@@ -14933,7 +17603,7 @@ index 3382d678e68e559b8d3cb9dced4fce24206cd38f..3b7894256dc8daa81be35f845cb5f8de
          return (InputStream) this.f.wrap(inputstream);
      }
 diff --git a/src/main/java/net/minecraft/server/RegionFileSection.java b/src/main/java/net/minecraft/server/RegionFileSection.java
-index 04256a95108b8182e8f808e856e0d2b62165e242..79a11d17a2822b192dec5981d0344ae689c3d385 100644
+index 04256a95108b8182e8f808e856e0d2b62165e242..d1ea47654db190e7cb7fa4ec1ac002f64277cb47 100644
 --- a/src/main/java/net/minecraft/server/RegionFileSection.java
 +++ b/src/main/java/net/minecraft/server/RegionFileSection.java
 @@ -25,8 +25,8 @@ public class RegionFileSection<R> extends RegionFileCache implements AutoCloseab
@@ -14947,7 +17617,7 @@ index 04256a95108b8182e8f808e856e0d2b62165e242..79a11d17a2822b192dec5981d0344ae6
      private final Function<Runnable, Codec<R>> e;
      private final Function<Runnable, R> f;
      private final DataFixer g;
-@@ -50,8 +50,42 @@ public class RegionFileSection<R> extends RegionFileCache implements AutoCloseab
+@@ -50,11 +50,46 @@ public class RegionFileSection<R> extends RegionFileCache implements AutoCloseab
  
      }
  
@@ -14987,12 +17657,16 @@ index 04256a95108b8182e8f808e856e0d2b62165e242..79a11d17a2822b192dec5981d0344ae6
 +    }
 +    // Tuinity end - actually unload POI data
 +
-+    @Nullable protected Optional<R> getIfLoaded(long value) { return this.c(value); } // Tuinity - OBFHELPER
++    @Nullable public final Optional<R> getIfLoaded(long value) { return this.c(value); } // Tuinity - OBFHELPER // Tuinity - OBFHELPER
 +    @Nullable protected Optional<R> c(long i) { // Tuinity - OBFHELPER
          return (Optional) this.c.get(i);
      }
  
-@@ -150,6 +184,7 @@ public class RegionFileSection<R> extends RegionFileCache implements AutoCloseab
++    public final Optional<R> getOrLoad(long coordinate) { return this.d(coordinate); } // Tuinity - OBFHELPER
+     protected Optional<R> d(long i) {
+         SectionPosition sectionposition = SectionPosition.a(i);
+ 
+@@ -150,6 +185,7 @@ public class RegionFileSection<R> extends RegionFileCache implements AutoCloseab
                  });
              }
          }
@@ -15000,7 +17674,7 @@ index 04256a95108b8182e8f808e856e0d2b62165e242..79a11d17a2822b192dec5981d0344ae6
  
      }
  
-@@ -221,6 +256,7 @@ public class RegionFileSection<R> extends RegionFileCache implements AutoCloseab
+@@ -221,6 +257,7 @@ public class RegionFileSection<R> extends RegionFileCache implements AutoCloseab
          return dynamic.get("DataVersion").asInt(1945);
      }
  
@@ -15022,17 +17696,21 @@ index f95925f1c5d091f1a129d0437bb6e175c6ac080f..0bb3ad0bffc04eba38cd827eaf5c63e8
      }
  
 diff --git a/src/main/java/net/minecraft/server/SensorNearestBed.java b/src/main/java/net/minecraft/server/SensorNearestBed.java
-index ad3609f2b884f64f1a1a449036cece49a46e933e..d3d28f97f9d2f969a182aec5e0947b6969d2939c 100644
+index ad3609f2b884f64f1a1a449036cece49a46e933e..89f8ce32225bc560b9927273f5984c6206360ac7 100644
 --- a/src/main/java/net/minecraft/server/SensorNearestBed.java
 +++ b/src/main/java/net/minecraft/server/SensorNearestBed.java
-@@ -40,15 +40,15 @@ public class SensorNearestBed extends Sensor<EntityInsentient> {
+@@ -40,15 +40,19 @@ public class SensorNearestBed extends Sensor<EntityInsentient> {
                      return true;
                  }
              };
 -            Stream<BlockPosition> stream = villageplace.a(VillagePlaceType.r.c(), predicate, entityinsentient.getChunkCoordinates(), 48, VillagePlace.Occupancy.ANY);
 -            PathEntity pathentity = entityinsentient.getNavigation().a(stream, VillagePlaceType.r.d());
-+            Set<BlockPosition> set = BehaviorFindPosition.findPoi(villageplace, VillagePlaceType.r.c(), predicate, entityinsentient.getChunkCoordinates(), 48, VillagePlace.Occupancy.ANY, Integer.MAX_VALUE); // Tuinity - remove streams
-+            PathEntity pathentity = entityinsentient.getNavigation().a(set, 8, false, VillagePlaceType.r.d()); // this.a((Set) stream.collect(Collectors.toSet()), 8, false, i) // Tuinity - remove streams
++            // Tuinity start - optimise POI access
++            java.util.List<BlockPosition> poiposes = new java.util.ArrayList<>();
++            // don't ask me why it's unbounded. ask mojang.
++            com.tuinity.tuinity.util.PoiAccess.findAnyPoiPositions(villageplace, VillagePlaceType.r.c(), predicate, entityinsentient.getChunkCoordinates(), 48, VillagePlace.Occupancy.ANY, false, Integer.MAX_VALUE, poiposes);
++            PathEntity pathentity = entityinsentient.getNavigation().a(new java.util.HashSet<>(poiposes), VillagePlaceType.r.d());
++            // Tuinity end - optimise POI access
  
              if (pathentity != null && pathentity.j()) {
                  BlockPosition blockposition = pathentity.m();
@@ -15208,10 +17886,53 @@ index 5f4dacf9c93c2495a07df2647fe0411f796da6af..0668d383db1f3a81d1053954d72678c7
                  protected void initChannel(Channel channel) throws Exception {
                      try {
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
-index 661ad8f8e67046211e001ea40d97660d7c88f8e5..a77b1d61b9dcb0a2a27d7e50357eaf44c99a661e 100644
+index 661ad8f8e67046211e001ea40d97660d7c88f8e5..53fd0549c965b2252ad80648d61ff1f7cd2b837a 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java
 +++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
-@@ -216,7 +216,7 @@ public final class SpawnerCreature {
+@@ -30,9 +30,9 @@ public final class SpawnerCreature {
+ 
+     public static SpawnerCreature.d a(int i, Iterable<Entity> iterable, SpawnerCreature.b spawnercreature_b) {
+         // Paper start - add countMobs parameter
+-        return countMobs(i, iterable, spawnercreature_b, false);
++        return countMobs(i, iterable, spawnercreature_b, false, null); // Tuinity - it'll still be broken no matter what
+     }
+-    public static SpawnerCreature.d countMobs(int i, Iterable<Entity> iterable, SpawnerCreature.b spawnercreature_b, boolean countMobs) {
++    public static SpawnerCreature.d countMobs(int i, Iterable<Entity> iterable, SpawnerCreature.b spawnercreature_b, boolean countMobs, ChunkProviderServer chunkProvider) { // Tuinity - add CPS param
+         // Paper end - add countMobs parameter
+         SpawnerCreatureProbabilities spawnercreatureprobabilities = new SpawnerCreatureProbabilities();
+         Object2IntOpenHashMap<EnumCreatureType> object2intopenhashmap = new Object2IntOpenHashMap();
+@@ -63,7 +63,16 @@ public final class SpawnerCreature {
+                 BlockPosition blockposition = entity.getChunkCoordinates();
+                 long j = ChunkCoordIntPair.pair(blockposition.getX() >> 4, blockposition.getZ() >> 4);
+ 
+-                spawnercreature_b.query(j, (chunk) -> {
++                // Tuinity start - remove chunk lookup and lambda
++                Chunk chunk = entity.getCurrentChunk();
++                if (chunk == null || j != chunk.coordinateKey) { // no chunk or coordinate doesn't match
++                    chunk = chunkProvider.getChunkAtIfLoadedMainThreadNoCache(blockposition.getX() >> 4, blockposition.getZ() >> 4);
++                    if (chunk == null) {
++                        // unloaded chunk! no longer FULL.
++                        continue;
++                    }
++                }
++                // Tuinity end - remove chunk lookup and lambda
+                     BiomeSettingsMobs.b biomesettingsmobs_b = b(blockposition, chunk).b().a(entity.getEntityType());
+ 
+                     if (biomesettingsmobs_b != null) {
+@@ -73,10 +82,10 @@ public final class SpawnerCreature {
+                     object2intopenhashmap.addTo(enumcreaturetype, 1);
+                     // Paper start
+                     if (countMobs) {
+-                        ((WorldServer)chunk.world).getChunkProvider().playerChunkMap.updatePlayerMobTypeMap(entity);
++                        chunkProvider.playerChunkMap.updatePlayerMobTypeMap(entity); // Tuinity - directly use chunk provider
+                     }
+                     // Paper end
+-                });
++                // Tuinity - remove chunk lookup and lambda
+             }
+         }
+ 
+@@ -216,7 +225,7 @@ public final class SpawnerCreature {
                              blockposition_mutableblockposition.d(l, i, i1);
                              double d0 = (double) l + 0.5D;
                              double d1 = (double) i1 + 0.5D;
@@ -15220,7 +17941,7 @@ index 661ad8f8e67046211e001ea40d97660d7c88f8e5..a77b1d61b9dcb0a2a27d7e50357eaf44
  
                              if (entityhuman != null) {
                                  double d2 = entityhuman.h(d0, (double) i, d1);
-@@ -288,7 +288,7 @@ public final class SpawnerCreature {
+@@ -288,7 +297,7 @@ public final class SpawnerCreature {
      }
  
      private static boolean a(WorldServer worldserver, IChunkAccess ichunkaccess, BlockPosition.MutableBlockPosition blockposition_mutableblockposition, double d0) {
@@ -15413,10 +18134,10 @@ index 8c3aa47a28914fd69a7f2e55a8c8f91d8e02371e..afc2ddf519cf4930663f1859b8ce89a7
  
      private static JsonElement a(UserCache.UserCacheEntry usercache_usercacheentry, DateFormat dateformat) {
 diff --git a/src/main/java/net/minecraft/server/Vec3D.java b/src/main/java/net/minecraft/server/Vec3D.java
-index 7f05587d42b7cdb09552277ec2e467f0edf06f10..5af554870bcf36e47aef43b966b141b9eda6c4d5 100644
+index 7f05587d42b7cdb09552277ec2e467f0edf06f10..7190316a38e6b4edf5501bfedbb12be79e990797 100644
 --- a/src/main/java/net/minecraft/server/Vec3D.java
 +++ b/src/main/java/net/minecraft/server/Vec3D.java
-@@ -4,7 +4,7 @@ import java.util.EnumSet;
+@@ -4,11 +4,17 @@ import java.util.EnumSet;
  
  public class Vec3D implements IPosition {
  
@@ -15425,7 +18146,17 @@ index 7f05587d42b7cdb09552277ec2e467f0edf06f10..5af554870bcf36e47aef43b966b141b9
      public final double x;
      public final double y;
      public final double z;
-@@ -61,6 +61,7 @@ public class Vec3D implements IPosition {
+ 
++    // Tuinity start
++    public final double magnitudeXZSquared() {
++        return (this.x * this.x) + (this.z * this.z);
++    }
++    // Tuinity end
++
+     public static Vec3D a(BaseBlockPosition baseblockposition) {
+         return new Vec3D((double) baseblockposition.getX() + 0.5D, (double) baseblockposition.getY() + 0.5D, (double) baseblockposition.getZ() + 0.5D);
+     }
+@@ -61,6 +67,7 @@ public class Vec3D implements IPosition {
          return this.add(-d0, -d1, -d2);
      }
  
@@ -15433,7 +18164,7 @@ index 7f05587d42b7cdb09552277ec2e467f0edf06f10..5af554870bcf36e47aef43b966b141b9
      public Vec3D e(Vec3D vec3d) {
          return this.add(vec3d.x, vec3d.y, vec3d.z);
      }
-@@ -109,10 +110,12 @@ public class Vec3D implements IPosition {
+@@ -109,10 +116,12 @@ public class Vec3D implements IPosition {
          return new Vec3D(this.x * d0, this.y * d1, this.z * d2);
      }
  
@@ -15447,7 +18178,7 @@ index 7f05587d42b7cdb09552277ec2e467f0edf06f10..5af554870bcf36e47aef43b966b141b9
          return this.x * this.x + this.y * this.y + this.z * this.z;
      }
 diff --git a/src/main/java/net/minecraft/server/VillagePlace.java b/src/main/java/net/minecraft/server/VillagePlace.java
-index 6a0f07b13eef5560dfc7c7b39618c0b825533aec..fce9967912628c232fe41ccc17fe2296f001ec61 100644
+index 6a0f07b13eef5560dfc7c7b39618c0b825533aec..245bdedd17b844dcd13aa0b60dffb1cac6a5bdb8 100644
 --- a/src/main/java/net/minecraft/server/VillagePlace.java
 +++ b/src/main/java/net/minecraft/server/VillagePlace.java
 @@ -4,6 +4,7 @@ import com.mojang.datafixers.DataFixer;
@@ -15610,7 +18341,71 @@ index 6a0f07b13eef5560dfc7c7b39618c0b825533aec..fce9967912628c232fe41ccc17fe2296
      public void a(BlockPosition blockposition, VillagePlaceType villageplacetype) {
          ((VillagePlaceSection) this.e(SectionPosition.a(blockposition).s())).a(blockposition, villageplacetype);
      }
-@@ -140,10 +272,11 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
+@@ -95,31 +227,47 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
+     }
+ 
+     public Optional<BlockPosition> c(Predicate<VillagePlaceType> predicate, Predicate<BlockPosition> predicate1, BlockPosition blockposition, int i, VillagePlace.Occupancy villageplace_occupancy) {
+-        return this.a(predicate, predicate1, blockposition, i, villageplace_occupancy).findFirst();
++        // Tuinity start - re-route to faster logic
++        BlockPosition ret = com.tuinity.tuinity.util.PoiAccess.findAnyPoiPosition(this, predicate, predicate1, blockposition, i, villageplace_occupancy, false);
++        return Optional.ofNullable(ret);
++        // Tuinity end - re-route to faster logic
+     }
+ 
+     public Optional<BlockPosition> d(Predicate<VillagePlaceType> predicate, BlockPosition blockposition, int i, VillagePlace.Occupancy villageplace_occupancy) {
+-        return this.c(predicate, blockposition, i, villageplace_occupancy).map(VillagePlaceRecord::f).min(Comparator.comparingDouble((blockposition1) -> {
+-            return blockposition1.j(blockposition);
+-        }));
++        // Tuinity start - re-route to faster logic
++        BlockPosition ret = com.tuinity.tuinity.util.PoiAccess.findClosestPoiDataPosition(this, predicate, null, blockposition, i, i*i, villageplace_occupancy, false);
++        return Optional.ofNullable(ret);
++        // Tuinity end - re-route to faster logic
+     }
+ 
+     public Optional<BlockPosition> a(Predicate<VillagePlaceType> predicate, Predicate<BlockPosition> predicate1, BlockPosition blockposition, int i) {
+-        return this.c(predicate, blockposition, i, VillagePlace.Occupancy.HAS_SPACE).filter((villageplacerecord) -> {
+-            return predicate1.test(villageplacerecord.f());
+-        }).findFirst().map((villageplacerecord) -> {
+-            villageplacerecord.b();
+-            return villageplacerecord.f();
+-        });
++        // Tuinity start - re-route to faster logic
++        VillagePlaceRecord ret = com.tuinity.tuinity.util.PoiAccess.findAnyPoiRecord(this, predicate, predicate1, blockposition, i,
++                VillagePlace.Occupancy.HAS_SPACE, false);
++        if (ret == null) {
++            return Optional.empty();
++        }
++        // copy from the map() from the old code
++        ret.b();
++        return Optional.ofNullable(ret.f());
++        // Tuinity end - re-route to faster logic
+     }
+ 
+     public Optional<BlockPosition> a(Predicate<VillagePlaceType> predicate, Predicate<BlockPosition> predicate1, VillagePlace.Occupancy villageplace_occupancy, BlockPosition blockposition, int i, Random random) {
+-        List<VillagePlaceRecord> list = (List) this.c(predicate, blockposition, i, villageplace_occupancy).collect(Collectors.toList());
+-
+-        Collections.shuffle(list, random);
+-        return list.stream().filter((villageplacerecord) -> {
+-            return predicate1.test(villageplacerecord.f());
+-        }).findFirst().map(VillagePlaceRecord::f);
++        // Tuinity start - re-route to faster logic
++        List<VillagePlaceRecord> list = new java.util.ArrayList<>();
++        com.tuinity.tuinity.util.PoiAccess.findAnyPoiRecords(this, predicate, predicate1, blockposition, i, villageplace_occupancy, false, Integer.MAX_VALUE, list);
++        // Tuinity end - re-route to faster logic
++
++        // Tuinity start - rewrite this to use improved logic
++        // the old method shuffled the list and then tried to find the first element in it that
++        // matched predicate1, however we moved predicate1 into the poi search. This means we can avoid a shuffle
++        // entirely, and just pick a random element from list
++        if (list.isEmpty()) {
++            return Optional.empty();
++        }
++        return Optional.ofNullable(list.get(random.nextInt(list.size())).f());
++        // Tuinity end - rewrite this to use improved logic
+     }
+ 
+     public boolean b(BlockPosition blockposition) {
+@@ -140,10 +288,11 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
      }
  
      public int a(SectionPosition sectionposition) {
@@ -15624,7 +18419,7 @@ index 6a0f07b13eef5560dfc7c7b39618c0b825533aec..fce9967912628c232fe41ccc17fe2296
      private boolean f(long i) {
          Optional<VillagePlaceSection> optional = this.c(i);
  
-@@ -159,7 +292,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
+@@ -159,7 +308,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
              super.a(booleansupplier);
          } else {
              //super.a(booleansupplier); // re-implement below
@@ -15633,7 +18428,7 @@ index 6a0f07b13eef5560dfc7c7b39618c0b825533aec..fce9967912628c232fe41ccc17fe2296
                  ChunkCoordIntPair chunkcoordintpair = SectionPosition.a(((RegionFileSection)this).d.firstLong()).r();
  
                  NBTTagCompound data;
-@@ -167,22 +300,27 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
+@@ -167,22 +316,27 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
                      data = this.getData(chunkcoordintpair);
                  }
                  com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE.scheduleSave(this.world,
@@ -15665,7 +18460,7 @@ index 6a0f07b13eef5560dfc7c7b39618c0b825533aec..fce9967912628c232fe41ccc17fe2296
      }
  
      public void a(ChunkCoordIntPair chunkcoordintpair, ChunkSection chunksection) {
-@@ -247,7 +385,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
+@@ -247,7 +401,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
  
          @Override
          protected int b(long i) {
@@ -15674,7 +18469,7 @@ index 6a0f07b13eef5560dfc7c7b39618c0b825533aec..fce9967912628c232fe41ccc17fe2296
          }
  
          @Override
-@@ -292,7 +430,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
+@@ -292,7 +446,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
          if (this.world != null && Thread.currentThread() != com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE) {
              com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE.scheduleSave(
                  this.world, chunkcoordintpair.x, chunkcoordintpair.z, nbttagcompound, null,
@@ -15683,7 +18478,7 @@ index 6a0f07b13eef5560dfc7c7b39618c0b825533aec..fce9967912628c232fe41ccc17fe2296
              return;
          }
          super.write(chunkcoordintpair, nbttagcompound);
-@@ -311,6 +449,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
+@@ -311,6 +465,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
              this.d = predicate;
          }
  
@@ -16117,7 +18912,7 @@ index 5d9d58411f2fad9d5da703f964d269b4a7c2b205..f0fdfd6891e59891e7370a2d682b65c6
          private double c;
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f5ab99156ce5429e63976183cbf115d5340a83a1..970c1be5477a01ab9c6d79e84c519e22775564ff 100644
+index f5ab99156ce5429e63976183cbf115d5340a83a1..bf06ef09cfd4d7618365249d1332d264d8ff1377 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -94,6 +94,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -16232,6 +19027,15 @@ index f5ab99156ce5429e63976183cbf115d5340a83a1..970c1be5477a01ab9c6d79e84c519e22
          IBlockData iblockdata = newBlock;
          IBlockData iblockdata1 = oldBlock;
          IBlockData iblockdata2 = actualBlock;
+@@ -473,7 +546,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+                 this.notify(blockposition, iblockdata1, iblockdata, i);
+                 // Paper start - per player view distance - allow block updates for non-ticking chunks in player view distance
+                 // if copied from above
+-            } else if ((i & 2) != 0 && (!this.isClientSide || (i & 4) == 0) && (this.isClientSide || chunk == null || ((WorldServer)this).getChunkProvider().playerChunkMap.playerViewDistanceBroadcastMap.getObjectsInRange(MCUtil.getCoordinateKey(blockposition)) != null)) {
++            } else if ((i & 2) != 0 && (!this.isClientSide || (i & 4) == 0) && (this.isClientSide || chunk == null || ((WorldServer)this).getChunkProvider().playerChunkMap.playerChunkManager.broadcastMap.getObjectsInRange(MCUtil.getCoordinateKey(blockposition)) != null)) { // Tuinity - replace old player chunk management
+                 ((WorldServer)this).getChunkProvider().flagDirty(blockposition);
+                 // Paper end - per player view distance
+             }
 @@ -895,6 +968,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
              return;
              // Paper end
@@ -16499,7 +19303,7 @@ index 6e82c1d1b272a95144bfc78d34b630c24466fa3e..6b4c007550c3e2e405314d8931630557
          return this.j.d();
      }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c2730338583527e447 100644
+index cf7d94aabab600822eb5e27f38690b06456d5fcc..a77fceac7c9e79a6bac05becc21bcb6bf2a1a7c7 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -55,12 +55,13 @@ import org.bukkit.event.server.MapInitializeEvent;
@@ -17094,7 +19898,54 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
              this.tickBlockEntities();
          }
  
-@@ -715,7 +1187,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -611,6 +1083,9 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+     private final BlockPosition.MutableBlockPosition chunkTickMutablePosition = new BlockPosition.MutableBlockPosition();
+     private final com.destroystokyo.paper.util.math.ThreadUnsafeRandom randomTickRandom = new com.destroystokyo.paper.util.math.ThreadUnsafeRandom();
+     // Paper end
++    // Tuinity start - optimise chunk ice snow ticking
++    private final BiomeBase[] biomeBaseCache = new BiomeBase[1];
++    // Tuinity end - optimise chunk ice snow ticking
+ 
+     public void a(Chunk chunk, int i) { final int randomTickSpeed = i; // Paper
+         ChunkCoordIntPair chunkcoordintpair = chunk.getPos();
+@@ -648,28 +1123,32 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+         gameprofilerfiller.exitEnter("iceandsnow");
+         if (!this.paperConfig.disableIceAndSnow && this.randomTickRandom.nextInt(16) == 0) { // Paper - Disable ice and snow // Paper - optimise random ticking
+             // Paper start - optimise chunk ticking
++            // Tuinity start - optimise chunk ice snow ticking
++            BiomeBase[] biomeCache = this.biomeBaseCache;
++            biomeCache[0] = null;
++            // Tuinity start - optimise chunk ice snow ticking
+             this.getRandomBlockPosition(j, 0, k, 15, blockposition);
+             int normalY = chunk.getHighestBlockY(HeightMap.Type.MOTION_BLOCKING, blockposition.getX() & 15, blockposition.getZ() & 15);
+             int downY = normalY - 1;
+             blockposition.setY(normalY);
+             // Paper end
+-            BiomeBase biomebase = this.getBiome(blockposition);
++            //BiomeBase biomebase = this.getBiome(blockposition); // Tuinity - lazily-get biome
+ 
+             // Paper start - optimise chunk ticking
+             blockposition.setY(downY);
+-            if (biomebase.a(this, blockposition)) {
++            if (BiomeBase.canTurnWaterIntoIce(this, blockposition, true, chunk, biomeCache)) { // Tuinity - add chunk parameter, avoid biome lookup
+                 org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockFormEvent(this, blockposition, Blocks.ICE.getBlockData(), null); // CraftBukkit
+                 // Paper end
+             }
+ 
+             blockposition.setY(normalY); // Paper
+-            if (flag && biomebase.b(this, blockposition)) {
++            if (flag && BiomeBase.canTurnAirIntoSnow(this, blockposition, chunk, biomeCache)) {
+                 org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockFormEvent(this, blockposition, Blocks.SNOW.getBlockData(), null); // CraftBukkit
+             }
+ 
+             // Paper start - optimise chunk ticking
+             blockposition.setY(downY);
+-            if (flag && this.getBiome(blockposition).c() == BiomeBase.Precipitation.RAIN) {
++            if (flag && chunk.getType(blockposition).getBlock() instanceof BlockCauldron && this.getBiome(blockposition).c() == BiomeBase.Precipitation.RAIN) { // Tuinity - only cauldron uses that method, and it's not likely to hit. So, avoid the expensive biome lookup and replace it with a block lookup TODO check on update for overrides
+                 chunk.getType(blockposition).getBlock().c((World) this, blockposition);
+                 // Paper end
+             }
+@@ -715,7 +1194,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              }
              gameprofilerfiller.exit();
              timings.chunkTicksBlocks.stopTiming(); // Paper
@@ -17103,19 +19954,17 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
              // Paper end
          }
      }
-@@ -810,7 +1282,26 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -810,7 +1289,26 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
      }
  
 +    // Tuinity start - log detailed entity tick information
-+    static final java.util.concurrent.ConcurrentLinkedDeque<Entity> currentlyTickingEntities = new java.util.concurrent.ConcurrentLinkedDeque<>();
++    // TODO replace with varhandle
++    static final java.util.concurrent.atomic.AtomicReference<Entity> currentlyTickingEntity = new java.util.concurrent.atomic.AtomicReference<>();
 +
 +    public static List<Entity> getCurrentlyTickingEntities() {
-+        List<Entity> ret = Lists.newArrayListWithCapacity(4);
-+
-+        for (Entity entity : currentlyTickingEntities) {
-+            ret.add(entity);
-+        }
++        Entity ticking = currentlyTickingEntity.get();
++        List<Entity> ret = java.util.Arrays.asList(ticking == null ? new Entity[0] : new Entity[] { ticking });
 +
 +        return ret;
 +    }
@@ -17125,37 +19974,41 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
 +        // Tuinity start - log detailed entity tick information
 +        com.tuinity.tuinity.util.TickThread.ensureTickThread("Cannot tick an entity off-main");
 +        try {
-+            currentlyTickingEntities.push(entity);
++            if (currentlyTickingEntity.get() == null) {
++                currentlyTickingEntity.lazySet(entity);
++            }
 +            // Tuinity end - log detailed entity tick information
          if (!(entity instanceof EntityHuman) && !this.getChunkProvider().a(entity)) {
              this.chunkCheck(entity);
          } else {
-@@ -863,6 +1354,11 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -863,6 +1361,13 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              //} finally { timer.stopTiming(); } // Paper - timings - move up
  
          }
 +        // Tuinity start - log detailed entity tick information
 +        } finally {
-+            currentlyTickingEntities.pop();
++            if (currentlyTickingEntity.get() == entity) {
++                currentlyTickingEntity.lazySet(null);
++            }
 +        }
 +        // Tuinity end - log detailed entity tick information
      }
  
      public void a(Entity entity, Entity entity1) {
-@@ -921,6 +1417,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -921,6 +1426,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              int i = MathHelper.floor(entity.locX() / 16.0D);
              int j =  Math.min(15, Math.max(0, MathHelper.floor(entity.locY() / 16.0D))); // Paper - stay consistent with chunk add/remove behavior
              int k = MathHelper.floor(entity.locZ() / 16.0D);
 +            // Tuinity start
-+            int oldRegionX = entity.chunkX >> com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.REGION_CHUNK_SIZE_SHIFT;
-+            int oldRegionZ = entity.chunkZ >> com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.REGION_CHUNK_SIZE_SHIFT;
-+            int newRegionX = i >> com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.REGION_CHUNK_SIZE_SHIFT;
-+            int newRegionZ = k >> com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.REGION_CHUNK_SIZE_SHIFT;
++            int oldRegionX = entity.chunkX >> this.getChunkProvider().playerChunkMap.dataRegionManager.regionChunkShift;
++            int oldRegionZ = entity.chunkZ >> this.getChunkProvider().playerChunkMap.dataRegionManager.regionChunkShift;
++            int newRegionX = i >> this.getChunkProvider().playerChunkMap.dataRegionManager.regionChunkShift;
++            int newRegionZ = k >> this.getChunkProvider().playerChunkMap.dataRegionManager.regionChunkShift;
 +            // Tuinity end
  
              if (!entity.inChunk || entity.chunkX != i || entity.chunkY != j || entity.chunkZ != k) {
                  // Paper start - remove entity if its in a chunk more correctly.
-@@ -930,6 +1432,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -930,6 +1441,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  }
                  // Paper end
  
@@ -17168,7 +20021,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
                  if (entity.inChunk && this.isChunkLoaded(entity.chunkX, entity.chunkZ)) {
                      this.getChunkAt(entity.chunkX, entity.chunkZ).a(entity, entity.chunkY);
                  }
-@@ -943,6 +1451,11 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -943,6 +1460,11 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  } else {
                      this.getChunkAt(i, k).a(entity);
                  }
@@ -17180,7 +20033,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
              }
  
              this.getMethodProfiler().exit();
-@@ -1279,9 +1792,13 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1279,9 +1801,13 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          // Spigot Start
          for (TileEntity tileentity : chunk.getTileEntities().values()) {
              if (tileentity instanceof IInventory) {
@@ -17195,7 +20048,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
              }
          }
          // Spigot End
-@@ -1298,7 +1815,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1298,7 +1824,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  Entity entity = (Entity) iterator.next();
  
                  if (!(entity instanceof EntityPlayer)) {
@@ -17204,7 +20057,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
                          throw (IllegalStateException) SystemUtils.c((Throwable) (new IllegalStateException("Removing entity while ticking!")));
                      }
  
-@@ -1326,6 +1843,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1326,6 +1852,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
      public void unregisterEntity(Entity entity) {
          org.spigotmc.AsyncCatcher.catchOp("entity unregister"); // Spigot
@@ -17212,7 +20065,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
          // Paper start - fix entity registration issues
          if (entity instanceof EntityComplexPart) {
              // Usually this is a no-op for complex parts, and ID's should be removed, but go ahead and remove it anyways
-@@ -1392,17 +1910,108 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1392,17 +1919,76 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          this.getScoreboard().a(entity);
          // CraftBukkit start - SPIGOT-5278
          if (entity instanceof EntityDrowned) {
@@ -17237,84 +20090,52 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
  
 +    // Tuinity start - optimise notify()
 +    void removeNavigatorsIfNotPathingFromRegion(Entity entity) {
-+        com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection<PlayerChunkMap.RegionData> section =
++        com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection section =
 +                this.getChunkProvider().playerChunkMap.dataRegionManager.getRegionSection(entity.chunkX, entity.chunkZ);
 +        if (section != null) {
-+            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<NavigationAbstract> navigators = (com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet)section.getOrCreateData(PlayerChunkMap.RegionData.PATHING_NAVIGATORS);
-+            // Copied from above
-+            if (entity instanceof EntityDrowned) {
-+                if (!((EntityDrowned)entity).navigationWater.isViableForPathRecalculationChecking()) {
-+                    navigators.remove(((EntityDrowned)entity).navigationWater);
-+                }
-+                if (!((EntityDrowned)entity).navigationLand.isViableForPathRecalculationChecking()) {
-+                    navigators.remove(((EntityDrowned)entity).navigationLand);
-+                }
-+            } else if (entity instanceof EntityInsentient) {
++            PlayerChunkMap.DataRegionSectionData sectionData = (PlayerChunkMap.DataRegionSectionData)section.sectionData;
++            if (entity instanceof EntityInsentient) {
 +                if (!((EntityInsentient)entity).getNavigation().isViableForPathRecalculationChecking()) {
-+                    navigators.remove(((EntityInsentient)entity).getNavigation());
++                    sectionData.removeFromNavigators(section, (EntityInsentient)entity);
 +                }
 +            }
 +        }
 +    }
 +
 +    void removeNavigatorsFromData(Entity entity) {
-+        com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection<PlayerChunkMap.RegionData> section =
++        com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection section =
 +                this.getChunkProvider().playerChunkMap.dataRegionManager.getRegionSection(entity.chunkX, entity.chunkZ);
 +        if (section != null) {
-+            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<NavigationAbstract> navigators = (com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet)section.getOrCreateData(PlayerChunkMap.RegionData.PATHING_NAVIGATORS);
-+            // Copied from above
-+            if (entity instanceof EntityDrowned) {
-+                navigators.remove(((EntityDrowned)entity).navigationWater);
-+                navigators.remove(((EntityDrowned)entity).navigationLand);
-+            } else if (entity instanceof EntityInsentient) {
-+                navigators.remove(((EntityInsentient)entity).getNavigation());
++            PlayerChunkMap.DataRegionSectionData sectionData = (PlayerChunkMap.DataRegionSectionData)section.sectionData;
++            if (entity instanceof EntityInsentient) {
++                sectionData.removeFromNavigators(section, ((EntityInsentient)entity));
 +            }
 +        }
 +    }
 +
 +    void addNavigatorsIfPathingToRegion(Entity entity) {
-+        com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection<PlayerChunkMap.RegionData> section =
++        com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection section =
 +                this.getChunkProvider().playerChunkMap.dataRegionManager.getRegionSection(entity.chunkX, entity.chunkZ);
 +        if (section != null) {
-+            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<NavigationAbstract> navigators = (com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet)section.getOrCreateData(PlayerChunkMap.RegionData.PATHING_NAVIGATORS);
-+            // Copied from above
-+            if (entity instanceof EntityDrowned) {
-+                if (((EntityDrowned)entity).navigationWater.isViableForPathRecalculationChecking()) {
-+                    navigators.add(((EntityDrowned)entity).navigationWater);
-+                }
-+                if (((EntityDrowned)entity).navigationLand.isViableForPathRecalculationChecking()) {
-+                    navigators.add(((EntityDrowned)entity).navigationLand);
-+                }
-+            } else if (entity instanceof EntityInsentient) {
++            PlayerChunkMap.DataRegionSectionData sectionData = (PlayerChunkMap.DataRegionSectionData)section.sectionData;
++            if (entity instanceof EntityInsentient) {
 +                if (((EntityInsentient)entity).getNavigation().isViableForPathRecalculationChecking()) {
-+                    navigators.add(((EntityInsentient)entity).getNavigation());
++                    sectionData.addToNavigators(section, ((EntityInsentient)entity));
 +                }
 +            }
 +        }
 +    }
 +
 +    void updateNavigatorsInRegion(Entity entity) {
-+        com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection<PlayerChunkMap.RegionData> section =
++        com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection section =
 +                this.getChunkProvider().playerChunkMap.dataRegionManager.getRegionSection(entity.chunkX, entity.chunkZ);
 +        if (section != null) {
-+            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<NavigationAbstract> navigators = (com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet)section.getOrCreateData(PlayerChunkMap.RegionData.PATHING_NAVIGATORS);
-+            // Copied from above
-+            if (entity instanceof EntityDrowned) {
-+                if (((EntityDrowned)entity).navigationWater.isViableForPathRecalculationChecking()) {
-+                    navigators.add(((EntityDrowned)entity).navigationWater);
-+                } else {
-+                    navigators.remove(((EntityDrowned)entity).navigationWater);
-+                }
-+                if (((EntityDrowned)entity).navigationLand.isViableForPathRecalculationChecking()) {
-+                    navigators.add(((EntityDrowned)entity).navigationLand);
-+                } else {
-+                    navigators.remove(((EntityDrowned)entity).navigationLand);
-+                }
-+            } else if (entity instanceof EntityInsentient) {
++            PlayerChunkMap.DataRegionSectionData sectionData = (PlayerChunkMap.DataRegionSectionData)section.sectionData;
++            if (entity instanceof EntityInsentient) {
 +                if (((EntityInsentient)entity).getNavigation().isViableForPathRecalculationChecking()) {
-+                    navigators.add(((EntityInsentient)entity).getNavigation());
++                    sectionData.addToNavigators(section, ((EntityInsentient)entity));
 +                } else {
-+                    navigators.remove(((EntityInsentient)entity).getNavigation());
++                    sectionData.removeFromNavigators(section, ((EntityInsentient)entity));
 +                }
 +            }
 +        }
@@ -17324,7 +20145,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
      private void registerEntity(Entity entity) {
          org.spigotmc.AsyncCatcher.catchOp("entity register"); // Spigot
          // Paper start - don't double enqueue entity registration
-@@ -1413,7 +2022,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1413,7 +1999,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              return;
          }
          // Paper end
@@ -17333,7 +20154,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
              if (!entity.isQueuedForRegister) { // Paper
                  this.entitiesToAdd.add(entity);
                  entity.isQueuedForRegister = true; // Paper
-@@ -1421,6 +2030,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1421,6 +2007,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          } else {
              entity.isQueuedForRegister = false; // Paper
              this.entitiesById.put(entity.getId(), entity);
@@ -17341,7 +20162,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
              if (entity instanceof EntityEnderDragon) {
                  EntityComplexPart[] aentitycomplexpart = ((EntityEnderDragon) entity).eJ();
                  int i = aentitycomplexpart.length;
-@@ -1429,6 +2039,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1429,6 +2016,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                      EntityComplexPart entitycomplexpart = aentitycomplexpart[j];
  
                      this.entitiesById.put(entitycomplexpart.getId(), entitycomplexpart);
@@ -17349,7 +20170,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
                  }
              }
  
-@@ -1453,12 +2064,16 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1453,12 +2041,16 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              // this.getChunkProvider().addEntity(entity); // Paper - moved down below valid=true
              // CraftBukkit start - SPIGOT-5278
              if (entity instanceof EntityDrowned) {
@@ -17369,7 +20190,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
              }
              entity.valid = true; // CraftBukkit
              this.getChunkProvider().addEntity(entity); // Paper - from above to be below valid=true
-@@ -1474,7 +2089,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1474,7 +2066,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
      }
  
      public void removeEntity(Entity entity) {
@@ -17378,7 +20199,7 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
              throw (IllegalStateException) SystemUtils.c((Throwable) (new IllegalStateException("Removing entity while ticking!")));
          } else {
              this.removeEntityFromChunk(entity);
-@@ -1570,14 +2185,33 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1570,20 +2162,33 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
      @Override
      public void notify(BlockPosition blockposition, IBlockData iblockdata, IBlockData iblockdata1, int i) {
@@ -17390,49 +20211,37 @@ index cf7d94aabab600822eb5e27f38690b06456d5fcc..9c77be805eb71c409a5d41c273033858
  
          if (VoxelShapes.c(voxelshape, voxelshape1, OperatorBoolean.NOT_SAME)) {
 +            // Tuinity start - optimise notify()
-+            com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.Region<PlayerChunkMap.RegionData> region = this.getChunkProvider().playerChunkMap.dataRegionManager.getRegion(blockposition.getX() >> 4, blockposition.getZ() >> 4);
++            com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.Region region = this.getChunkProvider().playerChunkMap.dataRegionManager.getRegion(blockposition.getX() >> 4, blockposition.getZ() >> 4);
 +            if (region == null) {
 +                return;
 +            }
-+            // Tuinity end - optimise notify()
++            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<EntityInsentient> navigatorsFromRegion = ((PlayerChunkMap.DataRegionData)region.regionData).getNavigators();
++            if (navigatorsFromRegion == null) {
++                return;
++            }
              boolean wasTicking = this.tickingEntities; this.tickingEntities = true; // Paper
 -            Iterator iterator = this.navigators.iterator();
 +            // Tuinity start
-+            // Tuinity start - optimise notify()
-+            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet.Iterator<com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection<PlayerChunkMap.RegionData>> sectionIterator = null;
-+            try {
-+            for (sectionIterator = region.getSections(); sectionIterator.hasNext();) {
-+            com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionSection<PlayerChunkMap.RegionData> section = sectionIterator.next();
-+            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<NavigationAbstract> navigators = (com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet)section.getData(PlayerChunkMap.RegionData.PATHING_NAVIGATORS);
-+            if (navigators == null) {
-+                    continue;
-+            }
-+            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet.Iterator iterator = navigators.iterator();
++            com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet.Iterator<EntityInsentient> iterator = navigatorsFromRegion.iterator();
 +            // Tuinity end - optimise notify()
 +            try { // Tuinity end
  
              while (iterator.hasNext()) {
                  // CraftBukkit start - fix SPIGOT-6362
-@@ -1596,7 +2230,21 @@ public class WorldServer extends World implements GeneratorAccessSeed {
-                 if (!navigationabstract.i()) {
+                 NavigationAbstract navigationabstract;
+                 try {
+-                    navigationabstract = (NavigationAbstract) iterator.next();
++                    navigationabstract = (NavigationAbstract) iterator.next().getNavigation(); // Tuinity - optimise notify
+                 } catch (java.util.ConcurrentModificationException ex) {
+                     // This can happen because the pathfinder update below may trigger a chunk load, which in turn may cause more navigators to register
+                     // In this case we just run the update again across all the iterators as the chunk will then be loaded
+@@ -1597,6 +2202,9 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                      navigationabstract.b(blockposition);
                  }
--            }
-+                // Tuinity start - optimise notify()
-+                if (!navigationabstract.isViableForPathRecalculationChecking()) {
-+                    navigators.remove(navigationabstract);
-+                }
-+                // Tuinity end - optimise notify()
-+            }
+             }
 +            } finally { // Tuinity start
 +                iterator.finishedIterating();
 +            } // Tuinity end
-+            } // Tuinity start - optimise notify()
-+            } finally {
-+                if (sectionIterator != null) {
-+                    sectionIterator.finishedIterating();
-+                }
-+            } // Tuinity end - optimise notify()
  
              this.tickingEntities = wasTicking; // Paper
          }
@@ -17519,7 +20328,7 @@ index 1398b18409db3b3741ce199ee7156a2dfe2cc96c..f994e99ebc8fe22e6f6b45f6379ec410
          public void restart() {
              org.spigotmc.RestartCommand.restart();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index cade3ed6079011f44eba613dece3d69ec18f8f04..3e54e643d28ced3074c4b044bc8a2238de05ccc2 100644
+index cade3ed6079011f44eba613dece3d69ec18f8f04..902aaee6a53dbb4dccd7a34b3d6283769604d309 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -342,6 +342,14 @@ public class CraftWorld implements World {
@@ -17601,6 +20410,39 @@ index cade3ed6079011f44eba613dece3d69ec18f8f04..3e54e643d28ced3074c4b044bc8a2238
              return CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, MinecraftServer.getServer());
      }
+@@ -2613,7 +2639,7 @@ public class CraftWorld implements World {
+ 
+     @Override
+     public int getNoTickViewDistance() {
+-        return getHandle().getChunkProvider().playerChunkMap.getEffectiveNoTickViewDistance();
++        return getHandle().getChunkProvider().playerChunkMap.playerChunkManager.getTargetNoTickViewDistance(); // Tuinity - replace old player chunk management
+     }
+ 
+     @Override
+@@ -2622,11 +2648,22 @@ public class CraftWorld implements World {
+             throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
+         }
+         net.minecraft.server.PlayerChunkMap chunkMap = getHandle().getChunkProvider().playerChunkMap;
+-        if (viewDistance != chunkMap.getRawNoTickViewDistance()) {
++        if (true) { // Tuinity - replace old player chunk management
+             chunkMap.setNoTickViewDistance(viewDistance);
+         }
+     }
+     // Paper end - per player view distance
++    // Tuinity start - add view distances
++    @Override
++    public int getSendViewDistance() {
++        return getHandle().getChunkProvider().playerChunkMap.playerChunkManager.getTargetSendDistance();
++    }
++
++    @Override
++    public void setSendViewDistance(int viewDistance) {
++        getHandle().getChunkProvider().playerChunkMap.playerChunkManager.setTargetSendDistance(viewDistance);
++    }
++    // Tuinity end - add view distances
+ 
+     // Spigot start
+     private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
 index 22bde395939f97086e411cef190bb2b1e7ede79a..0f6cb508a170360b6479f9c34048412453fbb89d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
@@ -17699,6 +20541,83 @@ index 2fc101869775711533a1e50f9ae608cd74d36d3a..2af3bee540ee25ea32a7548fd0d64dea
      @Override
      public boolean teleport(org.bukkit.entity.Entity destination) {
          return teleport(destination.getLocation());
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index f965b071cd2f6a70a216679e4f19956115edee4f..b3636032fd36efe2e7e546dbebdfd5c1208f9951 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -2248,15 +2248,70 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+     }
+ 
++    // Tuinity start - implement view distances
++    @Override
++    public int getSendViewDistance() {
++        net.minecraft.server.PlayerChunkMap chunkMap = this.getHandle().getWorldServer().getChunkProvider().playerChunkMap;
++        com.tuinity.tuinity.chunk.PlayerChunkLoader.PlayerLoaderData data = chunkMap.playerChunkManager.getData(this.getHandle());
++        if (data == null) {
++            return chunkMap.playerChunkManager.getTargetSendDistance();
++        }
++        return data.getTargetSendViewDistance();
++    }
++
++    @Override
++    public void setSendViewDistance(int viewDistance) {
++        net.minecraft.server.PlayerChunkMap chunkMap = this.getHandle().getWorldServer().getChunkProvider().playerChunkMap;
++        com.tuinity.tuinity.chunk.PlayerChunkLoader.PlayerLoaderData data = chunkMap.playerChunkManager.getData(this.getHandle());
++        if (data == null) {
++            throw new IllegalStateException("Player is not attached to world");
++        }
++
++        data.setTargetSendViewDistance(viewDistance);
++    }
++
++    @Override
++    public int getNoTickViewDistance() {
++        net.minecraft.server.PlayerChunkMap chunkMap = this.getHandle().getWorldServer().getChunkProvider().playerChunkMap;
++        com.tuinity.tuinity.chunk.PlayerChunkLoader.PlayerLoaderData data = chunkMap.playerChunkManager.getData(this.getHandle());
++        if (data == null) {
++            return chunkMap.playerChunkManager.getTargetNoTickViewDistance();
++        }
++        return data.getTargetNoTickViewDistance();
++    }
++
++    @Override
++    public void setNoTickViewDistance(int viewDistance) {
++        net.minecraft.server.PlayerChunkMap chunkMap = this.getHandle().getWorldServer().getChunkProvider().playerChunkMap;
++        com.tuinity.tuinity.chunk.PlayerChunkLoader.PlayerLoaderData data = chunkMap.playerChunkManager.getData(this.getHandle());
++        if (data == null) {
++            throw new IllegalStateException("Player is not attached to world");
++        }
++
++        data.setTargetNoTickViewDistance(viewDistance);
++    }
++
+     @Override
+     public int getViewDistance() {
+-        throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
++        net.minecraft.server.PlayerChunkMap chunkMap = this.getHandle().getWorldServer().getChunkProvider().playerChunkMap;
++        com.tuinity.tuinity.chunk.PlayerChunkLoader.PlayerLoaderData data = chunkMap.playerChunkManager.getData(this.getHandle());
++        if (data == null) {
++            return chunkMap.playerChunkManager.getTargetViewDistance();
++        }
++        return data.getTargetTickViewDistance();
+     }
+ 
+     @Override
+     public void setViewDistance(int viewDistance) {
+-        throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
++        net.minecraft.server.PlayerChunkMap chunkMap = this.getHandle().getWorldServer().getChunkProvider().playerChunkMap;
++        com.tuinity.tuinity.chunk.PlayerChunkLoader.PlayerLoaderData data = chunkMap.playerChunkManager.getData(this.getHandle());
++        if (data == null) {
++            throw new IllegalStateException("Player is not attached to world");
++        }
++
++        data.setTargetTickViewDistance(viewDistance);
+     }
++    // Tuinity end - implement view distances
+ 
+     @Override
+     public <T> T getClientOption(ClientOption<T> type) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncTask.java
 index fd32d1450a6a2ede3405be7d31697cd16957f553..c38e514b004a4684026d5a89c606399a4fd7efe1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftAsyncTask.java

--- a/patches/server/0002-Airplane-Server-Changes.patch
+++ b/patches/server/0002-Airplane-Server-Changes.patch
@@ -709,7 +709,7 @@ index c56e7fb18f9a56c8025eb70a524f028b5942da37..f39452535b2807a226ada095f5c21b19
          TimingsManager.privacy = getBoolean("timings.server-name-privacy", false);
          TimingsManager.hiddenConfigs = getList("timings.hidden-config-entries", Lists.newArrayList("database", "settings.bungeecord-addresses", "settings.velocity-support.secret"));
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-index 7063f1da3654b382e26b0093ad5d0ff04a2b38c2..dd2a1b1c72426c4172cfbd20f0c84ffd073df484 100644
+index 7063f1da3654b382e26b0093ad5d0ff04a2b38c2..b9c5479e5561f8fe68ea8f94fbf4e64de8a53bf9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 @@ -28,8 +28,8 @@ public class PaperVersionFetcher implements VersionFetcher {
@@ -718,8 +718,8 @@ index 7063f1da3654b382e26b0093ad5d0ff04a2b38c2..dd2a1b1c72426c4172cfbd20f0c84ffd
      public Component getVersionMessage(@Nonnull String serverVersion) {
 -        String[] parts = serverVersion.substring("git-Tuinity-".length()).split("[-\\s]"); // Tuinity
 -        final Component updateMessage = getUpdateStatusMessage("Spottedleaf/Tuinity", GITHUB_BRANCH_NAME, parts[0]); // Tuinity
-+        String[] parts = serverVersion.substring("git-Airplane-".length()).split("[-\\s]"); // Airplane // Tuinity
-+        final Component updateMessage = getUpdateStatusMessage("TECHNOVE/Airplane", GITHUB_BRANCH_NAME, parts[0]); // Airplane // Tuinity
++        String[] parts = serverVersion.substring("git-Airplane-".length()).split("[-\\s]"); // Tuinity
++        final Component updateMessage = getUpdateStatusMessage("TECHNOVE/Airplane", GITHUB_BRANCH_NAME, parts[0]); // Tuinity
          final Component history = getHistory();
  
          return history != null ? TextComponent.ofChildren(updateMessage, Component.newline(), history) : updateMessage;
@@ -800,10 +800,10 @@ index 0000000000000000000000000000000000000000..1fa9b40e2f89272fa8bc9d927a9a852b
 +}
 diff --git a/src/main/java/gg/airplane/AirplaneConfig.java b/src/main/java/gg/airplane/AirplaneConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e183b6cae23935823fa9e0f767e499a8102b0ad1
+index 0000000000000000000000000000000000000000..424325ada75b788ce390378d8df0116e5c50cf3d
 --- /dev/null
 +++ b/src/main/java/gg/airplane/AirplaneConfig.java
-@@ -0,0 +1,104 @@
+@@ -0,0 +1,107 @@
 +package gg.airplane;
 +
 +import gg.airplane.manual.ManualParser;
@@ -891,6 +891,9 @@ index 0000000000000000000000000000000000000000..e183b6cae23935823fa9e0f767e499a8
 +
 +        accessToken = manual.get("web-services.token", "");
 +        // todo lookup token (off-thread) and let users know if their token is valid
++        if (accessToken.length() > 0) {
++            gg.airplane.flare.FlareSetup.init(); // Airplane
++        }
 +    }
 +
 +
@@ -1034,10 +1037,10 @@ index 0000000000000000000000000000000000000000..f4976428bc721319d2926e97cbe0f64c
 +}
 diff --git a/src/main/java/gg/airplane/flare/FlareCommand.java b/src/main/java/gg/airplane/flare/FlareCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..81f5267d287138f6b47aa0a1f1d59d2d91a7e34a
+index 0000000000000000000000000000000000000000..e3ef62ae97b8b92459e1c405525790ba2172df01
 --- /dev/null
 +++ b/src/main/java/gg/airplane/flare/FlareCommand.java
-@@ -0,0 +1,158 @@
+@@ -0,0 +1,159 @@
 +package gg.airplane.flare;
 +
 +import com.google.common.collect.ImmutableList;
@@ -1062,6 +1065,7 @@ index 0000000000000000000000000000000000000000..81f5267d287138f6b47aa0a1f1d59d2d
 +
 +public class FlareCommand extends Command {
 +
++    private static final String BASE_URL = "https://blog.airplane.gg/flare-tutorial/#setting-the-access-token";
 +    private static final ChatColor HEX = ChatColor.of("#6a7eda");
 +    private static final BaseComponent[] PREFIX = new ComponentBuilder("Flare ✈ ")
 +      .color(HEX)
@@ -1087,10 +1091,10 @@ index 0000000000000000000000000000000000000000..81f5267d287138f6b47aa0a1f1d59d2d
 +    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
 +        if (!testPermission(sender)) return true;
 +        if (AirplaneConfig.accessToken.length() == 0) {
-+            BaseComponent clickable = new TextComponent("https://blog.airplane.gg/flare");
++            BaseComponent clickable = new TextComponent(BASE_URL);
 +            clickable.setUnderlined(true);
 +            clickable.setColor(HEX);
-+            clickable.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, "https://blog.airplane.gg/flare"));
++            clickable.setClickEvent(new ClickEvent(ClickEvent.Action.OPEN_URL, BASE_URL));
 +
 +            sender.sendMessage(create(new ComponentBuilder("Flare currently requires an access token to use. To learn more, visit ")
 +              .color(HEX)
@@ -1637,7 +1641,7 @@ index 0000000000000000000000000000000000000000..ace29adb0f140d99a8d85ac824654bed
 +}
 diff --git a/src/main/java/gg/airplane/structs/TrackQueue.java b/src/main/java/gg/airplane/structs/TrackQueue.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..601694aa6d36ce230d84cc6b55231d2fc3af30e9
+index 0000000000000000000000000000000000000000..e72229128285e1a48b9b461620620976ca0dc0a4
 --- /dev/null
 +++ b/src/main/java/gg/airplane/structs/TrackQueue.java
 @@ -0,0 +1,84 @@
@@ -1658,7 +1662,7 @@ index 0000000000000000000000000000000000000000..601694aa6d36ce230d84cc6b55231d2f
 +public class TrackQueue {
 +
 +    private final IteratorSafeOrderedReferenceSet<Chunk> chunks;
-+    private final ForkJoinPool pool = ForkJoinPool.commonPool();
++    private final ForkJoinPool pool = new ForkJoinPool(Math.max(4, Runtime.getRuntime().availableProcessors() >> 2));
 +    private final AtomicInteger taskIndex = new AtomicInteger();
 +
 +    private final ConcurrentLinkedQueue<Runnable> mainThreadTasks;
@@ -1762,10 +1766,10 @@ index 19f8cf4384ff7a1515ad33a5f573ea0061bab93d..e6507a9bef705e1496497ad6b58a5463
  
      private static EntityVillager a(EntityVillager entityvillager, EntityVillager entityvillager1) {
 diff --git a/src/main/java/net/minecraft/server/BehaviorFindPosition.java b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-index 8d445e9c0875db6cf45e4d8bcfce7cd3d5094d94..0594b0bb12c553edbb6284b48328a3dcf5a64ba4 100644
+index 83702e07dff72b639af32c8ba9e831e58da92a10..a48f2f82517bc391d5d5b7961e3c7a75175abb65 100644
 --- a/src/main/java/net/minecraft/server/BehaviorFindPosition.java
 +++ b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-@@ -278,6 +278,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+@@ -57,6 +57,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
  
      protected void a(WorldServer worldserver, EntityCreature entitycreature, long i) {
          this.f = i + 20L + (long) worldserver.getRandom().nextInt(20);
@@ -1812,7 +1816,7 @@ index 2291135eaef64c403183724cb6e413cd7e472672..72ee5fe0ca25844cbcd8f1bbbbd6a7f8
          @Override
          public BlockPosition shift(EnumDirection enumdirection, int i) {
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 8fda4702764e80dae93ef9c0eb53abc198642ab1..1d65d884d1f31a73333e4cf6a9ce30d7863dab9f 100644
+index 8e59a794f6190930cb7bb81a2fe1a1d374dacce7..6cde93d62c4c324a6544401cabe045cbb80f465e 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -53,6 +53,38 @@ public class Chunk implements IChunkAccess {
@@ -1863,10 +1867,10 @@ index 8fda4702764e80dae93ef9c0eb53abc198642ab1..1d65d884d1f31a73333e4cf6a9ce30d7
  
      public org.bukkit.Chunk bukkitChunk;
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index e26389d8d9ee4fedb32767fce3aed071af412304..9cf3cd69661a140d34d17195c2cd6dc299c95ddf 100644
+index b55f7dece329dbb3ff27d57a39c32c69e5baea74..5897d462d350dfbd1464feb92ecf77725651c694 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -974,6 +974,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -975,6 +975,7 @@ public class ChunkProviderServer extends IChunkProvider {
              }
              // Paper end - optimize isOutisdeRange
              this.world.getMethodProfiler().enter("pollingChunks");
@@ -1926,16 +1930,15 @@ index 73163b417af7e522a4509bf9c1ab56d6499be622..2855a2757c35afc5751a7ca6f3a12cc2
          for (int j = 0; j < 4096; ++j) {
              T t1 = this.a(j);
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 2644b190813cc934914aeab78fbd6515d1a37c4a..2ee781604868a508d81585a68da811ea366a21b2 100644
+index 2644b190813cc934914aeab78fbd6515d1a37c4a..665d2d03676fde8d7e7d09fef3fd9cc13110d98d 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -176,6 +176,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -176,6 +176,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
          // Paper end
          com.tuinity.tuinity.config.TuinityConfig.init((java.io.File) options.valueOf("tuinity-settings")); // Tuinity - Server Config
 +        gg.airplane.AirplaneConfig.load(); // Airplane - config
 +        gg.airplane.commands.AirplaneCommands.init(); // Airplane - command
-+        gg.airplane.flare.FlareSetup.init(); // Airplane
  
          this.setPVP(dedicatedserverproperties.pvp);
          this.setAllowFlight(dedicatedserverproperties.allowFlight);
@@ -2051,6 +2054,34 @@ index f6797925365836b6c2d3d2c48c746a4d58e28bf3..7bd22c81d75368697113915a97c7fbe5
      }
  
      @Override
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index f034977f4666385d6e7c7288e453d058c270be01..48a820e34d45623432a3dc3b01d0bba8824c6414 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -65,7 +65,8 @@ public abstract class EntityHuman extends EntityLiving {
+     protected int bG;
+     protected final float bH = 0.02F;
+     private int g;
+-    private GameProfile bJ; public final void setProfile(final GameProfile profile) { this.bJ = profile; } // Paper - OBFHELPER
++    private IChatBaseComponent displayName; // Airplane - cache displayName
++    private GameProfile bJ; public final void setProfile(final GameProfile profile) { this.bJ = profile; this.displayName = null; } // Paper - OBFHELPER // Airplane - use to reset displayName
+     private ItemStack bL;
+     private final ItemCooldown bM;
+     @Nullable
+@@ -1731,7 +1732,12 @@ public abstract class EntityHuman extends EntityLiving {
+ 
+     @Override
+     public IChatBaseComponent getDisplayName() {
+-        return new ChatComponentText(this.bJ.getName());
++        // Airplane start - cache display name
++        if (this.displayName == null) {
++            this.displayName = new ChatComponentText(this.getProfile().getName());
++        }
++        return this.displayName;
++        // Airplane end
+     }
+ 
+     public InventoryEnderChest getEnderChest() {
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
 index a47217c020d2c2a3caddafa0549dc827373798dd..81a91d63dd26a940c381b5a4f18eb60d42bbd61e 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
@@ -2152,7 +2183,7 @@ index ca7f9dc54ed2e58f521613b5d8027494bd20edd2..682b241ae0e2859aa57faea8a4521c1c
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index f40c24b6e2f7bea21d1cb2b58ed3da45ffcfc866..9851b7cf8f60be12cfba9787eabe210661344414 100644
+index c086579073c785b3b7cd556bbb629b91560bd449..90d64eb2a7e318c8501b7efb2314d2049441bd6f 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -52,7 +52,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -2426,10 +2457,10 @@ index 2e7721a650c5a351b3584665bd236f92ef577761..b3c2b461b2a654a9e37a57f2f62b3ba8
          return d0 == 0.0D ? 0 : (d0 > 0.0D ? 1 : -1);
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7ac34a8959a797bf2af96f3f402fa65cffe3d666..965f186f4efd808cc92b4570e7426ffb25650e29 100644
+index afc22e545df03a38c801362d308d135df90361e2..ec6ef20e93af2298bdb3953b15e1ec24e8c72261 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1520,7 +1520,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1524,7 +1524,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {
@@ -2439,7 +2470,7 @@ index 7ac34a8959a797bf2af96f3f402fa65cffe3d666..965f186f4efd808cc92b4570e7426ffb
  
      public CrashReport b(CrashReport crashreport) {
 diff --git a/src/main/java/net/minecraft/server/NavigationAbstract.java b/src/main/java/net/minecraft/server/NavigationAbstract.java
-index b92ca4a6de01f3f86367fb8dfe3591b08a3e9218..87172af0b007f93bbb0474bc8f3789ed396258f8 100644
+index 6aec5098d346c1b7498fd8b800154cd31ce08a97..be243d411abf68686e75d46023c93fb8bb5c84e0 100644
 --- a/src/main/java/net/minecraft/server/NavigationAbstract.java
 +++ b/src/main/java/net/minecraft/server/NavigationAbstract.java
 @@ -411,6 +411,7 @@ public abstract class NavigationAbstract {
@@ -2472,11 +2503,35 @@ index 9cad895c7d008487ce885cbcc2c3966645df4c19..2ce5e07f4dcd0c76073840c35be66b7c
      }
      public boolean hasTasks() {
          for (PathfinderGoalWrapped task : getTasks()) {
+diff --git a/src/main/java/net/minecraft/server/PathfinderTargetCondition.java b/src/main/java/net/minecraft/server/PathfinderTargetCondition.java
+index 3ebe3d0dc4c2c6aee6ea349006a74cbe5aa8e78f..7b80f6f08f274fd1adff114a81919bf41bf2cd53 100644
+--- a/src/main/java/net/minecraft/server/PathfinderTargetCondition.java
++++ b/src/main/java/net/minecraft/server/PathfinderTargetCondition.java
+@@ -80,9 +80,17 @@ public class PathfinderTargetCondition {
+                 }
+ 
+                 if (this.b > 0.0D) {
++                    // Airplane start - try to return early
++                    double range = (useFollowRange ? getFollowRange(entityliving) : this.b);
++                    double d2 = entityliving.h(entityliving1.locX(), entityliving1.locY(), entityliving1.locZ()); // move up here to use early
++
++                    if (d2 > range * range) { // if they're further than the absolute furthest allowed, they don't match
++                        return false;
++                    }
++
+                     double d0 = this.g ? entityliving1.A(entityliving) : 1.0D;
+-                    double d1 = Math.max((useFollowRange ? getFollowRange(entityliving) : this.b) * d0, 2.0D); // Paper
+-                    double d2 = entityliving.h(entityliving1.locX(), entityliving1.locY(), entityliving1.locZ());
++                    double d1 = Math.max(range * d0, 2.0D); // Paper // Airplane - reuse range calculated above
++                    // Airplane end
+ 
+                     if (d2 > d1 * d1) {
+                         return false;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2ae53161e5 100644
+index 3e0bf6df7c4608a5b19024612db52558fd722f4b..9b55171a20daefba97a4374a09253f75d32c6871 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -642,7 +642,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -651,7 +651,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return d2 * d2 + d3 * d3;
      }
  
@@ -2487,7 +2542,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
          int i;
          int j;
  
-@@ -656,12 +658,16 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -665,12 +667,16 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              j = MathHelper.floor(entityplayer.locZ() / 16.0D);
          }
  
@@ -2508,7 +2563,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
  
          return Math.max(Math.abs(k), Math.abs(l));
      }
-@@ -722,6 +728,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -731,6 +737,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return (PlayerChunk) (this.hasPendingVisibleUpdate ? this.pendingVisibleChunks.get(i) : ((ProtectedVisibleChunksMap)this.visibleChunks).safeGet(i));
          // Paper end
      }
@@ -2520,7 +2575,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
  
      protected final IntSupplier getPrioritySupplier(long i) { return c(i); } // Paper - OBFHELPER
      protected IntSupplier c(long i) {
-@@ -2124,10 +2135,30 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -2134,10 +2145,30 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          entity.tracker = null; // Paper - We're no longer tracked
      }
  
@@ -2551,7 +2606,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
              com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet.Iterator<Chunk> iterator = this.world.getChunkProvider().entityTickingChunks.iterator();
              try {
              while (iterator.hasNext()) {
-@@ -2389,7 +2420,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2403,7 +2434,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
      public class EntityTracker {
  
          final EntityTrackerEntry trackerEntry; // Paper - private -> package private
@@ -2560,7 +2615,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
          private final int trackingDistance;
          private SectionPosition e;
          // Paper start
-@@ -2408,7 +2439,9 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2422,7 +2453,9 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
          // Paper start - use distance map to optimise tracker
          com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> lastTrackerCandidates;
  
@@ -2571,7 +2626,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
              com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> oldTrackerCandidates = this.lastTrackerCandidates;
              this.lastTrackerCandidates = newTrackerCandidates;
  
-@@ -2449,7 +2482,13 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2463,7 +2496,13 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
              return this.tracker.getId();
          }
  
@@ -2586,7 +2641,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
              Iterator iterator = this.trackedPlayers.iterator();
  
              while (iterator.hasNext()) {
-@@ -2461,6 +2500,12 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2475,6 +2514,12 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
          }
  
          public void broadcastIncludingSelf(Packet<?> packet) {
@@ -2599,7 +2654,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
              this.broadcast(packet);
              if (this.tracker instanceof EntityPlayer) {
                  ((EntityPlayer) this.tracker).playerConnection.sendPacket(packet);
-@@ -2487,8 +2532,8 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2501,8 +2546,8 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
  
          }
  
@@ -2610,7 +2665,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
              if (entityplayer != this.tracker) {
                  // Paper start - remove allocation of Vec3D here
                  //Vec3D vec3d = entityplayer.getPositionVector().d(this.tracker.getPositionVector()); // MC-155077, SPIGOT-5113
-@@ -2503,11 +2548,17 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2517,11 +2562,16 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                      boolean flag1 = this.tracker.attachedToPlayer;
  
                      if (!flag1) {
@@ -2623,14 +2678,13 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
 +                        long chunkcoordintpair = ChunkCoordIntPair.pair(x, z);
 +                        PlayerChunk playerchunk = PlayerChunkMap.this.trackerGetVisibleChunk(chunkcoordintpair); // Airplane
  
-                         if (playerchunk != null && playerchunk.getSendingChunk() != null) { // Paper - no-tick view distance
+                         if (playerchunk != null && playerchunk.getSendingChunk() != null && PlayerChunkMap.this.playerChunkManager.isChunkSent(entityplayer, MathHelper.floor(this.tracker.locX()) >> 4, MathHelper.floor(this.tracker.locZ()) >> 4)) { // Paper - no-tick view distance // Tuinity - don't broadcast in chunks the player hasn't received
 -                            flag1 = PlayerChunkMap.b(chunkcoordintpair, entityplayer, false) <= PlayerChunkMap.this.viewDistance;
 +                            flag1 = PlayerChunkMap.someDistanceCalculation(x, z, entityplayer, false) <= PlayerChunkMap.this.viewDistance;
-+                            // Airplane end
                          }
                      }
  
-@@ -2537,8 +2588,10 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2551,8 +2601,10 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
          }
  
          private int b() {
@@ -2642,7 +2696,7 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
              Iterator iterator = collection.iterator();
  
              while (iterator.hasNext()) {
-@@ -2550,6 +2603,8 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2564,6 +2616,8 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                      i = j;
                  }
              }
@@ -2651,6 +2705,40 @@ index 285e976d4a655fb61e70883ae89f974812be7152..d7a17689ce44ccb8281906fb6ac7ba2a
  
              return this.a(i);
          }
+diff --git a/src/main/java/net/minecraft/server/PlayerInventory.java b/src/main/java/net/minecraft/server/PlayerInventory.java
+index 3b65711b91c51ac7b4b5b2b0144ffd279fe60eeb..478f33dbbd0b5a9b81ee420f77c97fa8c40e27d6 100644
+--- a/src/main/java/net/minecraft/server/PlayerInventory.java
++++ b/src/main/java/net/minecraft/server/PlayerInventory.java
+@@ -609,6 +609,8 @@ public class PlayerInventory implements IInventory, INamableTileEntity {
+     }
+ 
+     public boolean h(ItemStack itemstack) {
++        // Airplane start - skip using abstract iterators and stuff, they're generic and slow and allocating them sucks
++        /*
+         Iterator iterator = this.f.iterator();
+ 
+         while (iterator.hasNext()) {
+@@ -623,6 +625,20 @@ public class PlayerInventory implements IInventory, INamableTileEntity {
+                 }
+             }
+         }
++         */
++        List<NonNullList<ItemStack>> components = this.getComponents();
++        for (int i = 0; i < components.size(); i++) {
++            List<ItemStack> list = components.get(i);
++
++            for (int j = 0; j < list.size(); j++) {
++                ItemStack itemstack1 = list.get(j);
++
++                if (!itemstack1.isEmpty() && itemstack1.doMaterialsMatch(itemstack)) {
++                    return true;
++                }
++            }
++        }
++        // Airplane end
+ 
+         return false;
+     }
 diff --git a/src/main/java/net/minecraft/server/ShapelessRecipes.java b/src/main/java/net/minecraft/server/ShapelessRecipes.java
 index ecd63281912ae0ed93c5eb5ccb4249833cb23ab1..97825ec914709ca037159c46ecee218a6013ff58 100644
 --- a/src/main/java/net/minecraft/server/ShapelessRecipes.java
@@ -2702,10 +2790,10 @@ index ecd63281912ae0ed93c5eb5ccb4249833cb23ab1..97825ec914709ca037159c46ecee218a
          int i = 0;
  
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
-index a77b1d61b9dcb0a2a27d7e50357eaf44c99a661e..3406ffde3c56d9c35ec18a76af8fb258d4131417 100644
+index 53fd0549c965b2252ad80648d61ff1f7cd2b837a..c7573e1271288bd2b9dfe9801ea8f8804089f6ce 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java
 +++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
-@@ -372,7 +372,10 @@ public final class SpawnerCreature {
+@@ -381,7 +381,10 @@ public final class SpawnerCreature {
      }
  
      private static List<BiomeSettingsMobs.c> a(WorldServer worldserver, StructureManager structuremanager, ChunkGenerator chunkgenerator, EnumCreatureType enumcreaturetype, BlockPosition blockposition, @Nullable BiomeBase biomebase) {
@@ -2784,9 +2872,18 @@ index 2598ae3710d46c2cfd2be5d6be2a56e59ceef6ea..fd1f1e2d7e4be227697f534bdc6d9c52
          // Paper end
      }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 970c1be5477a01ab9c6d79e84c519e22775564ff..3c968c6133c42c3690fe554d5993d237de82c162 100644
+index bf06ef09cfd4d7618365249d1332d264d8ff1377..996fa5b4652f847f4e64d4cd191fe5a597471afe 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
+@@ -44,7 +44,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+     //public final List<TileEntity> tileEntityList = Lists.newArrayList(); // Paper - remove unused list
+     public final List<TileEntity> tileEntityListTick = Lists.newArrayList();
+     protected final List<TileEntity> tileEntityListPending = Lists.newArrayList();
+-    protected final java.util.Set<TileEntity> tileEntityListUnload = com.google.common.collect.Sets.newHashSet();
++    protected final java.util.Set<TileEntity> tileEntityListUnload = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>()); // Airplane - use set with faster contains
+     public final Thread serverThread;
+     private final boolean debugWorld;
+     private int d;
 @@ -318,6 +318,91 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return null;
      }
@@ -2879,7 +2976,25 @@ index 970c1be5477a01ab9c6d79e84c519e22775564ff..3c968c6133c42c3690fe554d5993d237
      public static boolean isValidLocation(BlockPosition blockposition) {
          return blockposition.isValidLocation(); // Paper - use better/optimized check
      }
-@@ -956,19 +1041,19 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -839,12 +924,17 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+         gameprofilerfiller.enter("blockEntities");
+         timings.tileEntityTick.startTiming(); // Spigot
+         if (!this.tileEntityListUnload.isEmpty()) {
++            // Airplane start - we just use the identitymap as the basis for the unload set now instead of copying
++            /*
+             // Paper start - Use alternate implementation with faster contains
+             java.util.Set<TileEntity> toRemove = java.util.Collections.newSetFromMap(new java.util.IdentityHashMap<>());
+             toRemove.addAll(tileEntityListUnload);
+             this.tileEntityListTick.removeAll(toRemove);
+             // Paper end
+             //this.tileEntityList.removeAll(this.tileEntityListUnload); // Paper - remove unused list
++             */
++            this.tileEntityListTick.removeAll(this.tileEntityListUnload);
++            // Airplane end
+             this.tileEntityListUnload.clear();
+         }
+ 
+@@ -956,19 +1046,19 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
      public void a(Consumer<Entity> consumer, Entity entity) {
          try {
@@ -2903,10 +3018,24 @@ index 970c1be5477a01ab9c6d79e84c519e22775564ff..3c968c6133c42c3690fe554d5993d237
      // Paper start - Prevent armor stands from doing entity lookups
      @Override
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 9c77be805eb71c409a5d41c2730338583527e447..0dc8399d419067403e786b604ca52d0752533419 100644
+index a77fceac7c9e79a6bac05becc21bcb6bf2a1a7c7..f4eb878f9a66fd3404ddde5a14924bb419a351db 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -992,7 +992,28 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -968,11 +968,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+                 // CraftBukkit end */
+ 
+                 gameprofilerfiller.enter("checkDespawn");
++                boolean entityTickingChunk = false; if (!entity.dead) entityTickingChunk = this.getChunkProvider().isInEntityTickingChunk(entity); // Airplane - check once, chunks won't unload ticking entities
+                 if (!entity.dead) {
+                     entity.checkDespawn();
+                     // Tuinity start - optimise notify()
+                     if (entity.inChunk && entity.valid) {
+-                        if (this.getChunkProvider().isInEntityTickingChunk(entity)) {
++                        if (entityTickingChunk) { // Airplane - reuse
+                             this.updateNavigatorsInRegion(entity);
+                         }
+                     } else {
+@@ -992,7 +993,28 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
                  gameprofilerfiller.enter("tick");
                  if (!entity.dead && !(entity instanceof EntityComplexPart)) {
@@ -2916,7 +3045,7 @@ index 9c77be805eb71c409a5d41c2730338583527e447..0dc8399d419067403e786b604ca52d07
 +                     */
 +                    boolean doMidTick = false; // usually there's a returns in the catch, so treat it like that
 +                    try {
-+                        this.entityJoinedWorld(entity);
++                        this.entityJoinedWorld(entity, entityTickingChunk); // Airplane - reuse
 +                        doMidTick = true;
 +                    } catch (Throwable throwable) {
 +                        if (throwable instanceof ThreadDeath) throw throwable; // Paper
@@ -2935,16 +3064,25 @@ index 9c77be805eb71c409a5d41c2730338583527e447..0dc8399d419067403e786b604ca52d07
                  }
  
                  gameprofilerfiller.exit();
-@@ -1084,6 +1105,8 @@ public class WorldServer extends World implements GeneratorAccessSeed {
-     private final com.destroystokyo.paper.util.math.ThreadUnsafeRandom randomTickRandom = new com.destroystokyo.paper.util.math.ThreadUnsafeRandom();
-     // Paper end
+@@ -1002,7 +1024,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+                     this.entitiesById.remove(entity.getId()); // Tuinity
+                     this.unregisterEntity(entity);
+                 } else if (entity.inChunk && entity.valid) { // Tuinity start - optimise notify()
+-                    if (this.getChunkProvider().isInEntityTickingChunk(entity)) {
++                    if (entityTickingChunk) { // Airplane - reuse
+                         this.updateNavigatorsInRegion(entity);
+                     }
+                 } else {
+@@ -1087,6 +1109,8 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+     private final BiomeBase[] biomeBaseCache = new BiomeBase[1];
+     // Tuinity end - optimise chunk ice snow ticking
  
 +    private int currentIceAndSnowTick = 0; protected void resetIceAndSnowTick() { this.currentIceAndSnowTick = this.randomTickRandom.nextInt(16); } // Airplane
 +
      public void a(Chunk chunk, int i) { final int randomTickSpeed = i; // Paper
          ChunkCoordIntPair chunkcoordintpair = chunk.getPos();
          boolean flag = this.isRaining();
-@@ -1094,7 +1117,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1097,7 +1121,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          gameprofilerfiller.enter("thunder");
          final BlockPosition.MutableBlockPosition blockposition = this.chunkTickMutablePosition; // Paper - use mutable to reduce allocation rate, final to force compile fail on change
  
@@ -2953,16 +3091,36 @@ index 9c77be805eb71c409a5d41c2730338583527e447..0dc8399d419067403e786b604ca52d07
              blockposition.setValues(this.a(this.a(j, 0, k, 15))); // Paper
              if (this.isRainingAt(blockposition)) {
                  DifficultyDamageScaler difficultydamagescaler = this.getDamageScaler(blockposition);
-@@ -1118,7 +1141,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1121,7 +1145,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          }
  
          gameprofilerfiller.exitEnter("iceandsnow");
 -        if (!this.paperConfig.disableIceAndSnow && this.randomTickRandom.nextInt(16) == 0) { // Paper - Disable ice and snow // Paper - optimise random ticking
 +        if (!this.paperConfig.disableIceAndSnow && (this.currentIceAndSnowTick++ & 15) == 0) { // Paper - Disable ice and snow // Paper - optimise random ticking // Airplane - optimize further random ticking
              // Paper start - optimise chunk ticking
-             this.getRandomBlockPosition(j, 0, k, 15, blockposition);
-             int normalY = chunk.getHighestBlockY(HeightMap.Type.MOTION_BLOCKING, blockposition.getX() & 15, blockposition.getZ() & 15);
-@@ -1328,9 +1351,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+             // Tuinity start - optimise chunk ice snow ticking
+             BiomeBase[] biomeCache = this.biomeBaseCache;
+@@ -1301,7 +1325,9 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+     }
+     // Tuinity end - log detailed entity tick information
+ 
+-    public void entityJoinedWorld(Entity entity) {
++    // Airplane start - reuse check for in entity ticking chunk
++    public void entityJoinedWorld(Entity entity) { entityJoinedWorld(entity, this.getChunkProvider().isInEntityTickingChunk(entity)); }
++    public void entityJoinedWorld(Entity entity, boolean entityTickingChunk) { // Airplane end
+         // Tuinity start - log detailed entity tick information
+         com.tuinity.tuinity.util.TickThread.ensureTickThread("Cannot tick an entity off-main");
+         try {
+@@ -1309,7 +1335,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+                 currentlyTickingEntity.lazySet(entity);
+             }
+             // Tuinity end - log detailed entity tick information
+-        if (!(entity instanceof EntityHuman) && !this.getChunkProvider().a(entity)) {
++        if (!(entity instanceof EntityHuman) && !entityTickingChunk) { // Airplane - reuse
+             this.chunkCheck(entity);
+         } else {
+             ++TimingHistory.entityTicks; // Paper - timings
+@@ -1335,9 +1361,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  ++entity.ticksLived;
                  GameProfilerFiller gameprofilerfiller = this.getMethodProfiler();
  

--- a/patches/server/0003-Rebrand.patch
+++ b/patches/server/0003-Rebrand.patch
@@ -48,10 +48,10 @@ index 229c3b0f0c650b501f31147adaa17194af57fedd..f88cf526d272fe47b5a474c0b344b748
                      throwable = throwable1;
                      throw throwable1;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 965f186f4efd808cc92b4570e7426ffb25650e29..2f2b8a0412195f4060b97ef23449102a18411c74 100644
+index ec6ef20e93af2298bdb3953b15e1ec24e8c72261..576a344b8bd66d69e3fd438b254f772b678471ba 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1520,7 +1520,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1524,7 +1524,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {
@@ -199,7 +199,7 @@ index ec8ad7a51f62c699588b5804331a5d33ab1fa5a7..a3cea65ab086fac48c68578c6be70b0f
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 00e53d577b1dcaccb409e62d35165ee015de9330..7de7afae711800154735411947ff140c76d5171f 100644
+index 57d56ff1b41582f0d249b24165d5b08b02b0f9fe..81cff601a5161c30df90de3cefc18d72cd7ee347 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -377,7 +377,7 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0004-Purpur-config-files.patch
+++ b/patches/server/0004-Purpur-config-files.patch
@@ -45,7 +45,7 @@ index f39452535b2807a226ada095f5c21b19ea238e5c..ad7df9e8a2cfc6fe65b193adfb65c7b3
              config.save(CONFIG_FILE);
          } catch (IOException ex) {
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 2ee781604868a508d81585a68da811ea366a21b2..a85a844a4766cde16eea9e814abfec29d8935c0f 100644
+index 665d2d03676fde8d7e7d09fef3fd9cc13110d98d..b8a45c80b6691214e513286262f31b7b5b1dd5eb 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -173,6 +173,15 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -65,7 +65,7 @@ index 2ee781604868a508d81585a68da811ea366a21b2..a85a844a4766cde16eea9e814abfec29
          // Paper end
          com.tuinity.tuinity.config.TuinityConfig.init((java.io.File) options.valueOf("tuinity-settings")); // Tuinity - Server Config
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 3c968c6133c42c3690fe554d5993d237de82c162..50548761bc94b06af7aaf9b2f91da54eb070df01 100644
+index 996fa5b4652f847f4e64d4cd191fe5a597471afe..068d303853572519efc16bb9cd3b799e458e39e7 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -95,6 +95,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0005-Timings-stuff.patch
+++ b/patches/server/0005-Timings-stuff.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Timings stuff
 
 
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index 5dfa0658838c4801cdf260eae8b98163f729e5af..dae2e5d70756c5b61163d57099b65f7e415b288c 100644
+index 35810f42d7a0cd50a4cbe90e8d698fe57914c889..5e672a0660d0aceffcdb26d185590ca18aa4f023 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
 @@ -227,10 +227,14 @@ public class TimingsExport extends Thread {

--- a/patches/server/0009-AFK-API.patch
+++ b/patches/server/0009-AFK-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] AFK API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index f034977f4666385d6e7c7288e453d058c270be01..390aae2733e397ac5c6c457c76bf75f9c8dcd873 100644
+index 48a820e34d45623432a3dc3b01d0bba8824c6414..a3aa2c8760b43e09f77f2790d6e21b8a2dc9dd3c 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -84,6 +84,15 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -85,6 +85,15 @@ public abstract class EntityHuman extends EntityLiving {
      }
      // CraftBukkit end
  
@@ -25,7 +25,7 @@ index f034977f4666385d6e7c7288e453d058c270be01..390aae2733e397ac5c6c457c76bf75f9
          super(EntityTypes.PLAYER, world);
          this.bL = ItemStack.b;
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 9851b7cf8f60be12cfba9787eabe210661344414..90024417dcb66716590de523dcbfb5034cf0ac20 100644
+index 90d64eb2a7e318c8501b7efb2314d2049441bd6f..9be41dab47230046e576f4472c4c1c23523aa28c 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1940,8 +1940,54 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -193,7 +193,7 @@ index 9146b60cff0aa06e2f6b6003bfe9e2be9d2f0d56..bba8dc8fd10dc34179ca3c8cf471fbb3
                                      if (from.getX() != Double.MAX_VALUE) {
                                          Location oldTo = to.clone();
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 0dc8399d419067403e786b604ca52d0752533419..c8b20f6789d8f2403a00a8c2d3b0869f0ba8718d 100644
+index f4eb878f9a66fd3404ddde5a14924bb419a351db..8ac7efc7a99a740f4c3078f926b626b38e15bb74 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -887,7 +887,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -205,7 +205,7 @@ index 0dc8399d419067403e786b604ca52d0752533419..c8b20f6789d8f2403a00a8c2d3b0869f
          })) {
              // CraftBukkit start
              long l = this.worldData.getDayTime() + 24000L;
-@@ -1247,7 +1247,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1255,7 +1255,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              while (iterator.hasNext()) {
                  EntityPlayer entityplayer = (EntityPlayer) iterator.next();
  
@@ -263,10 +263,10 @@ index 361f7857e461578e90cb71e15027dadaf794cb69..2578a4677d1ee060f687be531e696b7c
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f965b071cd2f6a70a216679e4f19956115edee4f..8e69ad39102b8a91e664b31a7f07c5212822e961 100644
+index b3636032fd36efe2e7e546dbebdfd5c1208f9951..abf2a6b9d18f04baa077ededa3562a30dbaa4fe4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2427,4 +2427,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2482,4 +2482,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return spigot;
      }
      // Spigot end

--- a/patches/server/0011-Configurable-server-mod-name.patch
+++ b/patches/server/0011-Configurable-server-mod-name.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable server mod name
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2f2b8a0412195f4060b97ef23449102a18411c74..fc88aa4982711a7fcd027cd684443b2c1a2829b7 100644
+index 576a344b8bd66d69e3fd438b254f772b678471ba..eafff4dcf1088b77ecae317a28b5d65dec997a7b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1520,7 +1520,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1524,7 +1524,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {

--- a/patches/server/0013-Lagging-threshold.patch
+++ b/patches/server/0013-Lagging-threshold.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Lagging threshold
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index fc88aa4982711a7fcd027cd684443b2c1a2829b7..ce829ab8f5ae0f2d231ab7b0aaabdf2392b4f108 100644
+index eafff4dcf1088b77ecae317a28b5d65dec997a7b..5e647afa74950bcb09de630ac641b9d178ef71c2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -167,6 +167,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0017-Player-invulnerabilities.patch
+++ b/patches/server/0017-Player-invulnerabilities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player invulnerabilities
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 90024417dcb66716590de523dcbfb5034cf0ac20..876c728a460860ee1881c2cce2220157bd66a4e5 100644
+index 9be41dab47230046e576f4472c4c1c23523aa28c..2660a87fcfbed135c834acc13db6c758a66ccf8c 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -154,6 +154,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -79,7 +79,7 @@ index bba8dc8fd10dc34179ca3c8cf471fbb3739fa7b4..c586005b34c59710cf398e30924ff365
          this.server.getPluginManager().callEvent(new PlayerResourcePackStatusEvent(getPlayer(), packStatus));
          // Paper end
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index d03d0c13cca1762078617744253a9757b388958f..00db0f5fb098a4db4092f8ab75a4489cf466baac 100644
+index a12e58668e74f2287ddff5bedc00daf2b0a416c1..7f784709ab8c560fd2dae551b6c8c234a2d134c6 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -914,6 +914,8 @@ public abstract class PlayerList {
@@ -108,10 +108,10 @@ index 2578a4677d1ee060f687be531e696b7c7be89e84..c441fcea9b2b5a77b801c8a69541cf42
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8e69ad39102b8a91e664b31a7f07c5212822e961..ca15efea5da7be1717a211b9b3556c755788561a 100644
+index abf2a6b9d18f04baa077ededa3562a30dbaa4fe4..8bf29aca4b5aa0d51ed3cda25b37d30e6c986848 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2443,5 +2443,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2498,5 +2498,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetIdleTimer() {
          getHandle().resetIdleTimer();
      }

--- a/patches/server/0028-Zombie-horse-naturally-spawn.patch
+++ b/patches/server/0028-Zombie-horse-naturally-spawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Zombie horse naturally spawn
 
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index c8b20f6789d8f2403a00a8c2d3b0869f0ba8718d..96d0735649476bac0581145c255c702941a17c0e 100644
+index 8ac7efc7a99a740f4c3078f926b626b38e15bb74..87113eff62442f350f8d97340ab868b9af721739 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1124,12 +1124,18 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1128,12 +1128,18 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  boolean flag1 = this.getGameRules().getBoolean(GameRules.DO_MOB_SPAWNING) && this.random.nextDouble() < (double) difficultydamagescaler.b() * paperConfig.skeleHorseSpawnChance; // Paper
  
                  if (flag1) {

--- a/patches/server/0038-Cat-spawning-options.patch
+++ b/patches/server/0038-Cat-spawning-options.patch
@@ -62,7 +62,7 @@ index 5e17868a76ea8e3f105c11d496d6da12afa0da41..5a0f8779672a9e34f6970045361630ab
      }
  
 diff --git a/src/main/java/net/minecraft/server/VillagePlace.java b/src/main/java/net/minecraft/server/VillagePlace.java
-index fce9967912628c232fe41ccc17fe2296f001ec61..44063d599e39e087b3eccfe204ef2fd79c3364e5 100644
+index 245bdedd17b844dcd13aa0b60dffb1cac6a5bdb8..64e251fb63e67b9ebf11779580b1bff6def6d1c6 100644
 --- a/src/main/java/net/minecraft/server/VillagePlace.java
 +++ b/src/main/java/net/minecraft/server/VillagePlace.java
 @@ -178,6 +178,7 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {

--- a/patches/server/0044-Ender-dragon-always-drop-full-exp.patch
+++ b/patches/server/0044-Ender-dragon-always-drop-full-exp.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ender dragon always drop full exp
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
-index 7289d6c706b6c845584bac616c9babea80f8e885..f777aea69dc9949aae3251e9a530b8cffb251bad 100644
+index 50b93c93cfede2d64a996a22b811994b352149af..de025a48c7ca08d8ae71d2d9239121dc4a86a339 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
 @@ -564,7 +564,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {

--- a/patches/server/0046-Signs-allow-color-codes.patch
+++ b/patches/server/0046-Signs-allow-color-codes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Signs allow color codes
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 876c728a460860ee1881c2cce2220157bd66a4e5..82268359f340eac0c0dd171c1ef9fe950fc0afb5 100644
+index 2660a87fcfbed135c834acc13db6c758a66ccf8c..e03c80f4b61e211c104e809d52d16a400b713f00 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1449,6 +1449,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0048-Controllable-Minecarts.patch
+++ b/patches/server/0048-Controllable-Minecarts.patch
@@ -106,7 +106,7 @@ index be859a1b41254b299a507d03e453dc8efee6f3dd..4de2877f30a9b231a5c8bbd173941699
          this.move(EnumMoveType.SELF, this.getMot());
          if (!this.onGround) {
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 82268359f340eac0c0dd171c1ef9fe950fc0afb5..75612f2e5489694e11c12bb232b5701e83375d1d 100644
+index e03c80f4b61e211c104e809d52d16a400b713f00..b05137eb7de2d5b236d9195db37b613733b99cf2 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1002,6 +1002,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0050-Players-should-not-cram-to-death.patch
+++ b/patches/server/0050-Players-should-not-cram-to-death.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Players should not cram to death
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 75612f2e5489694e11c12bb232b5701e83375d1d..c7b42907a522c81904f4f297daa5ac564f6180b1 100644
+index b05137eb7de2d5b236d9195db37b613733b99cf2..ec5248d7d472aa6868a5a3763ded267a919b3e58 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1426,7 +1426,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0055-Add-permission-for-F3-N-debug.patch
+++ b/patches/server/0055-Add-permission-for-F3-N-debug.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add permission for F3+N debug
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 00db0f5fb098a4db4092f8ab75a4489cf466baac..86f534c871a3c9b9ca71b20daa7780dfdab9e76d 100644
+index 7f784709ab8c560fd2dae551b6c8c234a2d134c6..f9043744ad0a622c6aa5e5bd3986fb9f60cab4c3 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -1073,6 +1073,7 @@ public abstract class PlayerList {

--- a/patches/server/0057-Configurable-TPS-Catchup.patch
+++ b/patches/server/0057-Configurable-TPS-Catchup.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable TPS Catchup
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ce829ab8f5ae0f2d231ab7b0aaabdf2392b4f108..c16ca6108f196bfaba887eb46479b225ed5abc39 100644
+index 5e647afa74950bcb09de630ac641b9d178ef71c2..bbc92489fd2e9037834fdea3a4514b5687ae86d7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1010,7 +1010,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0067-Add-player-death-exp-control-options.patch
+++ b/patches/server/0067-Add-player-death-exp-control-options.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player death exp control options
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 390aae2733e397ac5c6c457c76bf75f9c8dcd873..ab2ad054ce8d896e38ab4eb6ed38d8ea73d42954 100644
+index a3aa2c8760b43e09f77f2790d6e21b8a2dc9dd3c..0f7b60642c44630000d47f0e1fdebad15e14a810 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -85,6 +85,8 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -86,6 +86,8 @@ public abstract class EntityHuman extends EntityLiving {
      // CraftBukkit end
  
      // Purpur start
@@ -17,7 +17,7 @@ index 390aae2733e397ac5c6c457c76bf75f9c8dcd873..ab2ad054ce8d896e38ab4eb6ed38d8ea
      public void setAfk(boolean setAfk){
      }
  
-@@ -1716,9 +1718,18 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1717,9 +1719,18 @@ public abstract class EntityHuman extends EntityLiving {
      @Override
      protected int getExpValue(EntityHuman entityhuman) {
          if (!this.world.getGameRules().getBoolean(GameRules.KEEP_INVENTORY) && !this.isSpectator()) {

--- a/patches/server/0074-Add-5-second-tps-average-in-tps.patch
+++ b/patches/server/0074-Add-5-second-tps-average-in-tps.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add 5 second tps average in /tps
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c16ca6108f196bfaba887eb46479b225ed5abc39..1a721e28c757971b1a5c2521ad55f0845dbafd20 100644
+index bbc92489fd2e9037834fdea3a4514b5687ae86d7..e46705e7ab5d5c69e5d2bdd29d5066c4b2d60675 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -166,7 +166,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0080-Add-phantom-spawning-options.patch
+++ b/patches/server/0080-Add-phantom-spawning-options.patch
@@ -221,10 +221,10 @@ index 4e3f01bc79b6ed2a322155f29f1d0dcf298c8b82..ac1ea2f0c15bccf94f203194a5a7b10e
      }
  }
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
-index 3406ffde3c56d9c35ec18a76af8fb258d4131417..1016305a571a2fc211cd0e58b7210d8cfb4461d5 100644
+index c7573e1271288bd2b9dfe9801ea8f8804089f6ce..b5b0f295d63eb245a6221f88110f1bb1694c641c 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java
 +++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
-@@ -388,6 +388,7 @@ public final class SpawnerCreature {
+@@ -397,6 +397,7 @@ public final class SpawnerCreature {
          return new BlockPosition(i, l, j);
      }
  
@@ -233,10 +233,10 @@ index 3406ffde3c56d9c35ec18a76af8fb258d4131417..1016305a571a2fc211cd0e58b7210d8c
          return iblockdata.r(iblockaccess, blockposition) ? false : (iblockdata.isPowerSource() ? false : (!fluid.isEmpty() ? false : (iblockdata.a((Tag) TagsBlock.PREVENT_MOB_SPAWNING_INSIDE) ? false : !entitytypes.a(iblockdata))));
      }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 50548761bc94b06af7aaf9b2f91da54eb070df01..f83afe7eb84309849e2271a917ab476b4250f3ef 100644
+index 068d303853572519efc16bb9cd3b799e458e39e7..ad7360cd5ae79e4d031ae866bf911fb87a2c0cdf 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1682,6 +1682,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1687,6 +1687,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return new DifficultyDamageScaler(this.getDifficulty(), this.getDayTime(), i, f);
      }
  

--- a/patches/server/0083-Add-allow-water-in-end-world-option.patch
+++ b/patches/server/0083-Add-allow-water-in-end-world-option.patch
@@ -49,10 +49,10 @@ index 223361a1a8b41ebe91e0db39f40cf12a4968b1b4..07f23572bdf15c57a53e32646f2fc64f
  
                  return true;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f83afe7eb84309849e2271a917ab476b4250f3ef..bcd52f77e575fb8cac042c30a09332204588513d 100644
+index ad7360cd5ae79e4d031ae866bf911fb87a2c0cdf..404fcc307454e7f00dcc180dda53677c5a0f43e8 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1757,4 +1757,14 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1762,4 +1762,14 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
      public final boolean isDebugWorld() {
          return this.debugWorld;
      }

--- a/patches/server/0086-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
+++ b/patches/server/0086-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
@@ -17,7 +17,7 @@ index 4b7909a0c7e41cf41d4219ba7dda79519c0ee3c6..2de7fbd9651a7143802507d9cbed1484
                      }
                  }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index c7b42907a522c81904f4f297daa5ac564f6180b1..ca7ec1f237af347c3c5b2b5250948c072304e33c 100644
+index ec5248d7d472aa6868a5a3763ded267a919b3e58..c69ff970f4afe5c860fa8794b9be1f6b818ac395 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -2425,4 +2425,26 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0094-Populator-seed-controls.patch
+++ b/patches/server/0094-Populator-seed-controls.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Populator seed controls
 
 
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
-index dae2e5d70756c5b61163d57099b65f7e415b288c..55b67f1057224101272f9d6023a93872c4423405 100644
+index 5e672a0660d0aceffcdb26d185590ca18aa4f023..4b171a2a60e24947e884f8988920f335bd99a471 100644
 --- a/src/main/java/co/aikar/timings/TimingsExport.java
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
 @@ -293,7 +293,7 @@ public class TimingsExport extends Thread {
@@ -18,7 +18,7 @@ index dae2e5d70756c5b61163d57099b65f7e415b288c..55b67f1057224101272f9d6023a93872
              }
              final Object val = config.get(key);
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index 63dfad42c372a33b35c585aaa7ed24d8f16d44e0..3583efb41f80eac7b6dba3a8479ec74c5f60549c 100644
+index d1308b8cbb9490f1ccdc5514763e62bc5d66981b..f11d07f6e388dedc318868ffa95e80ae2d89119e 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -1,5 +1,6 @@
@@ -28,7 +28,7 @@ index 63dfad42c372a33b35c585aaa7ed24d8f16d44e0..3583efb41f80eac7b6dba3a8479ec74c
  import com.destroystokyo.paper.util.SneakyThrow;
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.TicketType;
-@@ -382,6 +383,19 @@ public final class TuinityConfig {
+@@ -401,6 +402,19 @@ public final class TuinityConfig {
              this.spawnLimitAmbient = this.getInt(path + ".ambient", -1);
          }
  
@@ -50,10 +50,10 @@ index 63dfad42c372a33b35c585aaa7ed24d8f16d44e0..3583efb41f80eac7b6dba3a8479ec74c
  }
 \ No newline at end of file
 diff --git a/src/main/java/net/minecraft/server/BiomeBase.java b/src/main/java/net/minecraft/server/BiomeBase.java
-index 0854ac9ef586b378420d9899f3afd2755e6f9f33..df6874c1cf5fc5764dc575866aab87883b6cf035 100644
+index 3fc101552e3c229076c91a1cfa45206b4cc7a04c..60d5c08706dc8b2f895ff7083d3a611a73ac19d2 100644
 --- a/src/main/java/net/minecraft/server/BiomeBase.java
 +++ b/src/main/java/net/minecraft/server/BiomeBase.java
-@@ -189,6 +189,10 @@ public final class BiomeBase {
+@@ -227,6 +227,10 @@ public final class BiomeBase {
          return this.k;
      }
  
@@ -64,7 +64,7 @@ index 0854ac9ef586b378420d9899f3afd2755e6f9f33..df6874c1cf5fc5764dc575866aab8788
      public void a(StructureManager structuremanager, ChunkGenerator chunkgenerator, RegionLimitedWorldAccess regionlimitedworldaccess, long i, SeededRandom seededrandom, BlockPosition blockposition) {
          List<List<Supplier<WorldGenFeatureConfigured<?, ?>>>> list = this.k.c();
          int j = WorldGenStage.Decoration.values().length;
-@@ -225,12 +229,24 @@ public final class BiomeBase {
+@@ -263,12 +267,24 @@ public final class BiomeBase {
                  }
              }
  

--- a/patches/server/0099-Add-no-tick-block-list.patch
+++ b/patches/server/0099-Add-no-tick-block-list.patch
@@ -22,7 +22,7 @@ index 829d4a7508e1656dbdc912096b7eafcf30cbb5b2..6aea156d7c7a9ca8a357aad6a6781d72
          }
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 96d0735649476bac0581145c255c702941a17c0e..aac44aa00a0cf8216a98bddb23f35244360ff6f1 100644
+index 87113eff62442f350f8d97340ab868b9af721739..cc022113d68574b025142deede4219f81326d62f 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -418,14 +418,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0103-Ridables.patch
+++ b/patches/server/0103-Ridables.patch
@@ -1175,7 +1175,7 @@ index 1a102816921fa3b40f6d364bb826db4459f68eb2..125eab60f2b4657e52a71eddf7586c57
  
          @Override
 diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
-index f777aea69dc9949aae3251e9a530b8cffb251bad..497d05996ab84f599aa0a02f853149f074e4d3cb 100644
+index de025a48c7ca08d8ae71d2d9239121dc4a86a339..81e63fe1b8252e2b5abcbf9051190cd0214b534c 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
 @@ -46,6 +46,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
@@ -2099,10 +2099,10 @@ index 0e98173607c810e0e74552a2ba8febf292357c39..559ba50977147b8e2a0e7c1e7dc281fa
 +    protected void eV() { if (world.purpurConfig.zombieHorseCanSwim) goalSelector.a(0, new PathfinderGoalFloat(this)); } // Purpur
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index ab2ad054ce8d896e38ab4eb6ed38d8ea73d42954..3a7dc584bd2b88415a238f9c0cb7f85968fb8dfb 100644
+index 0f7b60642c44630000d47f0e1fdebad15e14a810..fc51d6f9cd8c6ca61ae70b07cff817c5d871ab48 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -2155,4 +2155,15 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -2161,4 +2161,15 @@ public abstract class EntityHuman extends EntityLiving {
              return this.g;
          }
      }
@@ -3148,7 +3148,7 @@ index a3a428da99574c485fcf2b8c7944e0d8354146ee..cf7de0127166f6175a6246062c8664e6
          this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true));
          this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, false));
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index ca7ec1f237af347c3c5b2b5250948c072304e33c..565cec043a00bc683bbab5874f5887b0df048170 100644
+index c69ff970f4afe5c860fa8794b9be1f6b818ac395..da4943389fee9b8a8d03ad5c518806d85cc639db 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -512,6 +512,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -4423,7 +4423,7 @@ index ca3c5150bcfe2a92b49ad5a27c23dd37a7054fbb..323d79a99402b0f6952b4fb873170069
          this.targetSelector.a(2, this.br);
          this.targetSelector.a(3, this.bs);
 diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
-index b1159f0258eca2bee52ec0939ba86792d24a1f99..f149eeb4dd2be51ef028998c0ec6398cb9b3f4bb 100644
+index 3230c5454ccc39a2e3c89fdf8ca015cf7a15f380..87b7d52bdba357fa59c7b6397cb49286fd8cc8ec 100644
 --- a/src/main/java/net/minecraft/server/EntityWither.java
 +++ b/src/main/java/net/minecraft/server/EntityWither.java
 @@ -32,6 +32,7 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
@@ -4843,7 +4843,7 @@ index dc9f2a1a132b3a7925bd62aa1da0512afd90b8b1..b7e540dfeeabb13227596ecfc6eddabf
              Entity entity1 = this.getShooter();
              // Paper start - Cancel hit for vanished players
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1a721e28c757971b1a5c2521ad55f0845dbafd20..de69589a8e88d9330365decccc9e3bceb337b354 100644
+index e46705e7ab5d5c69e5d2bdd29d5066c4b2d60675..4f589ca6cfc770bd26d0046736f7100272d7e48e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1418,6 +1418,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -4926,10 +4926,10 @@ index b2c64b31440389db5abe2322f7e31b328f590f6c..515ba50aec81497d27297e4b6c642e86
          Vec3D vec3d = entity.getMot();
          World world = entity.world;
 diff --git a/src/main/java/net/minecraft/server/Vec3D.java b/src/main/java/net/minecraft/server/Vec3D.java
-index 5af554870bcf36e47aef43b966b141b9eda6c4d5..c59305ef7dd7847e204d4c4ed79758bf9d66e91e 100644
+index 7190316a38e6b4edf5501bfedbb12be79e990797..4469fdc932d725b8e6fa4f8e3ec15c22a88ca5e7 100644
 --- a/src/main/java/net/minecraft/server/Vec3D.java
 +++ b/src/main/java/net/minecraft/server/Vec3D.java
-@@ -39,6 +39,7 @@ public class Vec3D implements IPosition {
+@@ -45,6 +45,7 @@ public class Vec3D implements IPosition {
          return new Vec3D(vec3d.x - this.x, vec3d.y - this.y, vec3d.z - this.z);
      }
  
@@ -4937,7 +4937,7 @@ index 5af554870bcf36e47aef43b966b141b9eda6c4d5..c59305ef7dd7847e204d4c4ed79758bf
      public Vec3D d() {
          double d0 = (double) MathHelper.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
  
-@@ -98,6 +99,7 @@ public class Vec3D implements IPosition {
+@@ -104,6 +105,7 @@ public class Vec3D implements IPosition {
          return d3 * d3 + d4 * d4 + d5 * d5;
      }
  
@@ -4945,7 +4945,7 @@ index 5af554870bcf36e47aef43b966b141b9eda6c4d5..c59305ef7dd7847e204d4c4ed79758bf
      public Vec3D a(double d0) {
          return this.d(d0, d0, d0);
      }
-@@ -106,6 +108,7 @@ public class Vec3D implements IPosition {
+@@ -112,6 +114,7 @@ public class Vec3D implements IPosition {
          return this.d(vec3d.x, vec3d.y, vec3d.z);
      }
  
@@ -4954,10 +4954,10 @@ index 5af554870bcf36e47aef43b966b141b9eda6c4d5..c59305ef7dd7847e204d4c4ed79758bf
          return new Vec3D(this.x * d0, this.y * d1, this.z * d2);
      }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index bcd52f77e575fb8cac042c30a09332204588513d..808c9b298e1738797b42c14093b549e25333d287 100644
+index 404fcc307454e7f00dcc180dda53677c5a0f43e8..bb7cf83027ad0d0679fb208147f3481dbe280a82 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1766,5 +1766,10 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1771,5 +1771,10 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
      public boolean isTheEnd() {
          return getWorld().getEnvironment() == org.bukkit.World.Environment.THE_END;
      }
@@ -4969,7 +4969,7 @@ index bcd52f77e575fb8cac042c30a09332204588513d..808c9b298e1738797b42c14093b549e2
      // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index aac44aa00a0cf8216a98bddb23f35244360ff6f1..3124941f6310fb1074c92793dfe14873e64966a1 100644
+index cc022113d68574b025142deede4219f81326d62f..b7a17eafe7355b9c9247a9c79495134b43971aaf 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -102,6 +102,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0108-Customizable-wither-health-and-healing.patch
+++ b/patches/server/0108-Customizable-wither-health-and-healing.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Customizable wither health and healing
 Adds the ability to customize the health of the wither, as well as the amount that it heals, and how often.
 
 diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
-index f149eeb4dd2be51ef028998c0ec6398cb9b3f4bb..cc4b0945fb9186c6975136d48ce8dfc12b4d4230 100644
+index 87b7d52bdba357fa59c7b6397cb49286fd8cc8ec..edc58c5cb178ea9a53f960bd4a460f394b13ab64 100644
 --- a/src/main/java/net/minecraft/server/EntityWither.java
 +++ b/src/main/java/net/minecraft/server/EntityWither.java
 @@ -150,6 +150,11 @@ public class EntityWither extends EntityMonster implements IRangedEntity {

--- a/patches/server/0109-Allow-toggling-special-MobSpawners-per-world.patch
+++ b/patches/server/0109-Allow-toggling-special-MobSpawners-per-world.patch
@@ -29,7 +29,7 @@ index 341af7474690b929cfa3e35cd464bbbbacb6685e..ad00ff2bd525768e4f06631d16b912c6
              if (SpawnerCreature.a(EntityPositionTypes.Surface.ON_GROUND, iworldreader, blockposition2, EntityTypes.WANDERING_TRADER)) {
                  blockposition1 = blockposition2;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 808c9b298e1738797b42c14093b549e25333d287..553cf944e25f5d24f4d1af54bfb06a390a740974 100644
+index bb7cf83027ad0d0679fb208147f3481dbe280a82..42e06121f20b5366627b9612994187066c73328f 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -187,7 +187,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -42,7 +42,7 @@ index 808c9b298e1738797b42c14093b549e25333d287..553cf944e25f5d24f4d1af54bfb06a39
          this.generator = gen;
          this.world = new CraftWorld((WorldServer) this, gen, env);
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 3124941f6310fb1074c92793dfe14873e64966a1..c6e243b66a88054cba234113591491a701ed5f08 100644
+index b7a17eafe7355b9c9247a9c79495134b43971aaf..5508211d5922ef8072d929a5eb38c4d34f04c686 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -436,7 +436,24 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0118-Configurable-daylight-cycle.patch
+++ b/patches/server/0118-Configurable-daylight-cycle.patch
@@ -18,7 +18,7 @@ index 1b9b43ee696575d986c25cafec07d863acb951a7..e837db171545ceacbc84a2b360cf0d95
      public PacketPlayOutUpdateTime() {}
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index c6e243b66a88054cba234113591491a701ed5f08..6ba05e0d1bb800416e5602a44394936f601a57e9 100644
+index 5508211d5922ef8072d929a5eb38c4d34f04c686..f33b3ef2bf54eba4aa29447426f744a4f42d4b53 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -94,6 +94,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -37,7 +37,7 @@ index c6e243b66a88054cba234113591491a701ed5f08..6ba05e0d1bb800416e5602a44394936f
      }
  
      // Tuinity start - optimise collision
-@@ -1090,7 +1092,21 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1091,7 +1093,21 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              this.nextTickListBlock.nextTick(); // Paper
              this.nextTickListFluid.nextTick(); // Paper
              this.worldDataServer.u().a(this.server, i);
@@ -60,7 +60,7 @@ index c6e243b66a88054cba234113591491a701ed5f08..6ba05e0d1bb800416e5602a44394936f
                  this.setDayTime(this.worldData.getDayTime() + 1L);
              }
  
-@@ -1099,6 +1115,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1100,6 +1116,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
      public void setDayTime(long i) {
          this.worldDataServer.setDayTime(i);

--- a/patches/server/0122-Add-tablist-suffix-option-for-afk.patch
+++ b/patches/server/0122-Add-tablist-suffix-option-for-afk.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add tablist suffix option for afk
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 565cec043a00bc683bbab5874f5887b0df048170..3478de27261ec5a9f48a5128d774e4eca4ed5489 100644
+index da4943389fee9b8a8d03ad5c518806d85cc639db..f4e0a0714fa17c370202f6ea02412dc7afb0af97 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1991,7 +1991,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0124-Add-adjustable-breeding-cooldown-to-config.patch
+++ b/patches/server/0124-Add-adjustable-breeding-cooldown-to-config.patch
@@ -33,7 +33,7 @@ index b290218e506d5e4ddd1af17f91de19a588bbcfbd..cf9be4be18e913e49e9150358c66138b
              int experience = this.getRandom().nextInt(7) + 1;
              org.bukkit.event.entity.EntityBreedEvent entityBreedEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityBreedEvent(entityageable, this, entityanimal, entityplayer, this.breedItem, experience);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 553cf944e25f5d24f4d1af54bfb06a390a740974..8c162c5fdeaffccc9a28b592e030971fe51cafb3 100644
+index 42e06121f20b5366627b9612994187066c73328f..e13c5c97b91994c86161c86e5f03aca1545af676 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -104,6 +104,48 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/patches/server/0131-Add-critical-hit-check-to-EntityDamagedByEntityEvent.patch
+++ b/patches/server/0131-Add-critical-hit-check-to-EntityDamagedByEntityEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add critical hit check to EntityDamagedByEntityEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 3a7dc584bd2b88415a238f9c0cb7f85968fb8dfb..7ce46b53ad9fbaf7baf198557565b2467ab43c09 100644
+index fc51d6f9cd8c6ca61ae70b07cff817c5d871ab48..84fdb4710331791dfb180ce401f1da6962635b54 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -73,6 +73,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -74,6 +74,7 @@ public abstract class EntityHuman extends EntityLiving {
      // Paper start
      public boolean affectsSpawning = true;
      // Paper end
@@ -16,7 +16,7 @@ index 3a7dc584bd2b88415a238f9c0cb7f85968fb8dfb..7ce46b53ad9fbaf7baf198557565b246
  
      // CraftBukkit start
      public boolean fauxSleeping;
-@@ -1066,6 +1067,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1067,6 +1068,7 @@ public abstract class EntityHuman extends EntityLiving {
                      flag2 = flag2 && !world.paperConfig.disablePlayerCrits; // Paper
                      flag2 = flag2 && !this.isSprinting();
                      if (flag2) {
@@ -24,7 +24,7 @@ index 3a7dc584bd2b88415a238f9c0cb7f85968fb8dfb..7ce46b53ad9fbaf7baf198557565b246
                          f *= 1.5F;
                      }
  
-@@ -1102,6 +1104,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1103,6 +1105,7 @@ public abstract class EntityHuman extends EntityLiving {
  
                      Vec3D vec3d = entity.getMot();
                      boolean flag5 = entity.damageEntity(DamageSource.playerAttack(this), f);

--- a/patches/server/0136-Origami-Fix-ProtocolLib-issues-on-Java-15.patch
+++ b/patches/server/0136-Origami-Fix-ProtocolLib-issues-on-Java-15.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Origami - Fix ProtocolLib issues on Java 15
 
 
 diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
-index 65de374d485f31f8cd6f4e03941173565074ea0e..ea86843fa0313da15b905cbd712c15e7b217daa4 100644
+index d93634391501da01cb1afe70fedd5247c654e8fc..53b5063b43e42f09c2ef335251c91d2051676972 100644
 --- a/src/main/java/net/minecraft/server/NetworkManager.java
 +++ b/src/main/java/net/minecraft/server/NetworkManager.java
-@@ -394,9 +394,9 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -416,9 +416,9 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
              // note: since the type is not dynamic here, we need to actually copy the old executor code
              // into two branches. On conflict, just re-copy - no changes were made inside the executor code.
              if (flush) {
@@ -20,7 +20,7 @@ index 65de374d485f31f8cd6f4e03941173565074ea0e..ea86843fa0313da15b905cbd712c15e7
                      }
  
                      // Paper start
-@@ -406,7 +406,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -428,7 +428,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
                      }
                      try {
                          // Paper end
@@ -29,7 +29,7 @@ index 65de374d485f31f8cd6f4e03941173565074ea0e..ea86843fa0313da15b905cbd712c15e7
  
  
                          if (genericfuturelistener != null) {
-@@ -426,12 +426,12 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -448,12 +448,12 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
                          packet.onPacketDispatchFinish(player, null);
                      }
                      // Paper end
@@ -45,7 +45,7 @@ index 65de374d485f31f8cd6f4e03941173565074ea0e..ea86843fa0313da15b905cbd712c15e7
                      }
  
                      // Paper start
-@@ -441,7 +441,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -463,7 +463,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
                      }
                      try {
                          // Paper end
@@ -54,7 +54,7 @@ index 65de374d485f31f8cd6f4e03941173565074ea0e..ea86843fa0313da15b905cbd712c15e7
  
  
                          if (genericfuturelistener != null) {
-@@ -461,7 +461,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+@@ -483,7 +483,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
                          packet.onPacketDispatchFinish(player, null);
                      }
                      // Paper end

--- a/patches/server/0138-Add-boat-fall-damage-config.patch
+++ b/patches/server/0138-Add-boat-fall-damage-config.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add boat fall damage config
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 3478de27261ec5a9f48a5128d774e4eca4ed5489..3f00d66685479f3bec8cccb7a0b0988584122436 100644
+index f4e0a0714fa17c370202f6ea02412dc7afb0af97..5a602de5b9ff436e7cfb70c39475be34beddfb8d 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1011,7 +1011,16 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0144-Lobotomize-stuck-villagers.patch
+++ b/patches/server/0144-Lobotomize-stuck-villagers.patch
@@ -79,7 +79,7 @@ index 00e3ed9374f9962ea619a104892a4c32b2638876..b4719669d5dcfbc34dd37595be403e18
          long i = this.bC + 12000L;
          long j = this.world.getTime();
 diff --git a/src/main/java/net/minecraft/server/NavigationAbstract.java b/src/main/java/net/minecraft/server/NavigationAbstract.java
-index 87172af0b007f93bbb0474bc8f3789ed396258f8..b5ea7997040b5bfd98925a146e446aa3c56574da 100644
+index be243d411abf68686e75d46023c93fb8bb5c84e0..88368ae1633cf8bfb845d52b38110a6828fcf699 100644
 --- a/src/main/java/net/minecraft/server/NavigationAbstract.java
 +++ b/src/main/java/net/minecraft/server/NavigationAbstract.java
 @@ -101,6 +101,7 @@ public abstract class NavigationAbstract {

--- a/patches/server/0147-Spread-out-and-optimise-player-list-ticks.patch
+++ b/patches/server/0147-Spread-out-and-optimise-player-list-ticks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Spread out and optimise player list ticks
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 86f534c871a3c9b9ca71b20daa7780dfdab9e76d..d454b6c61c1a7d0ae9d6c2979cb865531acf405f 100644
+index f9043744ad0a622c6aa5e5bd3986fb9f60cab4c3..4415d081983d46bcece9b80bad6f3b5cdc624a4e 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -68,7 +68,7 @@ public abstract class PlayerList {
@@ -56,7 +56,7 @@ index 86f534c871a3c9b9ca71b20daa7780dfdab9e76d..d454b6c61c1a7d0ae9d6c2979cb86553
  
      public void sendAll(Packet<?> packet) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ca15efea5da7be1717a211b9b3556c755788561a..400e26c96f00e9f8895a45e70f22552ec17f2436 100644
+index 8bf29aca4b5aa0d51ed3cda25b37d30e6c986848..7b5ffe92430121eebe2866ac33b37a840eed90f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1435,7 +1435,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0150-Configurable-entity-base-attributes.patch
+++ b/patches/server/0150-Configurable-entity-base-attributes.patch
@@ -188,7 +188,7 @@ index 638efc67d66001ee085957d4698f51a7daac77fc..a766910663e47b05d1e38908b5db7471
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
-index 497d05996ab84f599aa0a02f853149f074e4d3cb..29c8e1b67396df160cdb7ecf4e1a563fc1acd5ac 100644
+index 81e63fe1b8252e2b5abcbf9051190cd0214b534c..75e834caaf7bb64a3d51d793e86aa702f6ccb0ae 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
 @@ -97,6 +97,11 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {

--- a/patches/server/0153-Implement-TPSBar.patch
+++ b/patches/server/0153-Implement-TPSBar.patch
@@ -17,7 +17,7 @@ index b5cc099746e9f05ea69bc438bda22a5ac3ebc3c5..bbd17231a4f7ad0ddde6eb5e589a6c40
  
          if (commanddispatcher_servertype.d) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index de69589a8e88d9330365decccc9e3bceb337b354..f328fb6d9d7d3c4362c06a4aa06d379263ca087d 100644
+index 4f589ca6cfc770bd26d0046736f7100272d7e48e..c8c4c4e7acd05768d2dc7dc3096cb208abcda0f3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -472,6 +472,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -37,7 +37,7 @@ index de69589a8e88d9330365decccc9e3bceb337b354..f328fb6d9d7d3c4362c06a4aa06d3792
          this.isRestarting = isRestarting;
          this.hasLoggedStop = true; // Paper
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index d454b6c61c1a7d0ae9d6c2979cb865531acf405f..f80371ce1665d0760ad0553a2a057a955c56669c 100644
+index 4415d081983d46bcece9b80bad6f3b5cdc624a4e..3a4165efa33cce86457092c29d2cf2aced42f43d 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -513,6 +513,8 @@ public abstract class PlayerList {

--- a/patches/server/0156-Full-netherite-armor-grants-fire-resistance.patch
+++ b/patches/server/0156-Full-netherite-armor-grants-fire-resistance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Full netherite armor grants fire resistance
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 7ce46b53ad9fbaf7baf198557565b2467ab43c09..5581e9f1b8656bd2ee0dd338ffd17ac8297df94f 100644
+index 84fdb4710331791dfb180ce401f1da6962635b54..708f9c5d0b6e30512b3d3ea45ec2b2baf9482669 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -236,6 +236,16 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -237,6 +237,16 @@ public abstract class EntityHuman extends EntityLiving {
              this.addEffect(new MobEffect(MobEffects.WATER_BREATHING, 200, 0, false, false, true), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.TURTLE_HELMET); // CraftBukkit
          }
  

--- a/patches/server/0159-Add-mobGriefing-bypass-to-everything-affected.patch
+++ b/patches/server/0159-Add-mobGriefing-bypass-to-everything-affected.patch
@@ -58,7 +58,7 @@ index 0f147dc938cef428452bd3137c68b52a78f9fbde..276aac9afd5d987cf388a87718453c47
          return true;
          // Purpur end
 diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
-index 29c8e1b67396df160cdb7ecf4e1a563fc1acd5ac..fd019a7d8940150ba776e211fe5f7ecb4ffbc89c 100644
+index 75e834caaf7bb64a3d51d793e86aa702f6ccb0ae..e2377c6e8a98be431953533bf0b2060028caad45 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
 @@ -489,7 +489,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
@@ -246,7 +246,7 @@ index 1dd13dfea91a05b1e83b065328092a17d41a605f..eb6344a5671408ae9fdd6013774baa13
              }
  
 diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
-index cc4b0945fb9186c6975136d48ce8dfc12b4d4230..0b6cb7c3c55f4b0951fde643a898bd67a08e08af 100644
+index edc58c5cb178ea9a53f960bd4a460f394b13ab64..27bfef57cfa1386e81c6409be49ea6898057e631 100644
 --- a/src/main/java/net/minecraft/server/EntityWither.java
 +++ b/src/main/java/net/minecraft/server/EntityWither.java
 @@ -323,7 +323,7 @@ public class EntityWither extends EntityMonster implements IRangedEntity {

--- a/patches/server/0161-Add-EntityTeleportHinderedEvent.patch
+++ b/patches/server/0161-Add-EntityTeleportHinderedEvent.patch
@@ -123,7 +123,7 @@ index 5471422d23d261a06c67f9374cae933430ec03a0..4c592f6d4d6cbeb4c3225e7794f4b1d6
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 400e26c96f00e9f8895a45e70f22552ec17f2436..ec450146f82b656616c8b60cc05d727437eaa0b6 100644
+index 7b5ffe92430121eebe2866ac33b37a840eed90f1..98f4407848347dfc46b70d1c1fe466dce10f54b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -117,6 +117,7 @@ import org.bukkit.entity.EntityType;

--- a/patches/server/0165-Fix-stuck-in-portals.patch
+++ b/patches/server/0165-Fix-stuck-in-portals.patch
@@ -25,7 +25,7 @@ index 4b7ab2405a7d49ae085d64e482d4a851f18263d6..c27ce317c7acaf7ddd926c982d08e053
  
              this.inPortal = true;
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 3f00d66685479f3bec8cccb7a0b0988584122436..5c01d6609403c7aa8fe6e31faae485910db74a03 100644
+index 5a602de5b9ff436e7cfb70c39475be34beddfb8d..5cf4a2b41d7f088eeb7c8003b8b889f370a4d214 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1161,6 +1161,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0171-Add-unsafe-Entity-serialization-API.patch
+++ b/patches/server/0171-Add-unsafe-Entity-serialization-API.patch
@@ -46,7 +46,7 @@ index 4c592f6d4d6cbeb4c3225e7794f4b1d6c8d62394..b441dac8f31b679aa7e36d23848d34e2
      // Purpur end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 7de7afae711800154735411947ff140c76d5171f..b14e9a2cd6e849fe91a2512f379036a284323420 100644
+index 81cff601a5161c30df90de3cefc18d72cd7ee347..980696490709d04741c1617f528357100696d0e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -390,9 +390,14 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0173-Configs-for-if-Wither-Ender-Dragon-can-ride-vehicles.patch
+++ b/patches/server/0173-Configs-for-if-Wither-Ender-Dragon-can-ride-vehicles.patch
@@ -18,7 +18,7 @@ index c27ce317c7acaf7ddd926c982d08e0539e045e28..426bebc5cd67ffcc72ee56d437cc13f6
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
-index fd019a7d8940150ba776e211fe5f7ecb4ffbc89c..9e27d3ccfd6a5ee00cac72c3137189b1be1f81fb 100644
+index e2377c6e8a98be431953533bf0b2060028caad45..a495c14b9f168884a0bba6b95d28c9ecfa9dfdab 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
 @@ -1023,6 +1023,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
@@ -30,7 +30,7 @@ index fd019a7d8940150ba776e211fe5f7ecb4ffbc89c..9e27d3ccfd6a5ee00cac72c3137189b1
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
-index 0b6cb7c3c55f4b0951fde643a898bd67a08e08af..b6663cd71e2e0ec0c4dd27095160298f081c4ec5 100644
+index 27bfef57cfa1386e81c6409be49ea6898057e631..a8cda33da336f7c24a341f67a88681690d5a29a6 100644
 --- a/src/main/java/net/minecraft/server/EntityWither.java
 +++ b/src/main/java/net/minecraft/server/EntityWither.java
 @@ -673,6 +673,7 @@ public class EntityWither extends EntityMonster implements IRangedEntity {

--- a/patches/server/0178-Config-to-ignore-nearby-mobs-when-sleeping.patch
+++ b/patches/server/0178-Config-to-ignore-nearby-mobs-when-sleeping.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config to ignore nearby mobs when sleeping
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 5c01d6609403c7aa8fe6e31faae485910db74a03..453f1b9eb3e8a878f0645d1daa956de7810cbbac 100644
+index 5cf4a2b41d7f088eeb7c8003b8b889f370a4d214..c3833ea72c34efc9357706dac7afa2dbb768cf6a 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1311,7 +1311,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
39c487b37 Add per-command perms for paper command
cdbf2578c Add Item Rarity API (#5352)
d80e43647 [CI-SKIP] Removal from the MIT list (#5345)

Tuinity Changes:
aea6b8347 Merge dev/playerchunkloading
722c7ca8a Use hash table for maintaing changed block set
98ae59d85 Custom table implementation for blockstate state lookups
8b8704fb6 Oprimise map impl for tracked players
ea71d6ba4 Optimise snow & ice in chunk ticking
9871d4ce5 Remove chunk lookup & lambda allocation from counting mobs
5a4a35f3e Add patreon
7d93d9618 Refactor data management for region manager
c3035219f Change license from MIT to LGPLv3

Airplane Changes:
82253fd36 Early return optimization for target finding
9572643bb Cache entityhuman display name
5df98254f Remove iterators from inventory contains
18d2be193 Merge pull request #14 from violetwtf/patch-1
97df20651 Update README to reflect support changes
f716d4c33 Merge pull request #13 from violetwtf/master
cf161dd65 Change blog URL to more helpful one
128cbe519 Reduce entity chunk ticking checks from 3 to 1
03ac0933b Skip copying unloading tile entities
97dd027b5 Smaller pool size for tracking
9e9f57be4 Only set up Flare if token is available
580f380b6 Updated Upstream (Tuinity)