### PR TITLE
Config to show Armor Stand arms on spawn

### DIFF
--- a/patches/server/0193-Config-to-show-Armor-Stand-arms-on-spawn.patch
+++ b/patches/server/0193-Config-to-show-Armor-Stand-arms-on-spawn.patch
@@ -1,0 +1,38 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Tue, 23 Mar 2021 22:42:20 -0400
+Subject: [PATCH] Config to show Armor Stand arms on spawn
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/decoration/EntityArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/EntityArmorStand.java
+index ecb797e67554d30e35b3aca4d0fc9b0e3f6c1a50..ddc1c3383cdc32fa832485f3922c74185731557a 100644
+--- a/src/main/java/net/minecraft/world/entity/decoration/EntityArmorStand.java
++++ b/src/main/java/net/minecraft/world/entity/decoration/EntityArmorStand.java
+@@ -103,6 +103,7 @@ public class EntityArmorStand extends EntityLiving {
+         this.leftLegPose = EntityArmorStand.bn;
+         this.rightLegPose = EntityArmorStand.bo;
+         this.G = 0.0F;
++        this.setArms(world != null && world.purpurConfig.armorstandPlaceWithArms); // Purpur
+     }
+ 
+     public EntityArmorStand(World world, double d0, double d1, double d2) {
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 81769dea86810ebf8f173e2cf3414c6753191ca7..0173077fadaf6d61c3b516e3d783608ae72c4284 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -114,6 +114,7 @@ public class PurpurWorldConfig {
+     public boolean armorstandMovement = true;
+     public boolean armorstandWaterMovement = true;
+     public boolean armorstandWaterFence = true;
++    public boolean armorstandPlaceWithArms = false;
+     private void armorstandSettings() {
+         armorstandSetNameVisible = getBoolean("gameplay-mechanics.armorstand.set-name-visible-when-placing-with-custom-name", armorstandSetNameVisible);
+         armorstandFixNametags = getBoolean("gameplay-mechanics.armorstand.fix-nametags", armorstandFixNametags);
+@@ -121,6 +122,7 @@ public class PurpurWorldConfig {
+         armorstandMovement = getBoolean("gameplay-mechanics.armorstand.can-movement-tick", armorstandMovement);
+         armorstandWaterMovement = getBoolean("gameplay-mechanics.armorstand.can-move-in-water", armorstandWaterMovement);
+         armorstandWaterFence = getBoolean("gameplay-mechanics.armorstand.can-move-in-water-over-fence", armorstandWaterFence);
++        armorstandPlaceWithArms = getBoolean("gameplay-mechanics.armorstand.place-with-arms-visible", armorstandPlaceWithArms);
+     }
+ 
+     public boolean controllableMinecarts = false;


### PR DESCRIPTION
Armor stand arms can also be used to display items such as swords.
Closes #217

![Example](https://cdn.discordapp.com/attachments/365455566329348097/824118239247990904/file-compressed.gif)