### PR TITLE
Migrate multithreaded tracker config

### DIFF
--- a/patches/server/0005-Purpur-config-files.patch
+++ b/patches/server/0005-Purpur-config-files.patch
@@ -86,7 +86,7 @@ index 51e6cd6119465f9fd6385072997971449afb5f42..f8261e21a84bf8c29d72116fc3166dc7
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..19541e7071c05dce30c384093c8eae5beff3e515
+index 0000000000000000000000000000000000000000..2207d5ec00c0f6e4d332c0bbecbc224b24855927
 --- /dev/null
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -0,0 +1,130 @@
@@ -145,8 +145,8 @@ index 0000000000000000000000000000000000000000..19541e7071c05dce30c384093c8eae5b
 +        commands = new HashMap<>();
 +        commands.put("purpur", new PurpurCommand("purpur"));
 +
-+        version = getInt("config-version", 11);
-+        set("config-version", 11);
++        version = getInt("config-version", 12);
++        set("config-version", 12);
 +
 +        readConfig(PurpurConfig.class, null);
 +    }

--- a/patches/server/0006-Timings-stuff.patch
+++ b/patches/server/0006-Timings-stuff.patch
@@ -57,7 +57,7 @@ index 35810f42d7a0cd50a4cbe90e8d698fe57914c889..5e672a0660d0aceffcdb26d185590ca1
              String hostName = "BrokenHost";
              try {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 19541e7071c05dce30c384093c8eae5beff3e515..e1a85458a22007b0ba7f297c986c4a2765177f86 100644
+index 2207d5ec00c0f6e4d332c0bbecbc224b24855927..172545163646fb5cc28733af0e51b195c16898d6 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -127,4 +127,10 @@ public class PurpurConfig {

--- a/patches/server/0007-Barrels-and-enderchests-6-rows.patch
+++ b/patches/server/0007-Barrels-and-enderchests-6-rows.patch
@@ -123,7 +123,7 @@ index 7a6f150490bc3ef8a5ed43c401fd70bcc67f40f0..449d2c38abdd35b782a6732006eebb38
      }
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index e1a85458a22007b0ba7f297c986c4a2765177f86..64682d3188c356eec62b414d50e0221fc67de895 100644
+index 172545163646fb5cc28733af0e51b195c16898d6..5046628340f0f48587a790f7819fa368a849d979 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -7,6 +7,7 @@ import org.bukkit.Bukkit;

--- a/patches/server/0010-AFK-API.patch
+++ b/patches/server/0010-AFK-API.patch
@@ -215,7 +215,7 @@ index a7f2304acf8ee0a15d6eae8c42060e003be13ae7..fd56b2f15e570f266a79c25823a3b353
  
      @Nullable
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 64682d3188c356eec62b414d50e0221fc67de895..3c81d9f1171262d17407232433e3eb0383f424c0 100644
+index 5046628340f0f48587a790f7819fa368a849d979..215d691de61c514bb75077d25428c2c2f56df0b5 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -1,6 +1,7 @@

--- a/patches/server/0012-Configurable-server-mod-name.patch
+++ b/patches/server/0012-Configurable-server-mod-name.patch
@@ -18,7 +18,7 @@ index 8620bbcc7c555e4760777397063f0392c9acc35e..83b98a18a8b726621068b5fd2bed0468
  
      public CrashReport b(CrashReport crashreport) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 3c81d9f1171262d17407232433e3eb0383f424c0..db62e40a5bba3bdb60f1dac6f25a48f321a5d3e1 100644
+index 215d691de61c514bb75077d25428c2c2f56df0b5..7eadf925c4e4429fa63fb02af9e87bf2ed68efa6 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -139,6 +139,11 @@ public class PurpurConfig {

--- a/patches/server/0014-Lagging-threshold.patch
+++ b/patches/server/0014-Lagging-threshold.patch
@@ -25,7 +25,7 @@ index 83b98a18a8b726621068b5fd2bed046852dccf2d..a75a8322829f36045243d5fd61d28b12
                      }
                      // Tuinity - replace logic
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index db62e40a5bba3bdb60f1dac6f25a48f321a5d3e1..471b16492deab9c2466178425cdecdbc3f6c4896 100644
+index 7eadf925c4e4429fa63fb02af9e87bf2ed68efa6..60ef024891e78e18c64435b7ee8118075ce5fb90 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -150,6 +150,11 @@ public class PurpurConfig {

--- a/patches/server/0021-Alternative-Keepalive-Handling.patch
+++ b/patches/server/0021-Alternative-Keepalive-Handling.patch
@@ -68,7 +68,7 @@ index f1ebb59f328bffa80a5b9b6504535e711c1d5c9b..ac36ca9251e3acb663c62ad7af05bfaf
          if (this.awaitingKeepAlive && packetplayinkeepalive.b() == this.h) {
              int i = (int) (SystemUtils.getMonotonicMillis() - this.lastKeepAlive);
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 471b16492deab9c2466178425cdecdbc3f6c4896..7194ab80185683fe198a3c19fc7401976976cb19 100644
+index 60ef024891e78e18c64435b7ee8118075ce5fb90..6e855980d32717119f30f39f4b47d86f8039ecc9 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -155,6 +155,11 @@ public class PurpurConfig {

--- a/patches/server/0025-Logger-settings-suppressing-pointless-logs.patch
+++ b/patches/server/0025-Logger-settings-suppressing-pointless-logs.patch
@@ -17,7 +17,7 @@ index 7a8a1960882e291c46301d07da3e1c5415516893..59d781b5e61c5d2c004bc92300d8d42e
                              }
                              // CraftBukkit end
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 7194ab80185683fe198a3c19fc7401976976cb19..9a6028759f6e3faac57013e6044afbfcb2c481ce 100644
+index 6e855980d32717119f30f39f4b47d86f8039ecc9..c5da5c0a6f68d4844ad8f59ad603611c909f8dfd 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -178,4 +178,11 @@ public class PurpurConfig {

--- a/patches/server/0034-Dont-send-useless-entity-packets.patch
+++ b/patches/server/0034-Dont-send-useless-entity-packets.patch
@@ -61,7 +61,7 @@ index 37e64e24ca3a90370cdf12e5ff9cd1fceede796b..f63ec5fa5a1cb34f4809a06a29d01603
          this.tracker.c(entityplayer);
          entityplayer.c(this.tracker);
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 9a6028759f6e3faac57013e6044afbfcb2c481ce..8d5c326b8c3ae0c6117a14b9be749a148293c3cd 100644
+index c5da5c0a6f68d4844ad8f59ad603611c909f8dfd..892f72c89af1b550305e2771f1ff5f470941faf8 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -179,6 +179,11 @@ public class PurpurConfig {

--- a/patches/server/0058-Configurable-TPS-Catchup.patch
+++ b/patches/server/0058-Configurable-TPS-Catchup.patch
@@ -24,7 +24,7 @@ index a75a8322829f36045243d5fd61d28b126af1f0af..ab2424a868a3d29af96f36ce037f1ab9
                      this.methodProfiler.exit();
                      this.methodProfiler.b();
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 8d5c326b8c3ae0c6117a14b9be749a148293c3cd..5fb05a8b660ee8e43458fbef1e59c5499ccaac9d 100644
+index 892f72c89af1b550305e2771f1ff5f470941faf8..0d16eaeea8b38329ffd6859b3ef93562a8fb86ce 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -190,4 +190,9 @@ public class PurpurConfig {

--- a/patches/server/0078-Add-ping-command.patch
+++ b/patches/server/0078-Add-ping-command.patch
@@ -67,7 +67,7 @@ index bbad2b1399d9d2e16bfa77563bd564f7c6f640d7..a85c4525335fa46bc23a6dd57cfaea1f
          List<EntityPlayer> list = ((EntitySelector) commandcontext.getArgument(s, EntitySelector.class)).d((CommandListenerWrapper) commandcontext.getSource());
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 5fb05a8b660ee8e43458fbef1e59c5499ccaac9d..5cb45971721dd39d214434529ce434035173326b 100644
+index 0d16eaeea8b38329ffd6859b3ef93562a8fb86ce..969a4359dfb35e4cfeac26e1f6c700d7e9d142eb 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -133,10 +133,12 @@ public class PurpurConfig {

--- a/patches/server/0084-Add-allow-water-in-end-world-option.patch
+++ b/patches/server/0084-Add-allow-water-in-end-world-option.patch
@@ -68,7 +68,7 @@ index 461c85b426aab30c34529897e55aa842b45d0555..486a03f2582d6ece2775cb2db127953d
          } else {
              world.setTypeUpdate(blockposition, Blocks.WATER.getBlockData());
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 5cb45971721dd39d214434529ce434035173326b..f1e57b679db156b4013f6bc81925462a746001f2 100644
+index 969a4359dfb35e4cfeac26e1f6c700d7e9d142eb..5c65438c8b8acd2893346d26649c9fe142da05e9 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -186,6 +186,11 @@ public class PurpurConfig {

--- a/patches/server/0089-Configurable-end-spike-seed.patch
+++ b/patches/server/0089-Configurable-end-spike-seed.patch
@@ -25,7 +25,7 @@ index dd623702131eaa1a65937a19a0e986e865322258..54ac8444702c3cfc2bcbaa6c8bc40398
          List<WorldGenEnder.Spike> list = worldgenfeatureendspikeconfiguration.c();
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index f1e57b679db156b4013f6bc81925462a746001f2..e9257f76275774518bb1fefe3b78144fd93791ab 100644
+index 5c65438c8b8acd2893346d26649c9fe142da05e9..90f1b46a8afd858eb0bc8a3723eda38c583d1ce3 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0090-Configurable-dungeon-seed.patch
+++ b/patches/server/0090-Configurable-dungeon-seed.patch
@@ -31,7 +31,7 @@ index 4a2e3af98ef3383678445c1bdf535203097558ee..363de0352804e6a778d4e6ee34609a94
          int i = random.nextInt(2) + 2;
          int j = -i - 1;
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index e9257f76275774518bb1fefe3b78144fd93791ab..c356757bc6c3cca467c0f3839723391c9fc3347e 100644
+index 90f1b46a8afd858eb0bc8a3723eda38c583d1ce3..3a2476d78e74286636fb927258c583249aefd791 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -142,10 +142,13 @@ public class PurpurConfig {

--- a/patches/server/0097-Add-option-to-disable-mushroom-and-note-block-update.patch
+++ b/patches/server/0097-Add-option-to-disable-mushroom-and-note-block-update.patch
@@ -91,7 +91,7 @@ index feec1db88b22a4d13ffd3034633da79ed41b94fe..148718f8f96d94e76a4a7a96d5955b62
      }
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index c356757bc6c3cca467c0f3839723391c9fc3347e..1d6da0c0753e822bba9d7847980235ff876e1ee8 100644
+index 3a2476d78e74286636fb927258c583249aefd791..0f7d4aecadf319bef64793e4938736c531459e0e 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -202,6 +202,13 @@ public class PurpurConfig {

--- a/patches/server/0102-Short-enderman-height.patch
+++ b/patches/server/0102-Short-enderman-height.patch
@@ -31,7 +31,7 @@ index 72142f5c777c6218050bc2b69891072d256ea57d..52aa47036acee2ec21ae2d6f4df634ec
              if (this.tryEscape(EndermanEscapeEvent.Reason.INDIRECT)) { // Paper start
              for (int i = 0; i < 64; ++i) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 1d6da0c0753e822bba9d7847980235ff876e1ee8..76a1f157dc4ae0fdf804f3340b72dfa17ffbbb94 100644
+index 0f7d4aecadf319bef64793e4938736c531459e0e..3b20793e3eb4349f8a4ce724f8fc0d6366bb28c2 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -4,6 +4,8 @@ import co.aikar.timings.TimingsManager;

--- a/patches/server/0104-Ridables.patch
+++ b/patches/server/0104-Ridables.patch
@@ -5541,7 +5541,7 @@ index a19a26a88f247d359354902efeece9923f3e0e0b..1119f60890784d953c2cd4e0078af4d0
          return new Vec3D(this.x * d0, this.y * d1, this.z * d2);
      }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 76a1f157dc4ae0fdf804f3340b72dfa17ffbbb94..b587c96084a1ec3dd8fdec5a830fb8680e33e729 100644
+index 3b20793e3eb4349f8a4ce724f8fc0d6366bb28c2..9789d0f9f73540a486befcdd4901014efeed8403 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -137,11 +137,13 @@ public class PurpurConfig {

--- a/patches/server/0106-Crying-obsidian-valid-for-portal-frames.patch
+++ b/patches/server/0106-Crying-obsidian-valid-for-portal-frames.patch
@@ -42,7 +42,7 @@ index 3f8a674345bcad8289a48d2daa5e2a283528e952..3c35f5d171df518f491cad1f49882622
      private final GeneratorAccess b;
      private final EnumDirection.EnumAxis c;
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index b587c96084a1ec3dd8fdec5a830fb8680e33e729..2409dbc4fca9b7510f01c0abc092ab67dd402b79 100644
+index 9789d0f9f73540a486befcdd4901014efeed8403..d783f6a9288db216a5eb812ab0cbf5c000edb1b5 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -180,6 +180,7 @@ public class PurpurConfig {

--- a/patches/server/0120-Allow-infinite-and-mending-enchantments-together.patch
+++ b/patches/server/0120-Allow-infinite-and-mending-enchantments-together.patch
@@ -17,7 +17,7 @@ index bf9d6d0e593951aa5abc9aef6cf4803430ea18e5..29bebbccf8dd6ff8976d1bfdb4c2ddcf
      }
  }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 2409dbc4fca9b7510f01c0abc092ab67dd402b79..e0985ec72adf643a4439e8ed5457cb9381bc5dcb 100644
+index d783f6a9288db216a5eb812ab0cbf5c000edb1b5..24220d8a4e832771aa86619b660535867bb091de 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -198,6 +198,16 @@ public class PurpurConfig {

--- a/patches/server/0123-Add-tablist-suffix-option-for-afk.patch
+++ b/patches/server/0123-Add-tablist-suffix-option-for-afk.patch
@@ -22,7 +22,7 @@ index 86bd39af6e3240b82f5afd6e7c554471f7bbd6ba..7faf393954b703efda7290c831ff75b6
  
          ((WorldServer) world).everyoneSleeping();
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index e0985ec72adf643a4439e8ed5457cb9381bc5dcb..b005025e49f5b45bf5a28e5a38cffc9b70689b0f 100644
+index 24220d8a4e832771aa86619b660535867bb091de..b903a19e0fcf008cb8358be2d5050c89d2addf28 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -136,12 +136,14 @@ public class PurpurConfig {

--- a/patches/server/0135-Add-demo-command.patch
+++ b/patches/server/0135-Add-demo-command.patch
@@ -30,7 +30,7 @@ index edb6c0ab2826051b04e025a713d794dbc5de4792..0161657748d398b6827ef8bc2b00b8a6
      public static final PacketPlayOutGameStateChange.a h = new PacketPlayOutGameStateChange.a(7);
      public static final PacketPlayOutGameStateChange.a i = new PacketPlayOutGameStateChange.a(8);
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index b005025e49f5b45bf5a28e5a38cffc9b70689b0f..f99566da1ea88cfddf14fd73cba98643707bb893 100644
+index b903a19e0fcf008cb8358be2d5050c89d2addf28..69d6d3fb4333531ea63acf5272ffa52ed296346f 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -137,6 +137,7 @@ public class PurpurConfig {

--- a/patches/server/0140-Config-migration-disable-saving-projectiles-to-disk-.patch
+++ b/patches/server/0140-Config-migration-disable-saving-projectiles-to-disk-.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Config migration: disable saving projectiles to disk ->
 
 
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index f99566da1ea88cfddf14fd73cba98643707bb893..dc6122ef302055eb2c08fda05be977b045b6debe 100644
+index 69d6d3fb4333531ea63acf5272ffa52ed296346f..457a20aee6f7aa25be052bec202bbcb8153612c0 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -1,6 +1,7 @@

--- a/patches/server/0143-EMC-Configurable-disable-give-dropping.patch
+++ b/patches/server/0143-EMC-Configurable-disable-give-dropping.patch
@@ -20,7 +20,7 @@ index 6685bf1757458d908e32d4069f7a8a22a28c28d7..82d663d3b8bbbb020c3467ea93b54729
                      itemstack.setCount(1);
                      entityitem = entityplayer.drop(itemstack, false);
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index dc6122ef302055eb2c08fda05be977b045b6debe..f1088638716b4a02eb3b8541a040229da8a6ea24 100644
+index 457a20aee6f7aa25be052bec202bbcb8153612c0..521604b37ca61b849420f206fde88210b582cd3c 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -193,6 +193,11 @@ public class PurpurConfig {

--- a/patches/server/0144-Config-migration-climbing-should-not-bypass-cramming.patch
+++ b/patches/server/0144-Config-migration-climbing-should-not-bypass-cramming.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Config migration: climbing should not bypass cramming
 
 
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index f1088638716b4a02eb3b8541a040229da8a6ea24..70ac948a91c1d4f9cffeac982c505cd1c3908cd3 100644
+index 521604b37ca61b849420f206fde88210b582cd3c..116f17bcc02d15951fa248c6ce4e2cf3617034d4 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -145,6 +145,17 @@ public class PurpurConfig {

--- a/patches/server/0189-Allow-infinity-on-crossbows.patch
+++ b/patches/server/0189-Allow-infinity-on-crossbows.patch
@@ -63,7 +63,7 @@ index cf41863bc8b0be9f2a73ca2dd02a4d414d4f230e..2b75432d74df4f627d08d32c6553bd1a
      private EnchantmentSlotType() {}
  
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 70ac948a91c1d4f9cffeac982c505cd1c3908cd3..844f5d7fee4ea06a5761e8fb6d54357d58bff8f5 100644
+index 116f17bcc02d15951fa248c6ce4e2cf3617034d4..f469b27273883c56cee98fee464c4d1a32a31478 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -231,6 +231,7 @@ public class PurpurConfig {

--- a/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0195-Config-to-allow-for-unsafe-enchants.patch
@@ -27,7 +27,7 @@ index 96991d77cfef2ef0fdada1a831619293ffe37e70..4d85ae98369039bcbb5ed5acb2d281bd
                              ++j;
                          } else if (collection.size() == 1) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 844f5d7fee4ea06a5761e8fb6d54357d58bff8f5..6355f246809982f6da34671be22066a83cfba42c 100644
+index f469b27273883c56cee98fee464c4d1a32a31478..b410d38a431f79971ca183b476115d9e85e1cd6e 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -232,6 +232,7 @@ public class PurpurConfig {

--- a/patches/server/0200-Migrate-multithreaded-tracker-config.patch
+++ b/patches/server/0200-Migrate-multithreaded-tracker-config.patch
@@ -1,0 +1,133 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Thu, 22 Apr 2021 23:16:26 -0400
+Subject: [PATCH] Migrate multithreaded tracker config
+
+
+diff --git a/src/main/java/gg/airplane/AirplaneConfig.java b/src/main/java/gg/airplane/AirplaneConfig.java
+index 5a20ad857b7c550281000e8d94dac78d72591f31..15398d066d1bcd71765fdda1302d1b71efe96018 100644
+--- a/src/main/java/gg/airplane/AirplaneConfig.java
++++ b/src/main/java/gg/airplane/AirplaneConfig.java
+@@ -95,18 +95,4 @@ public class AirplaneConfig {
+         }
+     }
+ 
+-
+-    public static boolean multithreadedEntityTracker = false;
+-    public static boolean entityTrackerAsyncPackets = false;
+-
+-    private static void entityTracker() {
+-        config.setComment("tracker", "Options to improve the performance of the entity tracker");
+-
+-        multithreadedEntityTracker = config.getBoolean("tracker.multithreaded", multithreadedEntityTracker,
+-          "This enables the multithreading of the tracker.");
+-        entityTrackerAsyncPackets = config.getBoolean("tracker.unsafe-async-packets", entityTrackerAsyncPackets,
+-          "This option can break plugins that assume packets from the",
+-          "entity tracker will be sent sync.");
+-    }
+-
+ }
+diff --git a/src/main/java/net/minecraft/server/level/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/level/EntityTrackerEntry.java
+index b773480baef218d0aab2f524e7e305c18443517d..822ff1129e10d111b9989b38cc412000b5da15da 100644
+--- a/src/main/java/net/minecraft/server/level/EntityTrackerEntry.java
++++ b/src/main/java/net/minecraft/server/level/EntityTrackerEntry.java
+@@ -76,7 +76,7 @@ public class EntityTrackerEntry {
+      * Requested in https://github.com/PaperMC/Paper/issues/1537 to allow intercepting packets
+      */
+     public void sendPlayerPacket(EntityPlayer player, Packet packet) {
+-        if (!gg.airplane.AirplaneConfig.entityTrackerAsyncPackets && !org.bukkit.Bukkit.isPrimaryThread()) {
++        if (!net.pl3x.purpur.PurpurConfig.entityTrackerAsyncPackets && !org.bukkit.Bukkit.isPrimaryThread()) { // Purpur - migrate tracker options
+             this.b.chunkProvider.playerChunkMap.trackerEnsureMain(() -> sendPlayerPacket(player, packet));
+             return;
+         }
+@@ -480,7 +480,7 @@ public class EntityTrackerEntry {
+     // Paper end
+ 
+     private void broadcastIncludingSelf(Packet<?> packet) {
+-        if (!gg.airplane.AirplaneConfig.entityTrackerAsyncPackets && !org.bukkit.Bukkit.isPrimaryThread()) {
++        if (!net.pl3x.purpur.PurpurConfig.entityTrackerAsyncPackets && !org.bukkit.Bukkit.isPrimaryThread()) { // Purpur - migrate tracker options
+             this.b.chunkProvider.playerChunkMap.trackerEnsureMain(() -> broadcastIncludingSelf(packet));
+             return;
+         }
+diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
+index 4f11a19137531a0406a5214cd0cce0bea06d0088..b53f6916971481a49f54b066055ff8a5f91bdc24 100644
+--- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
++++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
+@@ -2218,7 +2218,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         try {
+             // Airplane start - multithreaded tracker
+             if (this.trackQueue == null) this.trackQueue = new gg.airplane.structs.TrackQueue(this.world.getChunkProvider().entityTickingChunks, trackerMainQueue);
+-            if (gg.airplane.AirplaneConfig.multithreadedEntityTracker) {
++            if (net.pl3x.purpur.PurpurConfig.multithreadedEntityTracker) { // Purpur - migrate tracker options
+                 this.trackQueue.start();
+                 return;
+             }
+@@ -2552,7 +2552,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+ 
+         public synchronized void broadcast(Packet<?> packet) { // Airplane - synchronized for tracked player
+             // Airplane start
+-            if (!gg.airplane.AirplaneConfig.entityTrackerAsyncPackets && !org.bukkit.Bukkit.isPrimaryThread()) {
++            if (!net.pl3x.purpur.PurpurConfig.entityTrackerAsyncPackets && !org.bukkit.Bukkit.isPrimaryThread()) { // Purpur - migrate tracker options
+                 trackerEnsureMain(() -> broadcast(packet));
+                 return;
+             }
+@@ -2569,7 +2569,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+ 
+         public void broadcastIncludingSelf(Packet<?> packet) {
+             // Airplane start
+-            if (!gg.airplane.AirplaneConfig.entityTrackerAsyncPackets && !org.bukkit.Bukkit.isPrimaryThread()) {
++            if (!net.pl3x.purpur.PurpurConfig.entityTrackerAsyncPackets && !org.bukkit.Bukkit.isPrimaryThread()) { // Purpur - migrate tracker options
+                 trackerEnsureMain(() -> broadcastIncludingSelf(packet));
+                 return;
+             }
+diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+index 6355f246809982f6da34671be22066a83cfba42c..31b43d6ea71eda8af38118c39fc66a216aa0dda8 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+@@ -1,6 +1,8 @@
+ package net.pl3x.purpur;
+ 
+ import co.aikar.timings.TimingsManager;
++import co.technove.air.AIR;
++import co.technove.air.ValueType;
+ import com.destroystokyo.paper.PaperConfig;
+ import com.google.common.base.Throwables;
+ import net.minecraft.locale.LocaleLanguage;
+@@ -15,6 +17,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.bukkit.event.inventory.InventoryType;
+ 
+ import java.io.File;
++import java.io.FileInputStream;
++import java.io.FileOutputStream;
+ import java.io.IOException;
+ import java.lang.reflect.InvocationTargetException;
+ import java.lang.reflect.Method;
+@@ -278,4 +282,28 @@ public class PurpurConfig {
+     private static void tpsCatchup() {
+         tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
+     }
++
++    public static boolean multithreadedEntityTracker = false;
++    public static boolean entityTrackerAsyncPackets = false;
++    private static void entityTracker() {
++        if (version < 12) {
++            File airplaneConfigFile = new File("airplane.air");
++            if (airplaneConfigFile.exists()) {
++                try {
++                    AIR airplaneConfig;
++
++                    FileInputStream inputStream = new FileInputStream(airplaneConfigFile);
++                    airplaneConfig = new AIR(inputStream);
++
++                    multithreadedEntityTracker = airplaneConfig.getBoolean("tracker.multithreaded", multithreadedEntityTracker);
++                    entityTrackerAsyncPackets = airplaneConfig.getBoolean("tracker.unsafe-async-packets", entityTrackerAsyncPackets);
++
++                    // Currently not working
++                    airplaneConfig.setComment("tracker", "No longer an Airplane feature, migrated to purpur.yml", "DO NOT seek multithreaded tracker support in Airplane's Discord!");
++                } catch (IOException ignored) {}
++            }
++        }
++        multithreadedEntityTracker = getBoolean("settings.tracker.multithreaded", multithreadedEntityTracker);
++        entityTrackerAsyncPackets = getBoolean("settings.tracker.unsafe-async-packets", entityTrackerAsyncPackets);
++    }
+ }

--- a/patches/server/0200-Migrate-multithreaded-tracker-config.patch
+++ b/patches/server/0200-Migrate-multithreaded-tracker-config.patch
@@ -81,28 +81,26 @@ index 4f11a19137531a0406a5214cd0cce0bea06d0088..b53f6916971481a49f54b066055ff8a5
                  return;
              }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 6355f246809982f6da34671be22066a83cfba42c..31b43d6ea71eda8af38118c39fc66a216aa0dda8 100644
+index b410d38a431f79971ca183b476115d9e85e1cd6e..167686c1b1aefd4eaaa40c99fa32dcdfe6223862 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-@@ -1,6 +1,8 @@
+@@ -1,6 +1,7 @@
  package net.pl3x.purpur;
  
  import co.aikar.timings.TimingsManager;
 +import co.technove.air.AIR;
-+import co.technove.air.ValueType;
  import com.destroystokyo.paper.PaperConfig;
  import com.google.common.base.Throwables;
  import net.minecraft.locale.LocaleLanguage;
-@@ -15,6 +17,8 @@ import org.bukkit.configuration.file.YamlConfiguration;
+@@ -15,6 +16,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
  import org.bukkit.event.inventory.InventoryType;
  
  import java.io.File;
 +import java.io.FileInputStream;
-+import java.io.FileOutputStream;
  import java.io.IOException;
  import java.lang.reflect.InvocationTargetException;
  import java.lang.reflect.Method;
-@@ -278,4 +282,28 @@ public class PurpurConfig {
+@@ -278,4 +280,28 @@ public class PurpurConfig {
      private static void tpsCatchup() {
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }


### PR DESCRIPTION
This isn't an Airplane feature anymore and causes confusion for the Airplane support team and Purpur's users.

- AIR doesn't have a method to set a value as null. We can either:
    * Set section comments to reflect migration [current solution]
    * Utilize an overcomplicated method to remove the section
    * Do nothing [Airplane's solution]
- Setting the section comment seems to be broken currently. I contacted Paul for support on why it's not working. I'd like to get this fixed before merge.
- This is a new patch since I don't want to deal with all the merge conflicts placing it after the Purpur config files. Feel free to adjust this if anyone has the time.