### PR TITLE
Configurable sponge absorption (fixed)

### DIFF
--- a/patches/server/0196-Configurable-sponge-absorption.patch
+++ b/patches/server/0196-Configurable-sponge-absorption.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Wed, 24 Mar 2021 20:30:37 -0400
+Subject: [PATCH] Configurable sponge absorption
+
+Allows the total area of liquid blocks the sponge can absorb to be changed.
+I'm not entirely sure what the queue limit of 6 was meant for, but that has been increased to the max area - 58.
+
+diff --git a/src/main/java/net/minecraft/world/level/block/BlockSponge.java b/src/main/java/net/minecraft/world/level/block/BlockSponge.java
+index d80eee47390ab202eea0368571421bbc94655ab1..4f4d4a22b83d60f433c38532cb501153de885507 100644
+--- a/src/main/java/net/minecraft/world/level/block/BlockSponge.java
++++ b/src/main/java/net/minecraft/world/level/block/BlockSponge.java
+@@ -76,13 +76,13 @@ public class BlockSponge extends Block {
+                 if (fluid.a((Tag) TagsFluid.WATER)) {
+                     if (iblockdata.getBlock() instanceof IFluidSource && ((IFluidSource) iblockdata.getBlock()).removeFluid(blockList, blockposition2, iblockdata) != FluidTypes.EMPTY) { // CraftBukkit
+                         ++i;
+-                        if (j < 6) {
++                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) {
+                             queue.add(new Tuple<>(blockposition2, j + 1));
+                         }
+                     } else if (iblockdata.getBlock() instanceof BlockFluids) {
+                         blockList.setTypeAndData(blockposition2, Blocks.AIR.getBlockData(), 3); // CraftBukkit
+                         ++i;
+-                        if (j < 6) {
++                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) {
+                             queue.add(new Tuple<>(blockposition2, j + 1));
+                         }
+                     } else if (material == Material.WATER_PLANT || material == Material.REPLACEABLE_WATER_PLANT) {
+@@ -93,14 +93,14 @@ public class BlockSponge extends Block {
+                         blockList.setTypeAndData(blockposition2, Blocks.AIR.getBlockData(), 3);
+                         // CraftBukkit end
+                         ++i;
+-                        if (j < 6) {
++                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) {
+                             queue.add(new Tuple<>(blockposition2, j + 1));
+                         }
+                     }
+                 }
+             }
+ 
+-            if (i > 64) {
++            if (i > world.purpurConfig.spongeAbsorptionArea) { // Purpur
+                 break;
+             }
+         }
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 480d1791bf6b5c5ea51468fd8e16c571f558c5a0..5da221366fe034022abb2ac32104e0a6e406c1df 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -543,6 +543,11 @@ public class PurpurWorldConfig {
+         spawnerDeactivateByRedstone = getBoolean("blocks.spawner.deactivate-by-redstone", spawnerDeactivateByRedstone);
+     }
+ 
++    public int spongeAbsorptionArea = 64;
++    private void spongeSettings() {
++        spongeAbsorptionArea = getInt("blocks.sponge.absorption-area", spongeAbsorptionArea);
++    }
++
+     public float stonecutterDamage = 0.0F;
+     private void stonecutterSettings() {
+         stonecutterDamage = (float) getDouble("blocks.stonecutter.damage", stonecutterDamage);

--- a/patches/server/0196-Configurable-sponge-absorption.patch
+++ b/patches/server/0196-Configurable-sponge-absorption.patch
@@ -3,11 +3,10 @@ From: Encode42 <me@encode42.dev>
 Date: Wed, 24 Mar 2021 20:30:37 -0400
 Subject: [PATCH] Configurable sponge absorption
 
-Allows the total area of liquid blocks the sponge can absorb to be changed.
-I'm not entirely sure what the queue limit of 6 was meant for, but that has been increased to the max area - 58.
+Allows the total area and radius of water blocks the sponge can absorb to be changed.
 
 diff --git a/src/main/java/net/minecraft/world/level/block/BlockSponge.java b/src/main/java/net/minecraft/world/level/block/BlockSponge.java
-index d80eee47390ab202eea0368571421bbc94655ab1..adcfaff1f0254c01ec22bd7894ae58dc7294b2ba 100644
+index d80eee47390ab202eea0368571421bbc94655ab1..b36536d4cc95797c59549f5db1f67b34ff7b9be2 100644
 --- a/src/main/java/net/minecraft/world/level/block/BlockSponge.java
 +++ b/src/main/java/net/minecraft/world/level/block/BlockSponge.java
 @@ -76,13 +76,13 @@ public class BlockSponge extends Block {
@@ -15,14 +14,14 @@ index d80eee47390ab202eea0368571421bbc94655ab1..adcfaff1f0254c01ec22bd7894ae58dc
                      if (iblockdata.getBlock() instanceof IFluidSource && ((IFluidSource) iblockdata.getBlock()).removeFluid(blockList, blockposition2, iblockdata) != FluidTypes.EMPTY) { // CraftBukkit
                          ++i;
 -                        if (j < 6) {
-+                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) { // Purpur
++                        if (j < world.purpurConfig.spongeAbsorptionRadius) { // Purpur
                              queue.add(new Tuple<>(blockposition2, j + 1));
                          }
                      } else if (iblockdata.getBlock() instanceof BlockFluids) {
                          blockList.setTypeAndData(blockposition2, Blocks.AIR.getBlockData(), 3); // CraftBukkit
                          ++i;
 -                        if (j < 6) {
-+                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) { // Purpur
++                        if (j < world.purpurConfig.spongeAbsorptionRadius) { // Purpur
                              queue.add(new Tuple<>(blockposition2, j + 1));
                          }
                      } else if (material == Material.WATER_PLANT || material == Material.REPLACEABLE_WATER_PLANT) {
@@ -31,7 +30,7 @@ index d80eee47390ab202eea0368571421bbc94655ab1..adcfaff1f0254c01ec22bd7894ae58dc
                          // CraftBukkit end
                          ++i;
 -                        if (j < 6) {
-+                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) { // Purpur
++                        if (j < world.purpurConfig.spongeAbsorptionRadius) { // Purpur
                              queue.add(new Tuple<>(blockposition2, j + 1));
                          }
                      }
@@ -44,16 +43,18 @@ index d80eee47390ab202eea0368571421bbc94655ab1..adcfaff1f0254c01ec22bd7894ae58dc
              }
          }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index eb91425fa9bdbb2bd2a25e7362b99e2b6687da80..116238b8936a68939bee8400f2a056c6927cc4dd 100644
+index eb91425fa9bdbb2bd2a25e7362b99e2b6687da80..a4cf0231861e6554df912cea77eaff2200c65c5f 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-@@ -555,6 +555,11 @@ public class PurpurWorldConfig {
+@@ -555,6 +555,13 @@ public class PurpurWorldConfig {
          spawnerDeactivateByRedstone = getBoolean("blocks.spawner.deactivate-by-redstone", spawnerDeactivateByRedstone);
      }
  
 +    public int spongeAbsorptionArea = 64;
++    public int spongeAbsorptionRadius = 6;
 +    private void spongeSettings() {
-+        spongeAbsorptionArea = getInt("blocks.sponge.absorption-area", spongeAbsorptionArea);
++        spongeAbsorptionArea = getInt("blocks.sponge.absorption.area", spongeAbsorptionArea);
++        spongeAbsorptionRadius = getInt("blocks.sponge.absorption.radius", spongeAbsorptionRadius);
 +    }
 +
      public float stonecutterDamage = 0.0F;

--- a/patches/server/0196-Configurable-sponge-absorption.patch
+++ b/patches/server/0196-Configurable-sponge-absorption.patch
@@ -7,7 +7,7 @@ Allows the total area of liquid blocks the sponge can absorb to be changed.
 I'm not entirely sure what the queue limit of 6 was meant for, but that has been increased to the max area - 58.
 
 diff --git a/src/main/java/net/minecraft/world/level/block/BlockSponge.java b/src/main/java/net/minecraft/world/level/block/BlockSponge.java
-index d80eee47390ab202eea0368571421bbc94655ab1..4f4d4a22b83d60f433c38532cb501153de885507 100644
+index d80eee47390ab202eea0368571421bbc94655ab1..adcfaff1f0254c01ec22bd7894ae58dc7294b2ba 100644
 --- a/src/main/java/net/minecraft/world/level/block/BlockSponge.java
 +++ b/src/main/java/net/minecraft/world/level/block/BlockSponge.java
 @@ -76,13 +76,13 @@ public class BlockSponge extends Block {
@@ -15,14 +15,14 @@ index d80eee47390ab202eea0368571421bbc94655ab1..4f4d4a22b83d60f433c38532cb501153
                      if (iblockdata.getBlock() instanceof IFluidSource && ((IFluidSource) iblockdata.getBlock()).removeFluid(blockList, blockposition2, iblockdata) != FluidTypes.EMPTY) { // CraftBukkit
                          ++i;
 -                        if (j < 6) {
-+                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) {
++                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) { // Purpur
                              queue.add(new Tuple<>(blockposition2, j + 1));
                          }
                      } else if (iblockdata.getBlock() instanceof BlockFluids) {
                          blockList.setTypeAndData(blockposition2, Blocks.AIR.getBlockData(), 3); // CraftBukkit
                          ++i;
 -                        if (j < 6) {
-+                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) {
++                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) { // Purpur
                              queue.add(new Tuple<>(blockposition2, j + 1));
                          }
                      } else if (material == Material.WATER_PLANT || material == Material.REPLACEABLE_WATER_PLANT) {
@@ -31,7 +31,7 @@ index d80eee47390ab202eea0368571421bbc94655ab1..4f4d4a22b83d60f433c38532cb501153
                          // CraftBukkit end
                          ++i;
 -                        if (j < 6) {
-+                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) {
++                        if (j < world.purpurConfig.spongeAbsorptionArea - 58) { // Purpur
                              queue.add(new Tuple<>(blockposition2, j + 1));
                          }
                      }
@@ -44,10 +44,10 @@ index d80eee47390ab202eea0368571421bbc94655ab1..4f4d4a22b83d60f433c38532cb501153
              }
          }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 480d1791bf6b5c5ea51468fd8e16c571f558c5a0..5da221366fe034022abb2ac32104e0a6e406c1df 100644
+index eb91425fa9bdbb2bd2a25e7362b99e2b6687da80..116238b8936a68939bee8400f2a056c6927cc4dd 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-@@ -543,6 +543,11 @@ public class PurpurWorldConfig {
+@@ -555,6 +555,11 @@ public class PurpurWorldConfig {
          spawnerDeactivateByRedstone = getBoolean("blocks.spawner.deactivate-by-redstone", spawnerDeactivateByRedstone);
      }
  


### PR DESCRIPTION
Changes the max amount of blocks sponges can absorb.
Closes #232 

(previous was accidentally closed while recovering the git history after a failed rebase)