### PR TITLE
Config to make Creepers explode on death

### DIFF
--- a/patches/server/0183-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0183-Config-to-make-Creepers-explode-on-death.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Tue, 16 Mar 2021 19:50:58 -0400
+Subject: [PATCH] Config to make Creepers explode on death
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
+index 523988bcc0607198dfb73afca5932ed6dd82cca1..7b69eddd21e7effee63cbd4c78976eb87ed5d633 100644
+--- a/src/main/java/net/minecraft/server/EntityCreeper.java
++++ b/src/main/java/net/minecraft/server/EntityCreeper.java
+@@ -102,6 +102,14 @@ public class EntityCreeper extends EntityMonster {
+     public void initAttributes() {
+         this.getAttributeInstance(GenericAttributes.MAX_HEALTH).setValue(this.world.purpurConfig.creeperMaxHealth);
+     }
++
++    public void die() {
++        super.die();
++
++        if (this.world.purpurConfig.creeperExplodeWhenKilled && this.getKillingEntity() instanceof EntityPlayer) {
++            this.explode();
++        }
++    }
+     // Purpur end
+ 
+     @Override
+@@ -297,7 +305,7 @@ public class EntityCreeper extends EntityMonster {
+             if (!event.isCancelled()) {
+                 this.killed = true;
+                 this.world.createExplosion(this, this.locX(), this.locY(), this.locZ(), event.getRadius(), event.getFire(), explosion_effect);
+-                this.die();
++                if (!this.dead) this.die(); // Purpur
+                 this.createEffectCloud();
+             } else {
+                 fuseTicks = 0;
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index e3dccf08a9b931f83e0c0a218f5db60e643f7674..5ce9e76e4aad9338b950a30cc90d7f2f77eba271 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -699,12 +699,14 @@ public class PurpurWorldConfig {
+ 
+     public boolean creeperRidable = false;
+     public boolean creeperRidableInWater = false;
++    public boolean creeperExplodeWhenKilled = false;
+     public boolean creeperAllowGriefing = true;
+     public double creeperChargedChance = 0.0D;
+     public double creeperMaxHealth = 20.0D;
+     private void creeperSettings() {
+         creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
+         creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
++        creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
+         creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
+         creeperChargedChance = getDouble("mobs.creeper.naturally-charged-chance", creeperChargedChance);
+         if (PurpurConfig.version < 10) {

--- a/patches/server/0183-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0183-Config-to-make-Creepers-explode-on-death.patch
@@ -3,6 +3,7 @@ From: Encode42 <me@encode42.dev>
 Date: Tue, 16 Mar 2021 19:50:58 -0400
 Subject: [PATCH] Config to make Creepers explode on death
 
+Creepers exploded after being killed in the alpha days. This brings that back.
 
 diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
 index 523988bcc0607198dfb73afca5932ed6dd82cca1..7b69eddd21e7effee63cbd4c78976eb87ed5d633 100644

--- a/patches/server/0183-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0183-Config-to-make-Creepers-explode-on-death.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Config to make Creepers explode on death
 Creepers exploded after being killed in the alpha days. This brings that back.
 
 diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
-index 523988bcc0607198dfb73afca5932ed6dd82cca1..ef6d98912754dfb18c9bc531ee712aef06976996 100644
+index 523988bcc0607198dfb73afca5932ed6dd82cca1..6b3b1303862cd2ea90b5158e51ce94d3ad81d463 100644
 --- a/src/main/java/net/minecraft/server/EntityCreeper.java
 +++ b/src/main/java/net/minecraft/server/EntityCreeper.java
 @@ -23,6 +23,7 @@ public class EntityCreeper extends EntityMonster {
@@ -40,19 +40,10 @@ index 523988bcc0607198dfb73afca5932ed6dd82cca1..ef6d98912754dfb18c9bc531ee712aef
          if (!this.world.isClientSide) {
              Explosion.Effect explosion_effect = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) && world.purpurConfig.creeperAllowGriefing ? Explosion.Effect.DESTROY : Explosion.Effect.NONE; // Purpur
              float f = this.isPowered() ? 2.0F : 1.0F;
-@@ -295,6 +305,7 @@ public class EntityCreeper extends EntityMonster {
-             ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), this.explosionRadius * f, false);
-             this.world.getServer().getPluginManager().callEvent(event);
-             if (!event.isCancelled()) {
-+
-                 this.killed = true;
-                 this.world.createExplosion(this, this.locX(), this.locY(), this.locZ(), event.getRadius(), event.getFire(), explosion_effect);
-                 this.die();
-@@ -305,7 +316,7 @@ public class EntityCreeper extends EntityMonster {
-             }
+@@ -306,6 +316,7 @@ public class EntityCreeper extends EntityMonster {
              // CraftBukkit end
          }
--
+ 
 +        this.exploding = false; // Purpur
      }
  

--- a/patches/server/0183-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0183-Config-to-make-Creepers-explode-on-death.patch
@@ -6,33 +6,57 @@ Subject: [PATCH] Config to make Creepers explode on death
 Creepers exploded after being killed in the alpha days. This brings that back.
 
 diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
-index 523988bcc0607198dfb73afca5932ed6dd82cca1..7b69eddd21e7effee63cbd4c78976eb87ed5d633 100644
+index 523988bcc0607198dfb73afca5932ed6dd82cca1..ef6d98912754dfb18c9bc531ee712aef06976996 100644
 --- a/src/main/java/net/minecraft/server/EntityCreeper.java
 +++ b/src/main/java/net/minecraft/server/EntityCreeper.java
-@@ -102,6 +102,14 @@ public class EntityCreeper extends EntityMonster {
+@@ -23,6 +23,7 @@ public class EntityCreeper extends EntityMonster {
+     private int spacebarCharge = 0;
+     private int prevSpacebarCharge = 0;
+     private int powerToggleDelay = 0;
++    private boolean exploding = false;
+     // Purpur end
+ 
+     public EntityCreeper(EntityTypes<? extends EntityCreeper> entitytypes, World world) {
+@@ -102,6 +103,14 @@ public class EntityCreeper extends EntityMonster {
      public void initAttributes() {
          this.getAttributeInstance(GenericAttributes.MAX_HEALTH).setValue(this.world.purpurConfig.creeperMaxHealth);
      }
 +
-+    public void die() {
-+        super.die();
-+
-+        if (this.world.purpurConfig.creeperExplodeWhenKilled && this.getKillingEntity() instanceof EntityPlayer) {
++    protected org.bukkit.event.entity.EntityDeathEvent d(DamageSource damagesource) {
++        if (!exploding && this.world.purpurConfig.creeperExplodeWhenKilled && damagesource.getEntity() instanceof EntityPlayer) {
 +            this.explode();
 +        }
++
++        return super.d(damagesource);
 +    }
      // Purpur end
  
      @Override
-@@ -297,7 +305,7 @@ public class EntityCreeper extends EntityMonster {
+@@ -287,6 +296,7 @@ public class EntityCreeper extends EntityMonster {
+     }
+ 
+     public void explode() {
++        this.exploding = true; // Purpur
+         if (!this.world.isClientSide) {
+             Explosion.Effect explosion_effect = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) && world.purpurConfig.creeperAllowGriefing ? Explosion.Effect.DESTROY : Explosion.Effect.NONE; // Purpur
+             float f = this.isPowered() ? 2.0F : 1.0F;
+@@ -295,6 +305,7 @@ public class EntityCreeper extends EntityMonster {
+             ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), this.explosionRadius * f, false);
+             this.world.getServer().getPluginManager().callEvent(event);
              if (!event.isCancelled()) {
++
                  this.killed = true;
                  this.world.createExplosion(this, this.locX(), this.locY(), this.locZ(), event.getRadius(), event.getFire(), explosion_effect);
--                this.die();
-+                if (!this.dead) this.die(); // Purpur
-                 this.createEffectCloud();
-             } else {
-                 fuseTicks = 0;
+                 this.die();
+@@ -305,7 +316,7 @@ public class EntityCreeper extends EntityMonster {
+             }
+             // CraftBukkit end
+         }
+-
++        this.exploding = false; // Purpur
+     }
+ 
+     private void createEffectCloud() {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 index e3dccf08a9b931f83e0c0a218f5db60e643f7674..5ce9e76e4aad9338b950a30cc90d7f2f77eba271 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java

--- a/patches/server/0184-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0184-Config-to-make-Creepers-explode-on-death.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Tue, 16 Mar 2021 19:50:58 -0400
+Subject: [PATCH] Config to make Creepers explode on death
+
+Creepers exploded after being killed in the alpha days. This brings that back.
+
+diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
+index 523988bcc0607198dfb73afca5932ed6dd82cca1..6b3b1303862cd2ea90b5158e51ce94d3ad81d463 100644
+--- a/src/main/java/net/minecraft/server/EntityCreeper.java
++++ b/src/main/java/net/minecraft/server/EntityCreeper.java
+@@ -23,6 +23,7 @@ public class EntityCreeper extends EntityMonster {
+     private int spacebarCharge = 0;
+     private int prevSpacebarCharge = 0;
+     private int powerToggleDelay = 0;
++    private boolean exploding = false;
+     // Purpur end
+ 
+     public EntityCreeper(EntityTypes<? extends EntityCreeper> entitytypes, World world) {
+@@ -102,6 +103,14 @@ public class EntityCreeper extends EntityMonster {
+     public void initAttributes() {
+         this.getAttributeInstance(GenericAttributes.MAX_HEALTH).setValue(this.world.purpurConfig.creeperMaxHealth);
+     }
++
++    protected org.bukkit.event.entity.EntityDeathEvent d(DamageSource damagesource) {
++        if (!exploding && this.world.purpurConfig.creeperExplodeWhenKilled && damagesource.getEntity() instanceof EntityPlayer) {
++            this.explode();
++        }
++
++        return super.d(damagesource);
++    }
+     // Purpur end
+ 
+     @Override
+@@ -287,6 +296,7 @@ public class EntityCreeper extends EntityMonster {
+     }
+ 
+     public void explode() {
++        this.exploding = true; // Purpur
+         if (!this.world.isClientSide) {
+             Explosion.Effect explosion_effect = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) && world.purpurConfig.creeperAllowGriefing ? Explosion.Effect.DESTROY : Explosion.Effect.NONE; // Purpur
+             float f = this.isPowered() ? 2.0F : 1.0F;
+@@ -306,6 +316,7 @@ public class EntityCreeper extends EntityMonster {
+             // CraftBukkit end
+         }
+ 
++        this.exploding = false; // Purpur
+     }
+ 
+     private void createEffectCloud() {
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index fc584ec761f04dbcc45e7e058d19a0efb110c2c6..4968223d4711e6fea414ee7fba4904f5fc35c074 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -699,12 +699,14 @@ public class PurpurWorldConfig {
+ 
+     public boolean creeperRidable = false;
+     public boolean creeperRidableInWater = false;
++    public boolean creeperExplodeWhenKilled = false;
+     public boolean creeperAllowGriefing = true;
+     public double creeperChargedChance = 0.0D;
+     public double creeperMaxHealth = 20.0D;
+     private void creeperSettings() {
+         creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
+         creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
++        creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
+         creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
+         creeperChargedChance = getDouble("mobs.creeper.naturally-charged-chance", creeperChargedChance);
+         if (PurpurConfig.version < 10) {


### PR DESCRIPTION
Brings back an alpha mechanic of making Creepers explode when killed by players.
![Example](https://cdn.discordapp.com/attachments/365455566329348097/821828276204470282/file-compressed.gif)

Resolves #200