### PR TITLE
Add Note Block to disabled block updates setting

### DIFF
--- a/patches/server/0096-Add-option-to-disable-mushroom-and-note-block-update.patch
+++ b/patches/server/0096-Add-option-to-disable-mushroom-and-note-block-update.patch
@@ -1,7 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Tue, 4 Aug 2020 17:11:58 -0500
-Subject: [PATCH] Add option to disable mushroom block updates
+Subject: [PATCH] Add option to disable mushroom and note block updates
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/BlockHugeMushroom.java b/src/main/java/net/minecraft/world/level/block/BlockHugeMushroom.java
@@ -72,17 +72,37 @@ index 987301bfb9d963e3bebc2653bd95cf7f17a2a1e4..fd61c18905e81b1b193260f1c32b4ad0
      }
  
      @Override
+diff --git a/src/main/java/net/minecraft/world/level/block/BlockNote.java b/src/main/java/net/minecraft/world/level/block/BlockNote.java
+index feec1db88b22a4d13ffd3034633da79ed41b94fe..148718f8f96d94e76a4a7a96d5955b624c2dc661 100644
+--- a/src/main/java/net/minecraft/world/level/block/BlockNote.java
++++ b/src/main/java/net/minecraft/world/level/block/BlockNote.java
+@@ -35,11 +35,13 @@ public class BlockNote extends Block {
+ 
+     @Override
+     public IBlockData getPlacedState(BlockActionContext blockactioncontext) {
++        if (net.pl3x.purpur.PurpurConfig.disableNoteBlockUpdates) return this.getBlockData(); // Purpur
+         return (IBlockData) this.getBlockData().set(BlockNote.INSTRUMENT, BlockPropertyInstrument.a(blockactioncontext.getWorld().getType(blockactioncontext.getClickPosition().down())));
+     }
+ 
+     @Override
+     public IBlockData updateState(IBlockData iblockdata, EnumDirection enumdirection, IBlockData iblockdata1, GeneratorAccess generatoraccess, BlockPosition blockposition, BlockPosition blockposition1) {
++        if (net.pl3x.purpur.PurpurConfig.disableNoteBlockUpdates) return iblockdata; // Purpur
+         return enumdirection == EnumDirection.DOWN ? (IBlockData) iblockdata.set(BlockNote.INSTRUMENT, BlockPropertyInstrument.a(iblockdata1)) : super.updateState(iblockdata, enumdirection, iblockdata1, generatoraccess, blockposition, blockposition1);
+     }
+ 
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index c356757bc6c3cca467c0f3839723391c9fc3347e..26cd01fa0aefe9703b11b18468b21898cf5ba2a3 100644
+index c356757bc6c3cca467c0f3839723391c9fc3347e..1d6da0c0753e822bba9d7847980235ff876e1ee8 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-@@ -202,6 +202,11 @@ public class PurpurConfig {
+@@ -202,6 +202,13 @@ public class PurpurConfig {
          allowWaterPlacementInTheEnd = getBoolean("settings.allow-water-placement-in-the-end", allowWaterPlacementInTheEnd);
      }
  
 +    public static boolean disableMushroomBlockUpdates = false;
-+    private static void disableMushroomBlockUpdates() {
-+        disableMushroomBlockUpdates= getBoolean("settings.blocks.disable-mushroom-updates", disableMushroomBlockUpdates);
++    public static boolean disableNoteBlockUpdates = false;
++    private static void blockUpdatesSettings() {
++        disableMushroomBlockUpdates = getBoolean("settings.blocks.disable-mushroom-updates", disableMushroomBlockUpdates);
++        disableNoteBlockUpdates = getBoolean("settings.blocks.disable-note-block-updates", disableNoteBlockUpdates);
 +    }
 +
      public static boolean loggerSuppressInitLegacyMaterialError = false;

--- a/patches/server/0101-Short-enderman-height.patch
+++ b/patches/server/0101-Short-enderman-height.patch
@@ -31,7 +31,7 @@ index 72142f5c777c6218050bc2b69891072d256ea57d..52aa47036acee2ec21ae2d6f4df634ec
              if (this.tryEscape(EndermanEscapeEvent.Reason.INDIRECT)) { // Paper start
              for (int i = 0; i < 64; ++i) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 26cd01fa0aefe9703b11b18468b21898cf5ba2a3..2233b798473b0c408c1d755e481e62191c5644a1 100644
+index 1d6da0c0753e822bba9d7847980235ff876e1ee8..76a1f157dc4ae0fdf804f3340b72dfa17ffbbb94 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -4,6 +4,8 @@ import co.aikar.timings.TimingsManager;

--- a/patches/server/0103-Ridables.patch
+++ b/patches/server/0103-Ridables.patch
@@ -5518,7 +5518,7 @@ index a19a26a88f247d359354902efeece9923f3e0e0b..1119f60890784d953c2cd4e0078af4d0
          return new Vec3D(this.x * d0, this.y * d1, this.z * d2);
      }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 2233b798473b0c408c1d755e481e62191c5644a1..5238111a10ca8fcec1dda4cfed1e9c47b1245883 100644
+index 76a1f157dc4ae0fdf804f3340b72dfa17ffbbb94..b587c96084a1ec3dd8fdec5a830fb8680e33e729 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -137,11 +137,13 @@ public class PurpurConfig {

--- a/patches/server/0105-Crying-obsidian-valid-for-portal-frames.patch
+++ b/patches/server/0105-Crying-obsidian-valid-for-portal-frames.patch
@@ -42,7 +42,7 @@ index 3f8a674345bcad8289a48d2daa5e2a283528e952..3c35f5d171df518f491cad1f49882622
      private final GeneratorAccess b;
      private final EnumDirection.EnumAxis c;
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 5238111a10ca8fcec1dda4cfed1e9c47b1245883..648c496390bbf663df39429631514a1245c3f72d 100644
+index b587c96084a1ec3dd8fdec5a830fb8680e33e729..2409dbc4fca9b7510f01c0abc092ab67dd402b79 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -180,6 +180,7 @@ public class PurpurConfig {

--- a/patches/server/0119-Allow-infinite-and-mending-enchantments-together.patch
+++ b/patches/server/0119-Allow-infinite-and-mending-enchantments-together.patch
@@ -17,7 +17,7 @@ index bf9d6d0e593951aa5abc9aef6cf4803430ea18e5..29bebbccf8dd6ff8976d1bfdb4c2ddcf
      }
  }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 648c496390bbf663df39429631514a1245c3f72d..530645c45a33bc757a64716c39f41e7c0b3e613d 100644
+index 2409dbc4fca9b7510f01c0abc092ab67dd402b79..e0985ec72adf643a4439e8ed5457cb9381bc5dcb 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -198,6 +198,16 @@ public class PurpurConfig {

--- a/patches/server/0122-Add-tablist-suffix-option-for-afk.patch
+++ b/patches/server/0122-Add-tablist-suffix-option-for-afk.patch
@@ -22,7 +22,7 @@ index e1a6e4a359eb2aa484d479fde398473c349a63ba..9ec4008f2195908130410d2c36fb5bf2
  
          ((WorldServer) world).everyoneSleeping();
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 530645c45a33bc757a64716c39f41e7c0b3e613d..028436ca9e94d816348bd8772611cf71d0604e9e 100644
+index e0985ec72adf643a4439e8ed5457cb9381bc5dcb..b005025e49f5b45bf5a28e5a38cffc9b70689b0f 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -136,12 +136,14 @@ public class PurpurConfig {

--- a/patches/server/0134-Add-demo-command.patch
+++ b/patches/server/0134-Add-demo-command.patch
@@ -30,7 +30,7 @@ index edb6c0ab2826051b04e025a713d794dbc5de4792..0161657748d398b6827ef8bc2b00b8a6
      public static final PacketPlayOutGameStateChange.a h = new PacketPlayOutGameStateChange.a(7);
      public static final PacketPlayOutGameStateChange.a i = new PacketPlayOutGameStateChange.a(8);
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 028436ca9e94d816348bd8772611cf71d0604e9e..d6c8e584ed4a0fb32bbd052532e2fb9ceec5fa7a 100644
+index b005025e49f5b45bf5a28e5a38cffc9b70689b0f..f99566da1ea88cfddf14fd73cba98643707bb893 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -137,6 +137,7 @@ public class PurpurConfig {

--- a/patches/server/0139-Config-migration-disable-saving-projectiles-to-disk-.patch
+++ b/patches/server/0139-Config-migration-disable-saving-projectiles-to-disk-.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Config migration: disable saving projectiles to disk ->
 
 
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index d6c8e584ed4a0fb32bbd052532e2fb9ceec5fa7a..08780b09a163311a3eaae4dd89dd8dab2eba310e 100644
+index f99566da1ea88cfddf14fd73cba98643707bb893..dc6122ef302055eb2c08fda05be977b045b6debe 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -1,6 +1,7 @@

--- a/patches/server/0142-EMC-Configurable-disable-give-dropping.patch
+++ b/patches/server/0142-EMC-Configurable-disable-give-dropping.patch
@@ -20,7 +20,7 @@ index 6685bf1757458d908e32d4069f7a8a22a28c28d7..82d663d3b8bbbb020c3467ea93b54729
                      itemstack.setCount(1);
                      entityitem = entityplayer.drop(itemstack, false);
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 08780b09a163311a3eaae4dd89dd8dab2eba310e..a8d2df5ba1d6400dc3431f7aaf148a0691007e9c 100644
+index dc6122ef302055eb2c08fda05be977b045b6debe..f1088638716b4a02eb3b8541a040229da8a6ea24 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -193,6 +193,11 @@ public class PurpurConfig {

--- a/patches/server/0143-Config-migration-climbing-should-not-bypass-cramming.patch
+++ b/patches/server/0143-Config-migration-climbing-should-not-bypass-cramming.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Config migration: climbing should not bypass cramming
 
 
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index a8d2df5ba1d6400dc3431f7aaf148a0691007e9c..7b9f5e04af48e9c5ab9769b8f45ed2b2853dd98c 100644
+index f1088638716b4a02eb3b8541a040229da8a6ea24..70ac948a91c1d4f9cffeac982c505cd1c3908cd3 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -145,6 +145,17 @@ public class PurpurConfig {

--- a/patches/server/0160-Config-to-allow-Note-Block-sounds-when-blocked.patch
+++ b/patches/server/0160-Config-to-allow-Note-Block-sounds-when-blocked.patch
@@ -9,10 +9,10 @@ Normally, the sounds will only play when the block directly above is air.
 With this patch enabled, players can place any block above the Note Block and it will still work.
 
 diff --git a/src/main/java/net/minecraft/world/level/block/BlockNote.java b/src/main/java/net/minecraft/world/level/block/BlockNote.java
-index feec1db88b22a4d13ffd3034633da79ed41b94fe..4882046f46c33a8d828d13325af17237ae07cd86 100644
+index 148718f8f96d94e76a4a7a96d5955b624c2dc661..075987567cd4412c8f0fb4e31b78639415f6adba 100644
 --- a/src/main/java/net/minecraft/world/level/block/BlockNote.java
 +++ b/src/main/java/net/minecraft/world/level/block/BlockNote.java
-@@ -59,7 +59,7 @@ public class BlockNote extends Block {
+@@ -61,7 +61,7 @@ public class BlockNote extends Block {
      }
  
      private void play(World world, BlockPosition blockposition, IBlockData data) { // CraftBukkit

--- a/patches/server/0189-Allow-infinity-on-crossbows.patch
+++ b/patches/server/0189-Allow-infinity-on-crossbows.patch
@@ -63,7 +63,7 @@ index cf41863bc8b0be9f2a73ca2dd02a4d414d4f230e..2b75432d74df4f627d08d32c6553bd1a
      private EnchantmentSlotType() {}
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 7b9f5e04af48e9c5ab9769b8f45ed2b2853dd98c..e04150685e1ec9d2e318ca6a7ae24f9251fcc326 100644
+index 70ac948a91c1d4f9cffeac982c505cd1c3908cd3..844f5d7fee4ea06a5761e8fb6d54357d58bff8f5 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -231,6 +231,7 @@ public class PurpurConfig {

--- a/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
@@ -27,7 +27,7 @@ index 96991d77cfef2ef0fdada1a831619293ffe37e70..4d85ae98369039bcbb5ed5acb2d281bd
                              ++j;
                          } else if (collection.size() == 1) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 91677ee1dbb983179261bc1f09ccb08f93406aa9..a7f688f5b6a20e5971595fd6c4ee8214af53c2ec 100644
+index 844f5d7fee4ea06a5761e8fb6d54357d58bff8f5..6355f246809982f6da34671be22066a83cfba42c 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -232,6 +232,7 @@ public class PurpurConfig {


### PR DESCRIPTION
There's quite a discussion on #219 about why this should be added. I went ahead and did it anyways since it was a simple change.
I couldn't test if this change fully worked since I don't own or know how to use any plugin that utilizes note blocks that need to omit updating, but in theory it should work as expected.
Also renames the mushroomBlockUpdates function to just blockUpdatesSettings to reduce clutter.

A little fun fact, I believe Hypixel uses note blocks for their own custom blocks. I'm not 100% sure, but I recall seeing note blocks everywhere after denying a resource pack request.

Dear GitHub, this issue closes #219.