### PR TITLE
Config to allow for unsafe enchants

### DIFF
--- a/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config to allow for unsafe enchants
 
 
 diff --git a/src/main/java/net/minecraft/server/commands/CommandEnchant.java b/src/main/java/net/minecraft/server/commands/CommandEnchant.java
-index 96991d77cfef2ef0fdada1a831619293ffe37e70..07c7d74e9102b2dff25d8e1e8cf8efb07fc129fc 100644
+index 96991d77cfef2ef0fdada1a831619293ffe37e70..35a72ea180409048d3ec79b1622dd158fe208667 100644
 --- a/src/main/java/net/minecraft/server/commands/CommandEnchant.java
 +++ b/src/main/java/net/minecraft/server/commands/CommandEnchant.java
 @@ -48,7 +48,7 @@ public class CommandEnchant {
@@ -13,7 +13,7 @@ index 96991d77cfef2ef0fdada1a831619293ffe37e70..07c7d74e9102b2dff25d8e1e8cf8efb0
  
      private static int a(CommandListenerWrapper commandlistenerwrapper, Collection<? extends Entity> collection, Enchantment enchantment, int i) throws CommandSyntaxException {
 -        if (i > enchantment.getMaxLevel()) {
-+        if (!net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants && i > enchantment.getMaxLevel()) { // Purpur
++        if (!net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants && i > enchantment.getMaxLevel()) {
              throw CommandEnchant.d.create(i, enchantment.getMaxLevel());
          } else {
              int j = 0;
@@ -22,7 +22,7 @@ index 96991d77cfef2ef0fdada1a831619293ffe37e70..07c7d74e9102b2dff25d8e1e8cf8efb0
  
                      if (!itemstack.isEmpty()) {
 -                        if (enchantment.canEnchant(itemstack) && EnchantmentManager.a((Collection) EnchantmentManager.a(itemstack).keySet(), enchantment)) {
-+                        if (!net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants || (enchantment.canEnchant(itemstack) && EnchantmentManager.a((Collection) EnchantmentManager.a(itemstack).keySet(), enchantment))) { // Purpur
++                        if (net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants || (enchantment.canEnchant(itemstack) && EnchantmentManager.a((Collection) EnchantmentManager.a(itemstack).keySet(), enchantment))) {
                              itemstack.addEnchantment(enchantment, i);
                              ++j;
                          } else if (collection.size() == 1) {

--- a/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Wed, 24 Mar 2021 17:59:54 -0400
+Subject: [PATCH] Config to allow for unsafe enchants
+
+
+diff --git a/src/main/java/net/minecraft/server/commands/CommandEnchant.java b/src/main/java/net/minecraft/server/commands/CommandEnchant.java
+index 96991d77cfef2ef0fdada1a831619293ffe37e70..07c7d74e9102b2dff25d8e1e8cf8efb07fc129fc 100644
+--- a/src/main/java/net/minecraft/server/commands/CommandEnchant.java
++++ b/src/main/java/net/minecraft/server/commands/CommandEnchant.java
+@@ -48,7 +48,7 @@ public class CommandEnchant {
+     }
+ 
+     private static int a(CommandListenerWrapper commandlistenerwrapper, Collection<? extends Entity> collection, Enchantment enchantment, int i) throws CommandSyntaxException {
+-        if (i > enchantment.getMaxLevel()) {
++        if (!net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants && i > enchantment.getMaxLevel()) { // Purpur
+             throw CommandEnchant.d.create(i, enchantment.getMaxLevel());
+         } else {
+             int j = 0;
+@@ -62,7 +62,7 @@ public class CommandEnchant {
+                     ItemStack itemstack = entityliving.getItemInMainHand();
+ 
+                     if (!itemstack.isEmpty()) {
+-                        if (enchantment.canEnchant(itemstack) && EnchantmentManager.a((Collection) EnchantmentManager.a(itemstack).keySet(), enchantment)) {
++                        if (!net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants || (enchantment.canEnchant(itemstack) && EnchantmentManager.a((Collection) EnchantmentManager.a(itemstack).keySet(), enchantment))) { // Purpur
+                             itemstack.addEnchantment(enchantment, i);
+                             ++j;
+                         } else if (collection.size() == 1) {
+diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+index 91677ee1dbb983179261bc1f09ccb08f93406aa9..a7f688f5b6a20e5971595fd6c4ee8214af53c2ec 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+@@ -232,6 +232,7 @@ public class PurpurConfig {
+ 
+     public static boolean allowInfinityMending = false;
+     public static boolean allowCrossbowInfinity = false;
++    public static boolean allowUnsafeEnchants = false;
+     private static void enchantmentSettings() {
+         if (version < 5) {
+             boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
+@@ -240,6 +241,7 @@ public class PurpurConfig {
+         }
+         allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
+         allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);
++        allowUnsafeEnchants = getBoolean("settings.enchantment.allow-unsafe-enchants", allowUnsafeEnchants);
+     }
+ 
+     public static boolean endermanShortHeight = false;

--- a/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config to allow for unsafe enchants
 
 
 diff --git a/src/main/java/net/minecraft/server/commands/CommandEnchant.java b/src/main/java/net/minecraft/server/commands/CommandEnchant.java
-index 96991d77cfef2ef0fdada1a831619293ffe37e70..35a72ea180409048d3ec79b1622dd158fe208667 100644
+index 96991d77cfef2ef0fdada1a831619293ffe37e70..4d85ae98369039bcbb5ed5acb2d281bd65523fad 100644
 --- a/src/main/java/net/minecraft/server/commands/CommandEnchant.java
 +++ b/src/main/java/net/minecraft/server/commands/CommandEnchant.java
 @@ -48,7 +48,7 @@ public class CommandEnchant {
@@ -13,7 +13,7 @@ index 96991d77cfef2ef0fdada1a831619293ffe37e70..35a72ea180409048d3ec79b1622dd158
  
      private static int a(CommandListenerWrapper commandlistenerwrapper, Collection<? extends Entity> collection, Enchantment enchantment, int i) throws CommandSyntaxException {
 -        if (i > enchantment.getMaxLevel()) {
-+        if (!net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants && i > enchantment.getMaxLevel()) {
++        if (!net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants && i > enchantment.getMaxLevel()) { // Purpur
              throw CommandEnchant.d.create(i, enchantment.getMaxLevel());
          } else {
              int j = 0;
@@ -22,7 +22,7 @@ index 96991d77cfef2ef0fdada1a831619293ffe37e70..35a72ea180409048d3ec79b1622dd158
  
                      if (!itemstack.isEmpty()) {
 -                        if (enchantment.canEnchant(itemstack) && EnchantmentManager.a((Collection) EnchantmentManager.a(itemstack).keySet(), enchantment)) {
-+                        if (net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants || (enchantment.canEnchant(itemstack) && EnchantmentManager.a((Collection) EnchantmentManager.a(itemstack).keySet(), enchantment))) {
++                        if (net.pl3x.purpur.PurpurConfig.allowUnsafeEnchants || (enchantment.canEnchant(itemstack) && EnchantmentManager.a((Collection) EnchantmentManager.a(itemstack).keySet(), enchantment))) { // Purpur
                              itemstack.addEnchantment(enchantment, i);
                              ++j;
                          } else if (collection.size() == 1) {


### PR DESCRIPTION
Sometimes you just want to apply sharpness 50 to a stick. Normally, the command denies your request and you need to install a plugin such as Essentials to bypass this restriction. Well, no longer.

![Example](https://cdn.discordapp.com/attachments/365455566329348097/824417811798687804/unknown.png)
(yes, vanilla does that to enchants)