### PR TITLE
Config to disable hostile mob spawn on ice `:)`

### DIFF
--- a/patches/server/0176-Add-config-for-snow-on-blue-ice.patch
+++ b/patches/server/0176-Add-config-for-snow-on-blue-ice.patch
@@ -29,7 +29,7 @@ index d44b88185ce58346007c6ef70b76f8e0df23e95c..4b7497acc5b26da48375625b4a31fb05
  
      @Override
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index ef75a80793a5a36177dd99879d19a91a52077e95..3e7ec07ab595998b0a13ac9e44f5a5b9d0d45d03 100644
+index ef75a80793a5a36177dd99879d19a91a52077e95..d4fbbfbbf96c7cb843d7867289a51febef36218f 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -419,6 +419,11 @@ public class PurpurWorldConfig {
@@ -37,7 +37,7 @@ index ef75a80793a5a36177dd99879d19a91a52077e95..3e7ec07ab595998b0a13ac9e44f5a5b9
      }
  
 +    public boolean snowOnBlueIce = true;
-+    private void blueIceSettings() {
++    private void iceSettings() {
 +        snowOnBlueIce = getBoolean("blocks.blue_ice.allow-snow-formation", snowOnBlueIce);
 +    }
 +

--- a/patches/server/0177-Configurable-Ender-Pearl-cooldown-damage-and-Endermi.patch
+++ b/patches/server/0177-Configurable-Ender-Pearl-cooldown-damage-and-Endermi.patch
@@ -43,7 +43,7 @@ index 9896d77381e7fadf1ef2619210713e190c1445d0..61512c6755f29cb2c228ae3e80b1e083
                  // Paper end
                  if (entityhuman instanceof net.minecraft.server.level.EntityPlayer) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 3e7ec07ab595998b0a13ac9e44f5a5b9d0d45d03..c5a8f78563abc4dae68254b599b2ee60dee6d416 100644
+index d4fbbfbbf96c7cb843d7867289a51febef36218f..14c7a7054744080c5ebe820d10d37fa2c0b33cde 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -170,6 +170,10 @@ public class PurpurWorldConfig {

--- a/patches/server/0178-Config-to-ignore-nearby-mobs-when-sleeping.patch
+++ b/patches/server/0178-Config-to-ignore-nearby-mobs-when-sleeping.patch
@@ -18,7 +18,7 @@ index ccee67df065dcdee5e0e24ab12476572ca696687..b4dbc59faff3fd6ceb74d829762eb68e
                          }
                      }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index c5a8f78563abc4dae68254b599b2ee60dee6d416..fc68963c47d37b9ecec5debc367efe4647d67b2e 100644
+index 14c7a7054744080c5ebe820d10d37fa2c0b33cde..aa1fd10c975a4948233139ab29757d42791bda1d 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -283,6 +283,7 @@ public class PurpurWorldConfig {

--- a/patches/server/0179-Config-for-Enderman-to-aggro-spawned-Endermites.patch
+++ b/patches/server/0179-Config-for-Enderman-to-aggro-spawned-Endermites.patch
@@ -19,7 +19,7 @@ index d290787f74579dd4c138eb827e44544814bfe315..46143a710e057378ebe0ad644de27560
      private int br = Integer.MIN_VALUE;
      private int bs;
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index fc68963c47d37b9ecec5debc367efe4647d67b2e..f6d6e57a0dea4d9e0de04caaab530682e3b212d5 100644
+index aa1fd10c975a4948233139ab29757d42791bda1d..208668cf92b9e881ae300be6de8c8ae7677812ea 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -823,6 +823,7 @@ public class PurpurWorldConfig {

--- a/patches/server/0180-Config-to-ignore-Dragon-Head-wearers-and-stare-aggro.patch
+++ b/patches/server/0180-Config-to-ignore-Dragon-Head-wearers-and-stare-aggro.patch
@@ -28,7 +28,7 @@ index 46143a710e057378ebe0ad644de275604b11d886..0ed19429c1a9021e636fdfffa582b4e0
          } else {
              Vec3D vec3d = entityhuman.f(1.0F).d();
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index f6d6e57a0dea4d9e0de04caaab530682e3b212d5..fc29c54ee69bd39dec95cc5e877f5b6fb6bba442 100644
+index 208668cf92b9e881ae300be6de8c8ae7677812ea..4f484cb094b3c8e2dd07feb394f96360931f6642 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -824,6 +824,8 @@ public class PurpurWorldConfig {

--- a/patches/server/0182-Tick-fluids-config.patch
+++ b/patches/server/0182-Tick-fluids-config.patch
@@ -36,7 +36,7 @@ index 0ed8d938b8fafdb03e01a00a201ba3f8597ac6e9..0eff89bf9e114271c34c37cad1b98691
          }
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index fc29c54ee69bd39dec95cc5e877f5b6fb6bba442..ca108b3163c31fddd43112123c1c4cb70ba26bc9 100644
+index 4f484cb094b3c8e2dd07feb394f96360931f6642..6b44bc7efdfe992302782d23f5a6a46265d31f6d 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -261,6 +261,11 @@ public class PurpurWorldConfig {

--- a/patches/server/0183-Config-to-disable-Llama-caravans.patch
+++ b/patches/server/0183-Config-to-disable-Llama-caravans.patch
@@ -32,7 +32,7 @@ index 762fed5ba27474951c1962e6f034e8494b1035d6..567a1da3c167c20ae3fb86c2a1f3608e
          this.bB.bC = this;
      }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index ca108b3163c31fddd43112123c1c4cb70ba26bc9..886d04393bfbd25d3c0131520e239ac0c3404654 100644
+index 6b44bc7efdfe992302782d23f5a6a46265d31f6d..e3aee2e73b453105b47aaa5a38b07b54f3406138 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -1063,6 +1063,7 @@ public class PurpurWorldConfig {

--- a/patches/server/0184-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0184-Config-to-make-Creepers-explode-on-death.patch
@@ -57,7 +57,7 @@ index 6461e09e05f9255a399a6ce65d8fb90789a2fd7f..5e70746494c5397d4d798d24b7292c57
  
      private void createEffectCloud() {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 886d04393bfbd25d3c0131520e239ac0c3404654..d975b08e3ef4921f17fc0aac85cfa7d9febb9054 100644
+index e3aee2e73b453105b47aaa5a38b07b54f3406138..9c23c5939fcdecb7dbb86aa073582712a4f2230a 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -699,12 +699,14 @@ public class PurpurWorldConfig {

--- a/patches/server/0185-Configurable-ravager-griefable-blocks-list.patch
+++ b/patches/server/0185-Configurable-ravager-griefable-blocks-list.patch
@@ -31,7 +31,7 @@ index 5f8366beeaac7153a0421554f9bf91fbf265edca..7fca4d1713e8061d9de825cdae484012
          }
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index d975b08e3ef4921f17fc0aac85cfa7d9febb9054..94f975521e9770577975810bb2c6c40d96303392 100644
+index 9c23c5939fcdecb7dbb86aa073582712a4f2230a..332da1c508b68b02988756fe00c34fd55ef84df5 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -1404,6 +1404,7 @@ public class PurpurWorldConfig {

--- a/patches/server/0186-Sneak-to-bulk-process-composter.patch
+++ b/patches/server/0186-Sneak-to-bulk-process-composter.patch
@@ -44,7 +44,7 @@ index e4e519ba773388b8d26a8f794a6eff51e3d8f72e..c0b235d5edf3cd14021696d1b4f76ce3
              // CraftBukkit start
              double rand = worldserver.getRandom().nextDouble();
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 94f975521e9770577975810bb2c6c40d96303392..546d10217ffdf6de4c0c76ad4a55911b9fb6e903 100644
+index 332da1c508b68b02988756fe00c34fd55ef84df5..91f007cb1e14a0921d0b05f168be7dea15c57667 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -444,6 +444,11 @@ public class PurpurWorldConfig {

--- a/patches/server/0187-Config-for-skipping-night.patch
+++ b/patches/server/0187-Config-for-skipping-night.patch
@@ -18,7 +18,7 @@ index 63b22bd2dc828f4b5be45f8162745b4cc214382b..1dbd63f1b62851775f6289846118d9b1
          })) {
              // CraftBukkit start
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 546d10217ffdf6de4c0c76ad4a55911b9fb6e903..1ee973ca154595ddf5dc1560cfd26e9981a7bddf 100644
+index 91f007cb1e14a0921d0b05f168be7dea15c57667..fcf6095d1ff6deb4231866cd482f7d5d3040ad19 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -289,6 +289,7 @@ public class PurpurWorldConfig {

--- a/patches/server/0188-Add-config-for-villager-trading.patch
+++ b/patches/server/0188-Add-config-for-villager-trading.patch
@@ -31,7 +31,7 @@ index b84916c0c58fd208ef5547299f8db8462d1c42fe..0b6b6aa6b358759c45bbcf4a9ffa5377
                      this.openTrade(entityhuman, this.getScoreboardDisplayName(), 1);
                  }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 1ee973ca154595ddf5dc1560cfd26e9981a7bddf..03f5fae19685823d0cb23bad5f6f07dbd75437f4 100644
+index fcf6095d1ff6deb4231866cd482f7d5d3040ad19..adb9166b15654a81b2a852b518beea52a1ee8327 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -1712,6 +1712,7 @@ public class PurpurWorldConfig {

--- a/patches/server/0190-Drowning-Settings.patch
+++ b/patches/server/0190-Drowning-Settings.patch
@@ -40,7 +40,7 @@ index 659ccc8075945531ca714c43a034f2d5baa5defb..1d319ad82179ae261738d6e70aac3bbb
                  }
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 03f5fae19685823d0cb23bad5f6f07dbd75437f4..b0f6d5dae50f5689ef41b766a590ca5a26834fc2 100644
+index adb9166b15654a81b2a852b518beea52a1ee8327..66b0e4a2225ae9407a3b80b5354e960e6e1420b9 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -1987,6 +1987,15 @@ public class PurpurWorldConfig {

--- a/patches/server/0191-Break-individual-slabs-when-sneaking.patch
+++ b/patches/server/0191-Break-individual-slabs-when-sneaking.patch
@@ -57,7 +57,7 @@ index 12c0fa5072755fd2a4f575b0cc5e4222617490ce..94965b216d50b29b95f09fa9019c177b
 +    // Purpur end
  }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index b0f6d5dae50f5689ef41b766a590ca5a26834fc2..62f52be341a0ddec165bb9b24e2f4ed97e145104 100644
+index 66b0e4a2225ae9407a3b80b5354e960e6e1420b9..1e5cb69d5c1e61b7dd01d7ab615dbee88f9520e6 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -517,6 +517,11 @@ public class PurpurWorldConfig {

--- a/patches/server/0191-Config-to-disable-hostile-mob-spawn-on-ice.patch
+++ b/patches/server/0191-Config-to-disable-hostile-mob-spawn-on-ice.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Tue, 23 Mar 2021 15:40:45 -0400
+Subject: [PATCH] Config to disable hostile mob spawn on ice
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityMonster.java b/src/main/java/net/minecraft/world/entity/monster/EntityMonster.java
+index c484e27650364b6537fe6b2e8e14de98382b86a3..c881c023273edf5bc2ec3ba56566503ed788ae26 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/EntityMonster.java
++++ b/src/main/java/net/minecraft/world/entity/monster/EntityMonster.java
+@@ -24,6 +24,8 @@ import net.minecraft.world.level.GeneratorAccess;
+ import net.minecraft.world.level.IWorldReader;
+ import net.minecraft.world.level.World;
+ import net.minecraft.world.level.WorldAccess;
++import net.minecraft.world.level.block.Blocks;
++import net.minecraft.world.level.block.state.IBlockData;
+ 
+ public abstract class EntityMonster extends EntityCreature implements IMonster {
+ 
+@@ -95,6 +97,13 @@ public abstract class EntityMonster extends EntityCreature implements IMonster {
+     }
+ 
+     public static boolean a(WorldAccess worldaccess, BlockPosition blockposition, Random random) {
++        // Purpur start
++        IBlockData spawnBlock = worldaccess.getType(blockposition.down());
++        World world = worldaccess.getMinecraftWorld();
++        if ((!world.purpurConfig.mobsSpawnOnPackedIce && spawnBlock.equals(Blocks.PACKED_ICE)) || (!world.purpurConfig.mobsSpawnOnBlueIce && spawnBlock.equals(Blocks.BLUE_ICE))) {
++            return false;
++        }
++        // Purpur end
+         if (worldaccess.getBrightness(EnumSkyBlock.SKY, blockposition) > random.nextInt(32)) {
+             return false;
+         } else {
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index adb9166b15654a81b2a852b518beea52a1ee8327..b28bf41a08c2dddc76f2dd056cd9a2882510d06d 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -437,8 +437,12 @@ public class PurpurWorldConfig {
+     }
+ 
+     public boolean snowOnBlueIce = true;
++    public boolean mobsSpawnOnPackedIce = true;
++    public boolean mobsSpawnOnBlueIce = true;
+     private void iceSettings() {
+         snowOnBlueIce = getBoolean("blocks.blue_ice.allow-snow-formation", snowOnBlueIce);
++        mobsSpawnOnPackedIce = getBoolean("blocks.packed_ice.allow-mob-spawns", mobsSpawnOnPackedIce);
++        mobsSpawnOnBlueIce = getBoolean("blocks.blue_ice.allow-mob-spawns", mobsSpawnOnBlueIce);
+     }
+ 
+     public boolean chestOpenWithBlockOnTop = false;

--- a/patches/server/0192-Config-to-disable-hostile-mob-spawn-on-ice.patch
+++ b/patches/server/0192-Config-to-disable-hostile-mob-spawn-on-ice.patch
@@ -5,26 +5,16 @@ Subject: [PATCH] Config to disable hostile mob spawn on ice
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityMonster.java b/src/main/java/net/minecraft/world/entity/monster/EntityMonster.java
-index c484e27650364b6537fe6b2e8e14de98382b86a3..c881c023273edf5bc2ec3ba56566503ed788ae26 100644
+index c484e27650364b6537fe6b2e8e14de98382b86a3..096a7b76e0ae42ba8b859159e20fb72e101fe6de 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EntityMonster.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EntityMonster.java
-@@ -24,6 +24,8 @@ import net.minecraft.world.level.GeneratorAccess;
- import net.minecraft.world.level.IWorldReader;
- import net.minecraft.world.level.World;
- import net.minecraft.world.level.WorldAccess;
-+import net.minecraft.world.level.block.Blocks;
-+import net.minecraft.world.level.block.state.IBlockData;
- 
- public abstract class EntityMonster extends EntityCreature implements IMonster {
- 
-@@ -95,6 +97,13 @@ public abstract class EntityMonster extends EntityCreature implements IMonster {
+@@ -95,6 +95,12 @@ public abstract class EntityMonster extends EntityCreature implements IMonster {
      }
  
      public static boolean a(WorldAccess worldaccess, BlockPosition blockposition, Random random) {
 +        // Purpur start
-+        IBlockData spawnBlock = worldaccess.getType(blockposition.down());
-+        World world = worldaccess.getMinecraftWorld();
-+        if ((!world.purpurConfig.mobsSpawnOnPackedIce && spawnBlock.equals(Blocks.PACKED_ICE)) || (!world.purpurConfig.mobsSpawnOnBlueIce && spawnBlock.equals(Blocks.BLUE_ICE))) {
++        net.minecraft.world.level.block.state.IBlockData spawnBlock = worldaccess.getType(blockposition.down());
++        if ((!worldaccess.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.equals(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!worldaccess.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.equals(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
 +            return false;
 +        }
 +        // Purpur end
@@ -32,7 +22,7 @@ index c484e27650364b6537fe6b2e8e14de98382b86a3..c881c023273edf5bc2ec3ba56566503e
              return false;
          } else {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index adb9166b15654a81b2a852b518beea52a1ee8327..b28bf41a08c2dddc76f2dd056cd9a2882510d06d 100644
+index 1e5cb69d5c1e61b7dd01d7ab615dbee88f9520e6..81769dea86810ebf8f173e2cf3414c6753191ca7 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -437,8 +437,12 @@ public class PurpurWorldConfig {


### PR DESCRIPTION
Adds a configuration option to disable the ability for hostile mobs to spawn on packed ice and blue ice. In my testing, mobs do not spawn on normal ice. Polar bears (referenced in the issue) will not be affected since this only targets the Monster class.
Also renames `blueIceSettings` to `iceSettings` to reduce clutter.

Resolves #214 
The title is like that to see what the Jenkins build embed will do if merged.