### PR TITLE
Updated Upstream (Paper, Tuinity, & Airplane)

### DIFF
--- a/patches/api/0001-Tuinity-API-Changes.patch
+++ b/patches/api/0001-Tuinity-API-Changes.patch
@@ -217,10 +217,10 @@ index f3e27d2d02a9407bb1b091b8c1125ad5abf99e55..b3e7b2a8eaa3980e34bc74a846320b78
           * Sends the component to the player
           *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 4c80a999fcc4d656c047b96cb549782c693b33cd..226c9a1fc49b11a9dd7653c695f7031bb51c3a41 100644
+index a1496fe00a2d5ba6c1af054d4327f868b2cd7344..6ca9aa2c438810b5537dc196b3fd89b0750b3d67 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3517,6 +3517,26 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -3631,6 +3631,26 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
       * @param viewDistance view distance in [2, 32]
       */
      void setNoTickViewDistance(int viewDistance);

--- a/patches/api/0033-Fix-javadoc-warnings-missing-param-and-return.patch
+++ b/patches/api/0033-Fix-javadoc-warnings-missing-param-and-return.patch
@@ -534,10 +534,10 @@ index 28a1fe3af1546daa779df46468e0ff8ad823f9ca..7a3be414ef9d54d7a852ba92d704011f
  
          @NotNull
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index ba899198be49f9e95c3fb64759313662f75c4567..db4b94f8a4dd49fffdcb0cd9bf0690f0770653d9 100644
+index 3bf6e58b2351cee935e23abec1cea289e31943dc..5f2d5e12f11b471662943680b2012c99a8466306 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -81,6 +81,8 @@ public interface UnsafeValues {
+@@ -87,6 +87,8 @@ public interface UnsafeValues {
  
      /**
       * Called once by the version command on first use, then cached.
@@ -546,7 +546,7 @@ index ba899198be49f9e95c3fb64759313662f75c4567..db4b94f8a4dd49fffdcb0cd9bf0690f0
       */
      default com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {
          return new com.destroystokyo.paper.util.VersionFetcher.DummyVersionFetcher();
-@@ -99,6 +101,8 @@ public interface UnsafeValues {
+@@ -105,6 +107,8 @@ public interface UnsafeValues {
      /**
       * Return the translation key for the Material, so the client can translate it into the active
       * locale when using a TranslatableComponent.
@@ -555,7 +555,7 @@ index ba899198be49f9e95c3fb64759313662f75c4567..db4b94f8a4dd49fffdcb0cd9bf0690f0
       * @return the translation key
       */
      String getTranslationKey(Material mat);
-@@ -106,6 +110,8 @@ public interface UnsafeValues {
+@@ -112,6 +116,8 @@ public interface UnsafeValues {
      /**
       * Return the translation key for the Block, so the client can translate it into the active
       * locale when using a TranslatableComponent.
@@ -564,7 +564,7 @@ index ba899198be49f9e95c3fb64759313662f75c4567..db4b94f8a4dd49fffdcb0cd9bf0690f0
       * @return the translation key
       */
      String getTranslationKey(org.bukkit.block.Block block);
-@@ -114,6 +120,8 @@ public interface UnsafeValues {
+@@ -120,6 +126,8 @@ public interface UnsafeValues {
       * Return the translation key for the EntityType, so the client can translate it into the active
       * locale when using a TranslatableComponent.<br>
       * This is <code>null</code>, when the EntityType isn't known to NMS (custom entities)
@@ -573,7 +573,7 @@ index ba899198be49f9e95c3fb64759313662f75c4567..db4b94f8a4dd49fffdcb0cd9bf0690f0
       * @return the translation key
       */
      String getTranslationKey(org.bukkit.entity.EntityType type);
-@@ -122,6 +130,8 @@ public interface UnsafeValues {
+@@ -128,6 +136,8 @@ public interface UnsafeValues {
       * Creates and returns the next EntityId available.
       * <p>
       * Use this when sending custom packets, so that there are no collisions on the client or server.
@@ -661,7 +661,7 @@ index d1757f3d456ff9efce26ce8baa1d16d896908cc2..a5db52386e11e4b5511ae417a0e7ac92
      TASK(ChatColor.GREEN),
      CHALLENGE(ChatColor.DARK_PURPLE),
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 85ff6ce3bf75ab78f066a508d130def5913fff0e..c1f9114d1c0ac3457461c9326420a4afc00ce970 100644
+index 08e6f1741685f54506c8a4ff29bbd30f62cf8e45..8efd2669bd5e3dfa47ff8fcb858333210eb5c201 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -183,6 +183,9 @@ public interface Block extends Metadatable {
@@ -1045,17 +1045,19 @@ index 9a99b8ca1ec9c3c88b29275c88b1221e1b22bcef..f1763f75d5f223ef70b968e463361673
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Shulker.java b/src/main/java/org/bukkit/entity/Shulker.java
-index 3441bdb7fcb99dab67bfe9dad5ed989009e443ad..52927a7d84a2bfcae04526f38bf5efd75b3459bb 100644
+index 274d6131c893630dbc5e22aa2684d89e5a2c6c72..4507fa13689cd393f41c9f0c4a73362491f34c76 100644
 --- a/src/main/java/org/bukkit/entity/Shulker.java
 +++ b/src/main/java/org/bukkit/entity/Shulker.java
-@@ -2,4 +2,7 @@ package org.bukkit.entity;
+@@ -2,6 +2,9 @@ package org.bukkit.entity;
  
  import org.bukkit.material.Colorable;
  
 +/**
 + * Represents a shulker
 + */
- public interface Shulker extends Golem, Colorable {}
+ public interface Shulker extends Golem, Colorable {
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/entity/ShulkerBullet.java b/src/main/java/org/bukkit/entity/ShulkerBullet.java
 index 4623e0d767b343cbdc6fcf20b3b2ff7ff14863cf..ca3f98a8272bab3c9f57f59b077b206c6503de80 100644
 --- a/src/main/java/org/bukkit/entity/ShulkerBullet.java

--- a/patches/api/0038-Add-unsafe-Entity-serialization-API.patch
+++ b/patches/api/0038-Add-unsafe-Entity-serialization-API.patch
@@ -17,10 +17,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index db4b94f8a4dd49fffdcb0cd9bf0690f0770653d9..bca389b75ed072ec95beb7a5c5eb5ac93ce42ecd 100644
+index 5f2d5e12f11b471662943680b2012c99a8466306..7395fe0261da696d1b16c845d244ad5d6957d92a 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -159,4 +159,28 @@ public interface UnsafeValues {
+@@ -165,4 +165,28 @@ public interface UnsafeValues {
       */
      int getProtocolVersion();
      // Paper end

--- a/patches/server/0001-Tuinity-Server-Changes.patch
+++ b/patches/server/0001-Tuinity-Server-Changes.patch
@@ -326,7 +326,7 @@ index dee00aac05f1acf050f05d4db557a08dd0f301c8..52c0ab1ce46e1f3233ef746d9bc69935
                  metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {
                      Map<String, Map<String, Integer>> map = new HashMap<>();
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 12313a37ceeb6a0b6a539c38fdba67e5e43d7413..848eb25ed0640db61a0f28bc26ddabd0444e9ed4 100644
+index 12313a37ceeb6a0b6a539c38fdba67e5e43d7413..ec2b9995f1bf0f6cf029df7bfac526c2672acf3a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -219,6 +219,44 @@ public class PaperCommand extends Command {
@@ -397,6 +397,15 @@ index 12313a37ceeb6a0b6a539c38fdba67e5e43d7413..848eb25ed0640db61a0f28bc26ddabd0
          BlockPosition center = MCUtil.toBlockPosition(player.getLocation());
          Deque<ChunkCoordIntPair> queue = new ArrayDeque<>(MCUtil.getSpiralOutChunks(center, radius));
          updateLight(sender, world, lightengine, queue);
+@@ -362,7 +407,7 @@ public class PaperCommand extends Command {
+             int ticking = 0;
+             int entityTicking = 0;
+ 
+-            for (PlayerChunk chunk : world.getChunkProvider().playerChunkMap.updatingChunks.values()) {
++            for (PlayerChunk chunk : world.getChunkProvider().playerChunkMap.updatingChunks.getUpdatingMap().values()) { // Tuinity - change updating chunks map
+                 if (chunk.getFullChunkIfCached() == null) {
+                     continue;
+                 }
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 index dc0ea65ab87255fad0d54dfb509300098a0b4864..7063f1da3654b382e26b0093ad5d0ff04a2b38c2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
@@ -2050,10 +2059,10 @@ index 0000000000000000000000000000000000000000..5ea5b3933725d80dd193e815ac507ee5
 \ No newline at end of file
 diff --git a/src/main/java/com/tuinity/tuinity/chunk/light/BlockStarLightEngine.java b/src/main/java/com/tuinity/tuinity/chunk/light/BlockStarLightEngine.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2b939fabcc4cc45d697bfa2f3cda7fc64a4de8ca
+index 0000000000000000000000000000000000000000..331f0ae05384b29ceb59f2846c52a2194658bb39
 --- /dev/null
 +++ b/src/main/java/com/tuinity/tuinity/chunk/light/BlockStarLightEngine.java
-@@ -0,0 +1,277 @@
+@@ -0,0 +1,289 @@
 +package com.tuinity.tuinity.chunk.light;
 +
 +import net.minecraft.core.BlockPosition;
@@ -2065,6 +2074,7 @@ index 0000000000000000000000000000000000000000..2b939fabcc4cc45d697bfa2f3cda7fc6
 +import net.minecraft.world.level.block.state.IBlockData;
 +import net.minecraft.world.level.chunk.IChunkAccess;
 +import net.minecraft.world.level.chunk.ILightAccess;
++import net.minecraft.world.level.chunk.ProtoChunk;
 +import net.minecraft.world.level.chunk.ProtoChunkExtension;
 +import net.minecraft.world.phys.shapes.VoxelShape;
 +import net.minecraft.world.phys.shapes.VoxelShapes;
@@ -2074,6 +2084,7 @@ index 0000000000000000000000000000000000000000..2b939fabcc4cc45d697bfa2f3cda7fc6
 +import java.util.Iterator;
 +import java.util.List;
 +import java.util.Set;
++import java.util.stream.Collectors;
 +
 +public final class BlockStarLightEngine extends StarLightEngine {
 +
@@ -2287,7 +2298,17 @@ index 0000000000000000000000000000000000000000..2b939fabcc4cc45d697bfa2f3cda7fc6
 +
 +            return ret.iterator();
 +        } else {
-+            return chunk.getLightSources().iterator();
++            if (chunk instanceof ProtoChunk) {
++                ProtoChunk protoChunk = (ProtoChunk)chunk;
++                protoChunk.lockLightSources();
++                try {
++                    return new ArrayList<>(chunk.getLightSources().collect(Collectors.toList())).iterator();
++                } finally {
++                    protoChunk.releaseLightSources();
++                }
++            } else {
++                return new ArrayList<>(chunk.getLightSources().collect(Collectors.toList())).iterator();
++            }
 +        }
 +    }
 +
@@ -5647,7 +5668,7 @@ index 0000000000000000000000000000000000000000..0e4442a94559346b19a536d35ce5def6
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d0433feeb274f474af04ba1e09f9f75d5b4dcfea
+index 0000000000000000000000000000000000000000..a30bb38144acb74f41638cc2b573e09265cde0e1
 --- /dev/null
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -0,0 +1,415 @@
@@ -5907,12 +5928,12 @@ index 0000000000000000000000000000000000000000..d0433feeb274f474af04ba1e09f9f75d
 +
 +    private static void newPlayerChunkManagement() {
 +        playerMinChunkLoadRadius = TuinityConfig.getInt("player-chunks.min-load-radius", 2);
-+        playerMaxConcurrentChunkSends = TuinityConfig.getDouble("player-chunks.max-concurrent-sends", 15.0);
++        playerMaxConcurrentChunkSends = TuinityConfig.getDouble("player-chunks.max-concurrent-sends", 5.0);
 +        playerMaxConcurrentChunkLoads = TuinityConfig.getDouble("player-chunks.max-concurrent-loads", -6.0);
 +        playerAutoConfigureSendViewDistance = TuinityConfig.getBoolean("player-chunks.autoconfig-send-distance", true);
 +        // this costs server bandwidth. latest phosphor or starlight on the client fixes mc162253 anyways.
 +        enableMC162253Workaround = TuinityConfig.getBoolean("player-chunks.enable-mc162253-workaround", true);
-+        playerTargetChunkSendRate = TuinityConfig.getDouble("player-chunks.target-chunk-send-rate", 81.0 * 20.0);
++        playerTargetChunkSendRate = TuinityConfig.getDouble("player-chunks.target-chunk-send-rate", -35.0);
 +        playerFrustumPrioritisation = TuinityConfig.getBoolean("player-chunks.enable-frustum-priority", false);
 +    }
 +
@@ -7882,10 +7903,10 @@ index 0000000000000000000000000000000000000000..be408aebbccbda46e8aa82ef33757413
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/util/misc/Delayed26WayDistancePropagator3D.java b/src/main/java/com/tuinity/tuinity/util/misc/Delayed26WayDistancePropagator3D.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..155d10994f2d7df9ac927d955d99016fe304360f
+index 0000000000000000000000000000000000000000..9cc49e8e4ad841df2b38dc37ec761bf360f5a357
 --- /dev/null
 +++ b/src/main/java/com/tuinity/tuinity/util/misc/Delayed26WayDistancePropagator3D.java
-@@ -0,0 +1,295 @@
+@@ -0,0 +1,300 @@
 +package com.tuinity.tuinity.util.misc;
 +
 +import it.unimi.dsi.fastutil.HashCommon;
@@ -8007,10 +8028,12 @@ index 0000000000000000000000000000000000000000..155d10994f2d7df9ac927d955d99016f
 +        this.levelRemoveWorkQueueBitset |= (1L << level);
 +    }
 +
-+    public void propagateUpdates() {
++    public boolean propagateUpdates() {
 +        if (this.updatedSources.isEmpty()) {
-+            return;
++            return false;
 +        }
++
++        boolean ret = false;
 +
 +        for (final LongIterator iterator = this.updatedSources.iterator(); iterator.hasNext();) {
 +            final long coordinate = iterator.nextLong();
@@ -8021,6 +8044,7 @@ index 0000000000000000000000000000000000000000..155d10994f2d7df9ac927d955d99016f
 +            if (currentLevel == updatedSource) {
 +                continue;
 +            }
++            ret = true;
 +
 +            if (updatedSource > currentLevel) {
 +                // level increase
@@ -8041,6 +8065,8 @@ index 0000000000000000000000000000000000000000..155d10994f2d7df9ac927d955d99016f
 +
 +        // now we propagate the decreases (which will then re-propagate clobbered sources)
 +        this.propagateDecreases();
++
++        return ret;
 +    }
 +
 +    protected void propagateIncreases() {
@@ -8183,10 +8209,10 @@ index 0000000000000000000000000000000000000000..155d10994f2d7df9ac927d955d99016f
 +}
 diff --git a/src/main/java/com/tuinity/tuinity/util/misc/Delayed8WayDistancePropagator2D.java b/src/main/java/com/tuinity/tuinity/util/misc/Delayed8WayDistancePropagator2D.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..606417a8aeaca2682595f417bba8e9d411999da9
+index 0000000000000000000000000000000000000000..cdd3c4032c1d6b34a10ba415bd4d0e377aa9af3c
 --- /dev/null
 +++ b/src/main/java/com/tuinity/tuinity/util/misc/Delayed8WayDistancePropagator2D.java
-@@ -0,0 +1,713 @@
+@@ -0,0 +1,718 @@
 +package com.tuinity.tuinity.util.misc;
 +
 +import it.unimi.dsi.fastutil.HashCommon;
@@ -8567,10 +8593,12 @@ index 0000000000000000000000000000000000000000..606417a8aeaca2682595f417bba8e9d4
 +        this.levelRemoveWorkQueueBitset |= (1L << level);
 +    }
 +
-+    public void propagateUpdates() {
++    public boolean propagateUpdates() {
 +        if (this.updatedSources.isEmpty()) {
-+            return;
++            return false;
 +        }
++
++        boolean ret = false;
 +
 +        for (final LongIterator iterator = this.updatedSources.iterator(); iterator.hasNext();) {
 +            final long coordinate = iterator.nextLong();
@@ -8581,6 +8609,7 @@ index 0000000000000000000000000000000000000000..606417a8aeaca2682595f417bba8e9d4
 +            if (currentLevel == updatedSource) {
 +                continue;
 +            }
++            ret = true;
 +
 +            if (updatedSource > currentLevel) {
 +                // level increase
@@ -8601,6 +8630,8 @@ index 0000000000000000000000000000000000000000..606417a8aeaca2682595f417bba8e9d4
 +
 +        // now we propagate the decreases (which will then re-propagate clobbered sources)
 +        this.propagateDecreases();
++
++        return ret;
 +    }
 +
 +    protected void propagateIncreases() {
@@ -10913,7 +10944,7 @@ index 1d72af9cace7aa8f1d20c7c1c5be621f533e2dad..b7399d17dd64ca8b1f1fab405cb0ac91
              worldData.addProperty("keep-spawn-loaded-range", world.paperConfig.keepLoadedRange);
              worldData.addProperty("visible-chunk-count", visibleChunks.size());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8ee622108cebff2bba8a44fb255a3b6c03ed0220..7b0b416c73c8914f3c8c570f2020490ef2babf64 100644
+index 61712ae515b329a6b85dbe2e5960e4e864dc7731..2767a9369ddc922f1d9c7cb6c7acc8270545535a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -267,6 +267,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -11147,18 +11178,18 @@ index 8ee622108cebff2bba8a44fb255a3b6c03ed0220..7b0b416c73c8914f3c8c570f2020490e
  
      public CrashReport b(CrashReport crashreport) {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 52bb528e75eb43156ee2bf19877bc051a35bb6e3..d902efdb8f2d42ea4c3933f7fa76ebe135ee09db 100644
+index df8270c40ed7ce6f628686ff6f4fa4cf96af6738..fa7a78549a9bb92b93c305dc16f43a9ace7f6f43 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -214,6 +214,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
-         com.destroystokyo.paper.PaperConfig.registerCommands();
+@@ -215,6 +215,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
+         io.papermc.paper.brigadier.PaperBrigadierProviderImpl.INSTANCE.getClass(); // init PaperBrigadierProvider
          // Paper end
 +        com.tuinity.tuinity.config.TuinityConfig.init((java.io.File) options.valueOf("tuinity-settings")); // Tuinity - Server Config
  
          this.setPVP(dedicatedserverproperties.pvp);
          this.setAllowFlight(dedicatedserverproperties.allowFlight);
-@@ -398,7 +399,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -399,7 +400,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          }
  
          if (this.q != null) {
@@ -11168,22 +11199,30 @@ index 52bb528e75eb43156ee2bf19877bc051a35bb6e3..d902efdb8f2d42ea4c3933f7fa76ebe1
  
          if (this.remoteControlListener != null) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMapDistance.java b/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
-index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183d018b1fd 100644
+index 3644e8b24b082e17752ef52934625416130aaa08..a5fc023312c99e591fc269999c28a766a46f8849 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
-@@ -40,9 +40,9 @@ public abstract class ChunkMapDistance {
+@@ -8,6 +8,7 @@ import it.unimi.dsi.fastutil.longs.Long2ByteOpenHashMap;
+ import it.unimi.dsi.fastutil.longs.Long2IntMap;
+ import it.unimi.dsi.fastutil.longs.Long2IntMaps;
+ import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
++import it.unimi.dsi.fastutil.longs.Long2IntLinkedOpenHashMap; // Tuinity
+ import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectMap.Entry;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+@@ -40,9 +41,9 @@ public abstract class ChunkMapDistance {
      private static final int b = 33 + ChunkStatus.a(ChunkStatus.FULL) - 2;
      private final Long2ObjectMap<ObjectSet<EntityPlayer>> c = new Long2ObjectOpenHashMap();
      public final Long2ObjectOpenHashMap<ArraySetSorted<Ticket<?>>> tickets = new Long2ObjectOpenHashMap();
 -    private final ChunkMapDistance.a ticketLevelTracker = new ChunkMapDistance.a();
-+    private final ChunkMapDistance.a ticketLevelTracker = new ChunkMapDistance.a(); final ChunkMapDistance.a getTicketTracker() { return this.ticketLevelTracker; } // Tuinity - OBFHELPER
++    //private final ChunkMapDistance.a ticketLevelTracker = new ChunkMapDistance.a(); final ChunkMapDistance.a getTicketTracker() { return this.ticketLevelTracker; } // Tuinity - OBFHELPER  // Tuinity - replace ticket level propagator
      public static final int MOB_SPAWN_RANGE = 8; // private final ChunkMapDistance.b f = new ChunkMapDistance.b(8); // Paper - no longer used
 -    private final ChunkMapDistance.c g = new ChunkMapDistance.c(33);
 +    //private final ChunkMapDistance.c g = new ChunkMapDistance.c(33); // Tuinity - no longer used
      // Paper start use a queue, but still keep unique requirement
      public final java.util.Queue<PlayerChunk> pendingChunkUpdates = new java.util.ArrayDeque<PlayerChunk>() {
          @Override
-@@ -62,6 +62,47 @@ public abstract class ChunkMapDistance {
+@@ -62,6 +63,86 @@ public abstract class ChunkMapDistance {
  
      PlayerChunkMap chunkMap; // Paper
  
@@ -11202,7 +11241,7 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
 +            return ticket.getTicketType() == type;
 +        });
 +        if (changed) {
-+            this.getTicketTracker().update(chunk, getLowestTicketLevel(tickets), false);
++            this.updateTicketLevel(chunk, getLowestTicketLevel(tickets)); // Tuinity - replace ticket level propagator
 +        }
 +    }
 +
@@ -11227,11 +11266,50 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
 +        tickets.add(ticket); // re-add with new expire time and ticket level
 +    }
 +    // Tuinity end - delay chunk unloads
++    // Tuinity start - replace ticket level propagator
++    protected final Long2IntLinkedOpenHashMap ticketLevelUpdates = new Long2IntLinkedOpenHashMap() {
++        @Override
++        protected void rehash(int newN) {
++            // no downsizing allowed
++            if (newN < this.n) {
++                return;
++            }
++            super.rehash(newN);
++        }
++    };
++    protected final com.tuinity.tuinity.util.misc.Delayed8WayDistancePropagator2D ticketLevelPropagator = new com.tuinity.tuinity.util.misc.Delayed8WayDistancePropagator2D(
++            (long coordinate, byte oldLevel, byte newLevel) -> {
++                ChunkMapDistance.this.ticketLevelUpdates.putAndMoveToLast(coordinate, convertBetweenTicketLevels(newLevel));
++            }
++    );
++    // function for converting between ticket levels and propagator levels and vice versa
++    // the problem is the ticket level propagator will propagate from a set source down to zero, whereas mojang expects
++    // levels to propagate from a set value up to a maximum value. so we need to convert the levels we put into the propagator
++    // and the levels we get out of the propagator
++
++    // this maps so that GOLDEN_TICKET + 1 will be 0 in the propagator, GOLDEN_TICKET will be 1, and so on
++    // we need GOLDEN_TICKET+1 as 0 because anything >= GOLDEN_TICKET+1 should be unloaded
++    public static int convertBetweenTicketLevels(final int level) {
++        return PlayerChunkMap.GOLDEN_TICKET - level + 1;
++    }
++
++    protected final int getPropagatedTicketLevel(final long coordinate) {
++        return convertBetweenTicketLevels(this.ticketLevelPropagator.getLevel(coordinate));
++    }
++
++    protected final void updateTicketLevel(final long coordinate, final int ticketLevel) {
++        if (ticketLevel > PlayerChunkMap.GOLDEN_TICKET) {
++            this.ticketLevelPropagator.removeSource(coordinate);
++        } else {
++            this.ticketLevelPropagator.setSource(coordinate, convertBetweenTicketLevels(ticketLevel));
++        }
++    }
++    // Tuinity end - replace ticket level propagator
 +
      protected ChunkMapDistance(Executor executor, Executor executor1) {
          executor1.getClass();
          Mailbox<Runnable> mailbox = Mailbox.a("player ticket throttler", executor1::execute);
-@@ -74,21 +115,45 @@ public abstract class ChunkMapDistance {
+@@ -74,21 +155,45 @@ public abstract class ChunkMapDistance {
      }
  
      protected void purgeTickets() {
@@ -11264,13 +11342,14 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
 -            if ((entry.getValue()).removeIf((ticket) -> { // CraftBukkit - decompile error
 -                return ticket.b(this.currentTick);
 -            })) {
+-                this.ticketLevelTracker.update(entry.getLongKey(), getLowestTicketLevel((ArraySetSorted) entry.getValue()), false);
 +            if ((entry.getValue()).removeIf(isExpired)) { // Tuinity - move above - only allocate once
 +                // Tuinity start - delay chunk unloads
 +                if (tempLevel[0] < (PlayerChunkMap.GOLDEN_TICKET + 1)) {
 +                    this.computeDelayedTicketFor(entry.getLongKey(), tempLevel[0], entry.getValue());
 +                }
 +                // Tuinity end - delay chunk unloads
-                 this.ticketLevelTracker.update(entry.getLongKey(), getLowestTicketLevel((ArraySetSorted) entry.getValue()), false);
++                this.updateTicketLevel(entry.getLongKey(), getLowestTicketLevel((ArraySetSorted) entry.getValue())); // Tuinity - replace ticket level propagator
              }
  
              if (((ArraySetSorted) entry.getValue()).isEmpty()) {
@@ -11281,19 +11360,152 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
          }
  
      }
-@@ -107,9 +172,10 @@ public abstract class ChunkMapDistance {
-     protected abstract PlayerChunk a(long i, int j, @Nullable PlayerChunk playerchunk, int k);
+@@ -101,65 +206,99 @@ public abstract class ChunkMapDistance {
+     protected abstract boolean a(long i);
  
+     @Nullable
+-    protected abstract PlayerChunk b(long i);
++    protected abstract PlayerChunk b(long i); protected final PlayerChunk getUpdatingChunk(long i) { return this.b(i); } // Tuinity - OBFHELPER
+ 
+     @Nullable
+-    protected abstract PlayerChunk a(long i, int j, @Nullable PlayerChunk playerchunk, int k);
++    protected abstract PlayerChunk a(long i, int j, @Nullable PlayerChunk playerchunk, int k); protected final PlayerChunk updateTicketLevel(long coord, int newLevel, @Nullable PlayerChunk playerchunk, int oldLevel) { return this.a(coord, newLevel, playerchunk, oldLevel); } // Tuinity - OBFHELPER
+ 
++    protected long ticketLevelUpdateCount; // Tuinity - replace ticket level propagator
      public boolean a(PlayerChunkMap playerchunkmap) {
 +        com.tuinity.tuinity.util.TickThread.softEnsureTickThread("Cannot tick ChunkMapDistance off of the main-thread");// Tuinity
          //this.f.a(); // Paper - no longer used
          AsyncCatcher.catchOp("DistanceManagerTick"); // Paper
 -        this.g.a();
+-        int i = Integer.MAX_VALUE - this.ticketLevelTracker.a(Integer.MAX_VALUE);
+-        boolean flag = i != 0;
 +        //this.g.a(); // Tuinity - no longer used
-         int i = Integer.MAX_VALUE - this.ticketLevelTracker.a(Integer.MAX_VALUE);
-         boolean flag = i != 0;
++        boolean flag = this.ticketLevelPropagator.propagateUpdates(); // Tuinity - replace ticket level propagator
  
-@@ -185,27 +251,11 @@ public abstract class ChunkMapDistance {
+         if (flag) {
+             ;
+         }
+ 
+-        // Paper start
+-        if (!this.pendingChunkUpdates.isEmpty()) {
+-            this.pollingPendingChunkUpdates = true; try {
+-            while(!this.pendingChunkUpdates.isEmpty()) {
+-                PlayerChunk remove = this.pendingChunkUpdates.remove();
+-                remove.isUpdateQueued = false;
+-                remove.a(playerchunkmap);
+-            }
+-            } finally { this.pollingPendingChunkUpdates = false; }
+-            // Paper end
+-            return true;
+-        } else {
+-            if (!this.l.isEmpty()) {
+-                LongIterator longiterator = this.l.iterator();
++        // Tuinity start - replace level propagator
++        if (!this.ticketLevelUpdates.isEmpty()) {
++            boolean oldPolling = this.pollingPendingChunkUpdates;
++            this.pollingPendingChunkUpdates = true;
++            try {
++                for (java.util.Iterator<Long2IntMap.Entry> iterator = this.ticketLevelUpdates.long2IntEntrySet().fastIterator(); iterator.hasNext(); ) {
++                    Long2IntMap.Entry entry = iterator.next();
++                    long key = entry.getLongKey();
++                    int newLevel = entry.getIntValue();
++                    PlayerChunk chunk = this.getUpdatingChunk(key);
+ 
+-                while (longiterator.hasNext()) {
+-                    long j = longiterator.nextLong();
++                    if (chunk == null && newLevel > PlayerChunkMap.GOLDEN_TICKET) {
++                        // not loaded and it shouldn't be loaded!
++                        continue;
++                    }
+ 
+-                    if (this.e(j).stream().anyMatch((ticket) -> {
+-                        return ticket.getTicketType() == TicketType.PLAYER;
+-                    })) {
+-                        PlayerChunk playerchunk = playerchunkmap.getUpdatingChunk(j);
++                    int currentLevel = chunk == null ? PlayerChunkMap.GOLDEN_TICKET + 1 : chunk.getTicketLevel();
+ 
+-                        if (playerchunk == null) {
+-                            throw new IllegalStateException();
++                    if (currentLevel == newLevel) {
++                        // nothing to do
++                        continue;
++                    }
++
++                    this.updateTicketLevel(key, newLevel, chunk, currentLevel);
++                }
++
++                long recursiveCheck = ++this.ticketLevelUpdateCount;
++                while (!this.ticketLevelUpdates.isEmpty()) {
++                    long key = this.ticketLevelUpdates.firstLongKey();
++                    int newLevel = this.ticketLevelUpdates.removeFirstInt();
++                    PlayerChunk chunk = this.getUpdatingChunk(key);
++
++                    if (chunk == null) {
++                        if (newLevel <= PlayerChunkMap.GOLDEN_TICKET) {
++                            throw new IllegalStateException("Expected chunk holder to be created");
+                         }
++                        // not loaded and it shouldn't be loaded!
++                        continue;
++                    }
+ 
+-                        CompletableFuture<Either<Chunk, PlayerChunk.Failure>> completablefuture = playerchunk.b();
++                    int currentLevel = chunk.oldTicketLevel;
+ 
+-                        completablefuture.thenAccept((either) -> {
+-                            this.m.execute(() -> {
+-                                this.k.a(ChunkTaskQueueSorter.a(() -> {
+-                                }, j, false));
+-                            });
+-                        });
++                    if (currentLevel == newLevel) {
++                        // nothing to do
++                        continue;
++                    }
++
++                    chunk.handleLevelUpdate(playerchunkmap);
++                    if (recursiveCheck != this.ticketLevelUpdateCount) {
++                        if (!this.ticketLevelUpdates.isEmpty()) {
++                            throw new IllegalStateException("Recursive call should have processed updates");
++                        }
++                        break;
+                     }
+                 }
+ 
+-                this.l.clear();
++                for (;;) {
++                    if (recursiveCheck != this.ticketLevelUpdateCount) {
++                        break;
++                    }
++                    PlayerChunk pendingUpdate = this.pendingChunkUpdates.poll();
++                    if (pendingUpdate == null) {
++                        break;
++                    }
++
++                    pendingUpdate.handleLevelUpdate(playerchunkmap);
++                }
++            } finally {
++                this.pollingPendingChunkUpdates = oldPolling;
+             }
+ 
+-            return flag;
++            return true;
+         }
++
++        return flag;
++        // Tuinity end - replace level propagator
+     }
+     boolean pollingPendingChunkUpdates = false; // Paper
+ 
+@@ -171,7 +310,7 @@ public abstract class ChunkMapDistance {
+ 
+         ticket1.a(this.currentTick);
+         if (ticket.b() < j) {
+-            this.ticketLevelTracker.update(i, ticket.b(), true);
++            this.updateTicketLevel(i, ticket.b()); // Tuinity - replace ticket level propagator
+         }
+ 
+         return ticket == ticket1; // CraftBukkit
+@@ -185,27 +324,11 @@ public abstract class ChunkMapDistance {
          boolean removed = false; // CraftBukkit
          if (arraysetsorted.remove(ticket)) {
              removed = true; // CraftBukkit
@@ -11325,7 +11537,16 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
          }
  
          if (arraysetsorted.isEmpty()) {
-@@ -272,7 +322,7 @@ public abstract class ChunkMapDistance {
+@@ -213,7 +336,7 @@ public abstract class ChunkMapDistance {
+         }
+ 
+         int newLevel = getLowestTicketLevel(arraysetsorted); // Paper
+-        if (newLevel > oldLevel) this.ticketLevelTracker.update(i, newLevel, false); // Paper
++        if (newLevel > oldLevel) this.updateTicketLevel(i, newLevel); // Paper // Tuinity - replace ticket level propagator
+         return removed; // CraftBukkit
+     }
+ 
+@@ -272,7 +395,7 @@ public abstract class ChunkMapDistance {
          AsyncCatcher.catchOp("ChunkMapDistance::addPriorityTicket");
          long pair = coords.pair();
          PlayerChunk chunk = chunkMap.getUpdatingChunk(pair);
@@ -11334,7 +11555,7 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
  
          if (needsTicket) {
              Ticket<?> ticket = new Ticket<>(TicketType.PLAYER, 33, coords);
-@@ -379,6 +429,7 @@ public abstract class ChunkMapDistance {
+@@ -379,6 +502,7 @@ public abstract class ChunkMapDistance {
      }
  
      private ArraySetSorted<Ticket<?>> e(long i) {
@@ -11342,7 +11563,7 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
          return (ArraySetSorted) this.tickets.computeIfAbsent(i, (j) -> {
              return ArraySetSorted.a(4);
          });
-@@ -396,16 +447,18 @@ public abstract class ChunkMapDistance {
+@@ -396,16 +520,18 @@ public abstract class ChunkMapDistance {
      }
  
      public void a(SectionPosition sectionposition, EntityPlayer entityplayer) {
@@ -11362,7 +11583,7 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
          long i = sectionposition.r().pair();
          ObjectSet<EntityPlayer> objectset = (ObjectSet) this.c.get(i);
          if (objectset == null) return; // CraftBukkit - SPIGOT-6208
-@@ -414,7 +467,7 @@ public abstract class ChunkMapDistance {
+@@ -414,7 +540,7 @@ public abstract class ChunkMapDistance {
          if (objectset == null || objectset.isEmpty()) { // Paper
              this.c.remove(i);
              //this.f.update(i, Integer.MAX_VALUE, false); // Paper - no longer used
@@ -11371,7 +11592,7 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
          }
  
      }
-@@ -433,7 +486,7 @@ public abstract class ChunkMapDistance {
+@@ -433,7 +559,7 @@ public abstract class ChunkMapDistance {
      }
  
      protected void setNoTickViewDistance(int i) { // Paper - force abi breakage on usage change
@@ -11380,7 +11601,7 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
      }
  
      public int b() {
-@@ -456,6 +509,7 @@ public abstract class ChunkMapDistance {
+@@ -456,6 +582,7 @@ public abstract class ChunkMapDistance {
  
      // CraftBukkit start
      public <T> void removeAllTicketsFor(TicketType<T> ticketType, int ticketLevel, T ticketIdentifier) {
@@ -11388,7 +11609,16 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
          Ticket<T> target = new Ticket<>(ticketType, ticketLevel, ticketIdentifier);
  
          for (java.util.Iterator<Entry<ArraySetSorted<Ticket<?>>>> iterator = this.tickets.long2ObjectEntrySet().fastIterator(); iterator.hasNext();) {
-@@ -519,6 +573,7 @@ public abstract class ChunkMapDistance {
+@@ -463,7 +590,7 @@ public abstract class ChunkMapDistance {
+             ArraySetSorted<Ticket<?>> tickets = entry.getValue();
+             if (tickets.remove(target)) {
+                 // copied from removeTicket
+-                this.ticketLevelTracker.update(entry.getLongKey(), getLowestTicketLevel(tickets), false);
++                this.updateTicketLevel(entry.getLongKey(), getLowestTicketLevel(tickets)); // Tuinity - replace ticket level propagator
+ 
+                 // can't use entry after it's removed
+                 if (tickets.isEmpty()) {
+@@ -519,6 +646,7 @@ public abstract class ChunkMapDistance {
          }
      }
  
@@ -11396,7 +11626,7 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
      class c extends ChunkMapDistance.b {
  
          private int e = 0; private int getViewDistance() { return e; } private void setViewDistance(int value) { this.e = value; } // Paper - OBFHELPER
-@@ -737,6 +792,7 @@ public abstract class ChunkMapDistance {
+@@ -737,6 +865,7 @@ public abstract class ChunkMapDistance {
              return i <= this.e - 2;
          }
      }
@@ -11405,7 +11635,7 @@ index 3644e8b24b082e17752ef52934625416130aaa08..ad90735b5daa658cdd5467eadcb29183
      class b extends ChunkMap {
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
-index c5e54c519e1f686761faa53b5e9579c514a65332..cb83f1152c52a99d25e4e80cc8bf18c6793e8b50 100644
+index c5e54c519e1f686761faa53b5e9579c514a65332..fe040615ff03478a20cdf8376f89a6b7d100ba61 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 @@ -47,6 +47,12 @@ import net.minecraft.world.level.storage.WorldData;
@@ -11801,7 +12031,7 @@ index c5e54c519e1f686761faa53b5e9579c514a65332..cb83f1152c52a99d25e4e80cc8bf18c6
      }
  
      private void a(long i, Consumer<Chunk> consumer) {
-@@ -1026,51 +1237,19 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -1026,44 +1237,12 @@ public class ChunkProviderServer extends IChunkProvider {
              ChunkProviderServer.this.world.getMethodProfiler().c("runTask");
              super.executeTask(runnable);
          }
@@ -11849,16 +12079,8 @@ index c5e54c519e1f686761faa53b5e9579c514a65332..cb83f1152c52a99d25e4e80cc8bf18c6
          // CraftBukkit start - process pending Chunk loadCallback() and unloadCallback() after each run task
          try {
              boolean execChunkTask = com.destroystokyo.paper.io.chunk.ChunkTaskManager.pollChunkWaitQueue() || ChunkProviderServer.this.world.asyncChunkTaskManager.pollNextChunkTask(); // Paper
-             if (ChunkProviderServer.this.tickDistanceManager()) {
-                 return true;
-             } else {
--                ChunkProviderServer.this.lightEngine.queueUpdate(); // Paper - not needed
-+                ChunkProviderServer.this.lightEngine.queueUpdate(); // Paper - not needed // Tuinity - prevent queue overflow when no players are in this world
-                 return super.executeNext() || execChunkTask; // Paper
-             }
-         } finally {
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 37c9b5fd712e30a9a0faccc840f738f4b2cfc723..62b95dcba8606330fbb3239e74c5eaf8baa3c51d 100644
+index 1161605d9f4f9727282ac3677a916a9ebdb1263b..fb61b6ac167b34486282a24e598020fb96081f28 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -261,7 +261,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -12129,7 +12351,7 @@ index 4ee7070364a8989eece4fa4237b529926821f9c9..f22ab98d2e250081df8949be8a997370
          this.a(Long.MAX_VALUE, i, j, flag);
      }
 diff --git a/src/main/java/net/minecraft/server/level/LightEngineThreaded.java b/src/main/java/net/minecraft/server/level/LightEngineThreaded.java
-index 0b80569648c1df01aab52d0b8d47028cda925d86..4d651cc21a9cb2fdeabff62d8978c3ec4abe2f68 100644
+index 0b80569648c1df01aab52d0b8d47028cda925d86..ad584ba21c6e201b778f32cea6d7cc5bf67f9746 100644
 --- a/src/main/java/net/minecraft/server/level/LightEngineThreaded.java
 +++ b/src/main/java/net/minecraft/server/level/LightEngineThreaded.java
 @@ -2,6 +2,11 @@ package net.minecraft.server.level;
@@ -12457,7 +12679,7 @@ index 0b80569648c1df01aab52d0b8d47028cda925d86..4d651cc21a9cb2fdeabff62d8978c3ec
 +                LightEngineThreaded.this.queueUpdate();
 +            }).whenComplete((IChunkAccess chunk, Throwable throwable) -> {
 +                if (throwable != null && !(throwable instanceof ThreadDeath)) {
-+                    LOGGER.fatal("Failed to light chunk " + ichunkaccess.getPos().toString() + " in world '" + this.theLightEngine.getWorld().getWorld().getName() + "'");
++                    LOGGER.fatal("Failed to light chunk " + ichunkaccess.getPos().toString() + " in world '" + this.theLightEngine.getWorld().getWorld().getName() + "'", throwable);
 +                }
 +            });
 +        }
@@ -12515,7 +12737,7 @@ index 0b80569648c1df01aab52d0b8d47028cda925d86..4d651cc21a9cb2fdeabff62d8978c3ec
  
      public void a(int i) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunk.java b/src/main/java/net/minecraft/server/level/PlayerChunk.java
-index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b474f9a8ccf 100644
+index a323b76f68c273a73cb3f20167a668b2100f4944..86f156587a0939b28c5cf6f64907255c1c4f8b35 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunk.java
 @@ -3,6 +3,7 @@ package net.minecraft.server.level;
@@ -12526,6 +12748,15 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
  import it.unimi.dsi.fastutil.shorts.ShortSet;
  import java.util.List;
  import java.util.Optional;
+@@ -54,7 +55,7 @@ public class PlayerChunk {
+     private volatile CompletableFuture<Either<Chunk, PlayerChunk.Failure>> entityTickingFuture; private volatile boolean isEntityTickingReady; // Paper - cache chunk ticking stage
+     private CompletableFuture<IChunkAccess> chunkSave;
+     public int oldTicketLevel;
+-    private int ticketLevel;
++    private int ticketLevel; public final void setTicketLevel(final int level) { this.ticketLevel = level; } // Tuinity - OBFHELPER
+     volatile int n; public final int getCurrentPriority() { return n; } // Paper - OBFHELPER - make volatile since this is concurrently accessed
+     public final ChunkCoordIntPair location; // Paper - private -> public
+     private boolean p;
 @@ -82,6 +83,12 @@ public class PlayerChunk {
          long key = net.minecraft.server.MCUtil.getCoordinateKey(this.location);
          this.playersInMobSpawnRange = this.chunkMap.playerMobSpawnMap.getObjectsInRange(key);
@@ -12614,15 +12845,19 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> a(ChunkStatus chunkstatus, PlayerChunkMap playerchunkmap) {
          int i = chunkstatus.c();
          CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> completablefuture = (CompletableFuture) this.statusFutures.get(i);
-@@ -589,6 +600,7 @@ public class PlayerChunk {
+@@ -588,7 +599,11 @@ public class PlayerChunk {
+         this.ticketLevel = i;
      }
  
++    protected long updateCount; // Tuinity - correctly handle recursion
++    protected final void handleLevelUpdate(PlayerChunkMap playerchunkmap) { this.a(playerchunkmap); } // Tuinity - OBFHELPER
      protected void a(PlayerChunkMap playerchunkmap) {
 +        com.tuinity.tuinity.util.TickThread.ensureTickThread("Async ticket level update"); // Tuinity
++        long updateCount = ++this.updateCount; // Tuinity - correctly handle recursion
          ChunkStatus chunkstatus = getChunkStatus(this.oldTicketLevel);
          ChunkStatus chunkstatus1 = getChunkStatus(this.ticketLevel);
          boolean flag = this.oldTicketLevel <= PlayerChunkMap.GOLDEN_TICKET;
-@@ -598,7 +610,8 @@ public class PlayerChunk {
+@@ -598,7 +613,8 @@ public class PlayerChunk {
          // CraftBukkit start
          // ChunkUnloadEvent: Called before the chunk is unloaded: isChunkLoaded is still true and chunk can still be modified by plugins.
          if (playerchunk_state.isAtLeast(PlayerChunk.State.BORDER) && !playerchunk_state1.isAtLeast(PlayerChunk.State.BORDER)) {
@@ -12632,7 +12867,20 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
                  Chunk chunk = (Chunk)either.left().orElse(null);
                  if (chunk != null) {
                      playerchunkmap.callbackExecutor.execute(() -> {
-@@ -663,7 +676,8 @@ public class PlayerChunk {
+@@ -617,6 +633,12 @@ public class PlayerChunk {
+ 
+             // Run callback right away if the future was already done
+             playerchunkmap.callbackExecutor.run();
++            // Tuinity start - correctly handle recursion
++            if (this.updateCount != updateCount) {
++                // something else updated ticket level for us.
++                return;
++            }
++            // Tuinity end - correctly handle recursion
+         }
+         // CraftBukkit end
+         CompletableFuture completablefuture;
+@@ -663,7 +685,8 @@ public class PlayerChunk {
          if (!flag2 && flag3) {
              // Paper start - cache ticking ready status
              int expectCreateCount = ++this.fullChunkCreateCount;
@@ -12642,7 +12890,7 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
                  if (either.left().isPresent() && PlayerChunk.this.fullChunkCreateCount == expectCreateCount) {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      Chunk fullChunk = either.left().get();
-@@ -694,7 +708,8 @@ public class PlayerChunk {
+@@ -694,7 +717,8 @@ public class PlayerChunk {
  
          if (!flag4 && flag5) {
              // Paper start - cache ticking ready status
@@ -12652,7 +12900,7 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
                  if (either.left().isPresent()) {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      Chunk tickingChunk = either.left().get();
-@@ -704,6 +719,9 @@ public class PlayerChunk {
+@@ -704,6 +728,9 @@ public class PlayerChunk {
                      // Paper start - rewrite ticklistserver
                      PlayerChunk.this.chunkMap.world.onChunkSetTicking(PlayerChunk.this.location.x, PlayerChunk.this.location.z);
                      // Paper end - rewrite ticklistserver
@@ -12662,7 +12910,7 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
  
                  }
              });
-@@ -714,6 +732,12 @@ public class PlayerChunk {
+@@ -714,6 +741,12 @@ public class PlayerChunk {
          if (flag4 && !flag5) {
              this.tickingFuture.complete(PlayerChunk.UNLOADED_CHUNK); this.isTickingReady = false; // Paper - cache chunk ticking stage
              this.tickingFuture = PlayerChunk.UNLOADED_CHUNK_FUTURE;
@@ -12675,7 +12923,7 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
          }
  
          boolean flag6 = playerchunk_state.isAtLeast(PlayerChunk.State.ENTITY_TICKING);
-@@ -725,13 +749,16 @@ public class PlayerChunk {
+@@ -725,13 +758,16 @@ public class PlayerChunk {
              }
  
              // Paper start - cache ticking ready status
@@ -12694,7 +12942,7 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
  
  
                  }
-@@ -743,6 +770,12 @@ public class PlayerChunk {
+@@ -743,6 +779,12 @@ public class PlayerChunk {
          if (flag6 && !flag7) {
              this.entityTickingFuture.complete(PlayerChunk.UNLOADED_CHUNK); this.isEntityTickingReady = false; // Paper - cache chunk ticking stage
              this.entityTickingFuture = PlayerChunk.UNLOADED_CHUNK_FUTURE;
@@ -12707,7 +12955,7 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
          }
  
          // Paper start - raise IO/load priority if priority changes, use our preferred priority
-@@ -768,7 +801,8 @@ public class PlayerChunk {
+@@ -768,7 +810,8 @@ public class PlayerChunk {
          // CraftBukkit start
          // ChunkLoadEvent: Called after the chunk is loaded: isChunkLoaded returns true and chunk is ready to be modified by plugins.
          if (!playerchunk_state.isAtLeast(PlayerChunk.State.BORDER) && playerchunk_state1.isAtLeast(PlayerChunk.State.BORDER)) {
@@ -12718,7 +12966,7 @@ index a323b76f68c273a73cb3f20167a668b2100f4944..d9b134302f739efd93f50e93c8730b47
                  if (chunk != null) {
                      playerchunkmap.callbackExecutor.execute(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c87db53bb4 100644
+index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..b28995ecfd7f45e6b6197be96c418aa0d05d3383 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -103,6 +103,7 @@ import net.minecraft.world.level.storage.WorldDataServer;
@@ -12729,6 +12977,28 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  import org.apache.commons.lang3.mutable.MutableBoolean;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
+@@ -115,8 +116,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     private static final Logger LOGGER = LogManager.getLogger();
+     public static final int GOLDEN_TICKET = 33 + ChunkStatus.b();
+     // Paper start - faster copying
+-    public final Long2ObjectLinkedOpenHashMap<PlayerChunk> updatingChunks = new com.destroystokyo.paper.util.map.Long2ObjectLinkedOpenHashMapFastCopy<>(); // Paper - faster copying
+-    public final Long2ObjectLinkedOpenHashMap<PlayerChunk> visibleChunks = new ProtectedVisibleChunksMap(); // Paper - faster copying
++    // Tuinity start - Don't copy
++    public final com.destroystokyo.paper.util.map.QueuedChangesMapLong2Object<PlayerChunk> updatingChunks = new com.destroystokyo.paper.util.map.QueuedChangesMapLong2Object<>();
++    // Tuinity end - Don't copy
+ 
+     private class ProtectedVisibleChunksMap extends com.destroystokyo.paper.util.map.Long2ObjectLinkedOpenHashMapFastCopy<PlayerChunk> {
+         @Override
+@@ -139,8 +141,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         }
+     }
+     // Paper end
+-    public final com.destroystokyo.paper.util.map.Long2ObjectLinkedOpenHashMapFastCopy<PlayerChunk> pendingVisibleChunks = new com.destroystokyo.paper.util.map.Long2ObjectLinkedOpenHashMapFastCopy<PlayerChunk>(); // Paper - this is used if the visible chunks is updated while iterating only
+-    public transient com.destroystokyo.paper.util.map.Long2ObjectLinkedOpenHashMapFastCopy<PlayerChunk> visibleChunksClone; // Paper - used for async access of visible chunks, clone and cache only when needed
++    // Tuinity - Don't copy
+     private final Long2ObjectLinkedOpenHashMap<PlayerChunk> pendingUnload;
+     public final LongSet loadedChunks; // Paper - private -> public
+     public final WorldServer world;
 @@ -176,31 +177,28 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      // CraftBukkit start - recursion-safe executor for Chunk loadCallback() and unloadCallback()
      public final CallbackExecutor callbackExecutor = new CallbackExecutor();
@@ -12892,12 +13162,12 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
 +    // Tuinity start
 +    public final List<com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager> regionManagers = new java.util.ArrayList<>();
 +    public final com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager dataRegionManager;
-+
-+    public static final class DataRegionData implements com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionData {
  
 -        if (!this.cannotLoadChunks(player)) {
 -            this.playerViewDistanceTickMap.update(player, chunkX, chunkZ, effectiveTickViewDistance);
 -            this.playerViewDistanceNoTickMap.update(player, chunkX, chunkZ, effectiveNoTickViewDistance + 2); // clients need chunk 1 neighbour, and we need another 1 for sending those extra neighbours (as we require neighbours to send)
++    public static final class DataRegionData implements com.tuinity.tuinity.chunk.SingleThreadChunkRegionManager.RegionData {
++
 +        // Tuinity start - optimise notify()
 +        private com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet<EntityInsentient> navigators;
 +
@@ -13033,14 +13303,14 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
 -                checkHighPriorityChunks(player);
 -                if (newState.size() != 1) {
 -                    return;
+-                }
+-                Chunk chunk = PlayerChunkMap.this.world.getChunkProvider().getChunkAtIfLoadedMainThreadNoCache(rangeX, rangeZ);
+-                if (chunk == null || !chunk.areNeighboursLoaded(2)) {
+-                    return;
 +                Chunk chunk = PlayerChunkMap.this.world.getChunkProvider().getChunkAtIfCachedImmediately(rangeX, rangeZ);
 +                if (chunk != null) {
 +                    chunk.updateGeneralAreaCache(newState);
                  }
--                Chunk chunk = PlayerChunkMap.this.world.getChunkProvider().getChunkAtIfLoadedMainThreadNoCache(rangeX, rangeZ);
--                if (chunk == null || !chunk.areNeighboursLoaded(2)) {
--                    return;
--                }
 -
 -                ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(rangeX, rangeZ);
 -                PlayerChunkMap.this.world.getChunkProvider().addTicketAtLevel(TicketType.PLAYER, chunkPos, 31, chunkPos); // entity ticking level, TODO check on update
@@ -13105,7 +13375,74 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
          PlayerChunk chunk = getUpdatingChunk(coord.pair());
          return chunk != null && (chunk.isFullChunkReady());
      }
-@@ -811,6 +879,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -667,7 +735,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+ 
+     @Nullable
+     public PlayerChunk getUpdatingChunk(long i) { // Paper
+-        return (PlayerChunk) this.updatingChunks.get(i);
++        return this.updatingChunks.getUpdating(i); // Tuinity - Don't copy
+     }
+ 
+     // Paper start - remove cloning of visible chunks unless accessed as a collection async
+@@ -675,47 +743,25 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     private boolean isIterating = false;
+     private boolean hasPendingVisibleUpdate = false;
+     public void forEachVisibleChunk(java.util.function.Consumer<PlayerChunk> consumer) {
+-        org.spigotmc.AsyncCatcher.catchOp("forEachVisibleChunk");
+-        boolean prev = isIterating;
+-        isIterating = true;
+-        try {
+-            for (PlayerChunk value : this.visibleChunks.values()) {
+-                consumer.accept(value);
+-            }
+-        } finally {
+-            this.isIterating = prev;
+-            if (!this.isIterating && this.hasPendingVisibleUpdate) {
+-                ((ProtectedVisibleChunksMap)this.visibleChunks).copyFrom(this.pendingVisibleChunks);
+-                this.pendingVisibleChunks.clear();
+-                this.hasPendingVisibleUpdate = false;
+-            }
+-        }
++        throw new UnsupportedOperationException(); // Tuinity - Don't copy
+     }
+     public Long2ObjectLinkedOpenHashMap<PlayerChunk> getVisibleChunks() {
+-        if (Thread.currentThread() == this.world.serverThread) {
+-            return this.visibleChunks;
+-        } else {
+-            synchronized (this.visibleChunks) {
+-                if (DEBUG_ASYNC_VISIBLE_CHUNKS) new Throwable("Async getVisibleChunks").printStackTrace();
+-                if (this.visibleChunksClone == null) {
+-                    this.visibleChunksClone = this.hasPendingVisibleUpdate ? this.pendingVisibleChunks.clone() : ((ProtectedVisibleChunksMap)this.visibleChunks).clone();
+-                }
+-                return this.visibleChunksClone;
+-            }
++        // Tuinity start - Don't copy (except in rare cases)
++        synchronized (this.updatingChunks) {
++            return this.updatingChunks.getVisibleMap().clone();
+         }
++        // Tuinity end - Don't copy (except in rare cases)
+     }
+     // Paper end
+ 
+     @Nullable
+     public PlayerChunk getVisibleChunk(long i) { // Paper - protected -> public
+-        // Paper start - mt safe get
+-        if (Thread.currentThread() != this.world.serverThread) {
+-            synchronized (this.visibleChunks) {
+-                return (PlayerChunk) (this.hasPendingVisibleUpdate ? this.pendingVisibleChunks.get(i) : ((ProtectedVisibleChunksMap)this.visibleChunks).safeGet(i));
+-            }
++        // Tuinity start - Don't copy
++        if (Thread.currentThread() == this.world.serverThread) {
++            return this.updatingChunks.getVisible(i);
+         }
+-        return (PlayerChunk) (this.hasPendingVisibleUpdate ? this.pendingVisibleChunks.get(i) : ((ProtectedVisibleChunksMap)this.visibleChunks).safeGet(i));
+-        // Paper end
++        return this.updatingChunks.getVisibleAsync(i);
++        // Tuinity end - Don't copy
+     }
+ 
+     protected final IntSupplier getPrioritySupplier(long i) { return c(i); } // Paper - OBFHELPER
+@@ -811,6 +857,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      @Nullable
      private PlayerChunk a(long i, int j, @Nullable PlayerChunk playerchunk, int k) {
@@ -13114,7 +13451,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
          if (k > PlayerChunkMap.GOLDEN_TICKET && j > PlayerChunkMap.GOLDEN_TICKET) {
              return playerchunk;
          } else {
-@@ -833,7 +903,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -833,9 +881,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      playerchunk.a(j);
                  } else {
                      playerchunk = new PlayerChunk(new ChunkCoordIntPair(i), j, this.lightEngine, this.p, this);
@@ -13126,9 +13463,12 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
                  }
 +                this.getVillagePlace().dequeueUnload(playerchunk.location.pair()); // Tuinity - unload POI data
  
-                 this.updatingChunks.put(i, playerchunk);
+-                this.updatingChunks.put(i, playerchunk);
++                this.updatingChunks.queueUpdate(i, playerchunk); // Tuinity - Don't copy
                  this.updatingChunksModified = true;
-@@ -959,7 +1035,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             }
+ 
+@@ -959,7 +1013,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -13137,7 +13477,16 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  
      protected void unloadChunks(BooleanSupplier booleansupplier) {
          GameProfilerFiller gameprofilerfiller = this.world.getMethodProfiler();
-@@ -1025,7 +1101,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -988,7 +1042,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         while (longiterator.hasNext()) { // Spigot
+             long j = longiterator.nextLong();
+             longiterator.remove(); // Spigot
+-            PlayerChunk playerchunk = (PlayerChunk) this.updatingChunks.remove(j);
++            PlayerChunk playerchunk = this.updatingChunks.queueRemove(j); // Tuinity - Don't copy
+ 
+             if (playerchunk != null) {
+                 this.pendingUnload.put(j, playerchunk);
+@@ -1025,7 +1079,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          }
  
          com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE.scheduleSave(this.world, chunkPos.x, chunkPos.z,
@@ -13146,7 +13495,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  
          if (!chunk.isNeedsSaving()) {
              return;
-@@ -1059,7 +1135,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1059,7 +1113,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              asyncSaveData = ChunkRegionLoader.getAsyncSaveData(this.world, chunk);
          }
  
@@ -13155,7 +13504,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
              asyncSaveData, chunk);
  
          chunk.setLastSaved(this.world.getTime());
-@@ -1067,6 +1143,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1067,6 +1121,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
      // Paper end
  
@@ -13164,7 +13513,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
      private void a(long i, PlayerChunk playerchunk) {
          CompletableFuture<IChunkAccess> completablefuture = playerchunk.getChunkSave();
          Consumer<IChunkAccess> consumer = (ichunkaccess) -> { // CraftBukkit - decompile error
-@@ -1075,7 +1153,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1075,7 +1131,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              if (completablefuture1 != completablefuture) {
                  this.a(i, playerchunk);
              } else {
@@ -13187,7 +13536,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
                      if (ichunkaccess instanceof Chunk) {
                          ((Chunk) ichunkaccess).setLoaded(false);
                      }
-@@ -1098,7 +1190,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1098,7 +1168,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      this.lightEngine.a(ichunkaccess.getPos());
                      this.lightEngine.queueUpdate();
                      this.worldLoadListener.a(ichunkaccess.getPos(), (ChunkStatus) null);
@@ -13204,7 +13553,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  
              }
          };
-@@ -1114,6 +1214,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1114,22 +1192,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      protected boolean b() {
@@ -13212,7 +13561,27 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
          if (!this.updatingChunksModified) {
              return false;
          } else {
-@@ -1159,7 +1260,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+-            // Paper start - stop cloning visibleChunks
+-            synchronized (this.visibleChunks) {
+-                if (isIterating) {
+-                    hasPendingVisibleUpdate = true;
+-                    this.pendingVisibleChunks.copyFrom((com.destroystokyo.paper.util.map.Long2ObjectLinkedOpenHashMapFastCopy<PlayerChunk>)this.updatingChunks);
+-                } else {
+-                    hasPendingVisibleUpdate = false;
+-                    this.pendingVisibleChunks.clear();
+-                    ((ProtectedVisibleChunksMap)this.visibleChunks).copyFrom((com.destroystokyo.paper.util.map.Long2ObjectLinkedOpenHashMapFastCopy<PlayerChunk>)this.updatingChunks);
+-                    this.visibleChunksClone = null;
+-                }
++            // Tuinity start - Don't copy
++            synchronized (this.updatingChunks) {
++                this.updatingChunks.performUpdates();
+             }
+-            // Paper end
++            // Tuinity end - Don't copy
+ 
+             this.updatingChunksModified = false;
+             return true;
+@@ -1159,7 +1230,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      if (ichunkaccess.getChunkStatus().b(chunkstatus)) {
                          CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> completablefuture1; // Paper
  
@@ -13221,7 +13590,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
                              completablefuture1 = this.b(playerchunk, chunkstatus);
                          } else {
                              completablefuture1 = chunkstatus.a(this.world, this.definedStructureManager, this.lightEngine, (ichunkaccess1) -> {
-@@ -1189,6 +1290,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1189,6 +1260,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                  this.getVillagePlace().loadInData(chunkcoordintpair, chunkHolder.poiData);
                  chunkHolder.tasks.forEach(Runnable::run);
@@ -13229,7 +13598,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
                  // Paper end
  
                  if (chunkHolder.protoChunk != null) {try (Timing ignored2 = this.world.timings.chunkLoadLevelTimer.startTimingIfSync()) { // Paper start - timings // Paper - chunk is created async
-@@ -1301,9 +1403,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1301,9 +1373,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
              // Paper end
              this.mailboxWorldGen.a(ChunkTaskQueueSorter.a(playerchunk, runnable));
@@ -13244,7 +13613,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
      protected void c(ChunkCoordIntPair chunkcoordintpair) {
          this.executor.a(SystemUtils.a(() -> {
              this.chunkDistanceManager.b(TicketType.LIGHT, chunkcoordintpair, 33 + ChunkStatus.a(ChunkStatus.FEATURES), chunkcoordintpair);
-@@ -1470,9 +1576,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1470,9 +1546,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  chunk.B();
                  return chunk;
              });
@@ -13255,7 +13624,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
      }
  
      public int c() {
-@@ -1553,39 +1657,27 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1553,39 +1627,27 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public void setViewDistance(int i) { // Paper - public
@@ -13300,7 +13669,16 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
          if (entityplayer.world == this.world) {
              if (flag1 && !flag) {
                  PlayerChunk playerchunk = this.getVisibleChunk(chunkcoordintpair.pair());
-@@ -1681,7 +1773,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1609,7 +1671,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     }
+ 
+     public int d() {
+-        return this.visibleChunks.size();
++        return this.updatingChunks.getVisibleMap().size(); // Tuinity - Don't copy
+     }
+ 
+     protected PlayerChunkMap.a e() {
+@@ -1681,7 +1743,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          if (Thread.currentThread() != com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE) {
              com.destroystokyo.paper.io.PaperFileIOThread.Holder.INSTANCE.scheduleSave(
                  this.world, chunkcoordintpair.x, chunkcoordintpair.z, null, nbttagcompound,
@@ -13309,7 +13687,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
              return;
          }
          super.write(chunkcoordintpair, nbttagcompound);
-@@ -1765,6 +1857,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1765,6 +1827,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return chunkHolder == null ? null : chunkHolder.getAvailableChunkNow();
      }
      // Paper end
@@ -13321,7 +13699,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  
  
      // Paper start - async io
-@@ -1974,6 +2071,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1974,6 +2041,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          }*/ // Paper end - replaced by distance map
  
          this.updateMaps(entityplayer); // Paper - distance maps
@@ -13329,7 +13707,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  
      }
  
-@@ -1982,7 +2080,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1982,7 +2050,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          // Paper start - per player view distance
          // there can be potential desync with player's last mapped section and the view distance map, so use the
          // view distance map here.
@@ -13338,7 +13716,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  
          if (inRange == null) {
              return Stream.empty();
-@@ -1998,8 +2096,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1998,8 +2066,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      continue;
                  }
                  EntityPlayer player = (EntityPlayer)temp;
@@ -13350,7 +13728,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  
                  int distX = Math.abs(MCUtil.getCoordinateX(lastPosition) - chunkcoordintpair.x);
                  int distZ = Math.abs(MCUtil.getCoordinateZ(lastPosition) - chunkcoordintpair.z);
-@@ -2014,6 +2113,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -2014,6 +2083,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      continue;
                  }
                  EntityPlayer player = (EntityPlayer)temp;
@@ -13358,7 +13736,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
                  players.add(player);
              }
          }
-@@ -2092,22 +2192,25 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -2092,22 +2162,25 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      private final void processTrackQueue() {
          this.world.timings.tracker1.startTiming();
          try {
@@ -13397,7 +13775,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
          }
      }
      // Paper end - optimised tracker
-@@ -2229,6 +2332,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2229,6 +2302,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
              apacket[1] = new PacketPlayOutLightUpdate(chunk.getPos(), this.lightEngine, true);
  
              // Paper start - Fix MC-162253
@@ -13405,7 +13783,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
              final int lightMask = getLightMask(chunk);
              int i = 1;
              for (int x = -1; x <= 1; x++) {
-@@ -2253,10 +2357,12 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2253,10 +2327,12 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                      apacket[i] = new PacketPlayOutLightUpdate(new ChunkCoordIntPair(chunk.getPos().x + x, chunk.getPos().z + z), lightEngine, updateLightMask, 0, true);
                  }
              }
@@ -13420,7 +13798,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
  
          int j = 1;
          for (int x = -1; x <= 1; x++) {
-@@ -2281,6 +2387,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2281,6 +2357,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                  entityplayer.playerConnection.sendPacket(packet);
              }
          }
@@ -13428,7 +13806,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
          // Paper end - Fix MC-162253
  
          entityplayer.a(chunk.getPos(), apacket[0], apacket[1]);
-@@ -2356,7 +2463,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2356,7 +2433,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
          // Paper start
          // Replace trackedPlayers Set with a Map. The value is true until the player receives
          // their first update (which is forced to have absolute coordinates), false afterward.
@@ -13437,7 +13815,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
          public Set<EntityPlayer> trackedPlayers = trackedPlayerMap.keySet();
  
          public EntityTracker(Entity entity, int i, int j, boolean flag) {
-@@ -2457,7 +2564,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2457,7 +2534,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                  double vec3d_dy = entityplayer.locY() - this.tracker.locY();
                  double vec3d_dz = entityplayer.locZ() - this.tracker.locZ();
                  // Paper end - remove allocation of Vec3D here
@@ -13446,7 +13824,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
                  boolean flag = vec3d_dx >= (double) (-i) && vec3d_dx <= (double) i && vec3d_dz >= (double) (-i) && vec3d_dz <= (double) i && this.tracker.a(entityplayer); // Paper - remove allocation of Vec3D here
  
                  if (flag) {
-@@ -2467,7 +2574,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2467,7 +2544,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                          ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(this.tracker.chunkX, this.tracker.chunkZ);
                          PlayerChunk playerchunk = PlayerChunkMap.this.getVisibleChunk(chunkcoordintpair.pair());
  
@@ -13455,7 +13833,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
                              flag1 = PlayerChunkMap.b(chunkcoordintpair, entityplayer, false) <= PlayerChunkMap.this.viewDistance;
                          }
                      }
-@@ -2507,7 +2614,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2507,7 +2584,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                  int j = entity.getEntityType().getChunkRange() * 16;
                  j = org.spigotmc.TrackingRange.getEntityTrackingRange(entity, j); // Paper
  
@@ -13465,7 +13843,7 @@ index 300884804bf9ac3fba7c30a04d8adf52e3dd2e3e..d7eede51f1c4ebbe8e00b16efd6331c8
                  }
              }
 diff --git a/src/main/java/net/minecraft/server/level/PlayerInteractManager.java b/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
-index 1511cf54fea53577a2808b5d84417eee834db984..e47a743fd3adc62aa47beec722f49eeaded246bc 100644
+index 4203081692d2e4c43abc47aeb85f42b09acb7eee..238e143277eb75db6d96e1c52db810eb8a9423de 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
 @@ -55,14 +55,29 @@ public class PlayerInteractManager {
@@ -13665,7 +14043,7 @@ index 3c804c7b20a14ea6e510810e2be10c1cc89ff5c1..3738c51b5e673c439d88a7ef7f4614f3
          return new TicketType<>(s, comparator, 0L);
      }
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index ef9b08df58d9d28df6b8ade076d95bf7e5cb1b18..fcf9af44702f34d75185eee0b3259fe0e57001b1 100644
+index 47fbb8df04b2b77e10314666e87eaef621cffb3b..58e61aa19d71011c40c69a691f5644b3e823ad68 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -168,12 +168,13 @@ import org.bukkit.event.server.MapInitializeEvent;
@@ -14408,11 +14786,11 @@ index ef9b08df58d9d28df6b8ade076d95bf7e5cb1b18..fcf9af44702f34d75185eee0b3259fe0
 +                    }
 +                    chunk.a(entity);
 +                    // Tuinity end - gotta be careful here, sync load can teleport entity.
-+                }
+                 }
 +                // Tuinity start
 +                if (entity.inChunk && (oldRegionX != newRegionX || oldRegionZ != newRegionZ)) {
 +                    this.addNavigatorsIfPathingToRegion(entity);
-                 }
++                }
 +                // Tuinity end
              }
  
@@ -14630,6 +15008,19 @@ index ef9b08df58d9d28df6b8ade076d95bf7e5cb1b18..fcf9af44702f34d75185eee0b3259fe0
  
              this.tickingEntities = wasTicking; // Paper
          }
+@@ -2072,8 +2708,11 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+         Optional<VillagePlaceType> optional = VillagePlaceType.b(iblockdata);
+         Optional<VillagePlaceType> optional1 = VillagePlaceType.b(iblockdata1);
+ 
++        // Paper start
++        // Tuinity - oh god not for each block set
+         if (!Objects.equals(optional, optional1)) {
+-            BlockPosition blockposition1 = blockposition.immutableCopy();
++            BlockPosition blockposition1 = blockposition.immutableCopy(); // Tuinity - oh god not for each block set
++            // Paper end
+ 
+             optional.ifPresent((villageplacetype) -> {
+                 this.getMinecraftServer().execute(() -> {
 diff --git a/src/main/java/net/minecraft/server/network/LoginListener.java b/src/main/java/net/minecraft/server/network/LoginListener.java
 index 185667110cd6f566b23546728d20fc79223f3c92..dc98ef48a664d9ee2a302fff8c611fd16dc704b6 100644
 --- a/src/main/java/net/minecraft/server/network/LoginListener.java
@@ -14644,10 +15035,10 @@ index 185667110cd6f566b23546728d20fc79223f3c92..dc98ef48a664d9ee2a302fff8c611fd1
              throw new IllegalStateException("Protocol error", cryptographyexception);
          }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2f7bcbc46 100644
+index b543776da3b799643893984a8c6f29477ed78d4a..159c38618d7745ea513ad179b1217d76c2c4897a 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -540,6 +540,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -542,6 +542,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  double currDeltaZ = toZ - fromZ;
                  double d10 = Math.max(d6 * d6 + d7 * d7 + d8 * d8, (currDeltaX * currDeltaX + currDeltaY * currDeltaY + currDeltaZ * currDeltaZ) - 1);
                  // Paper end - fix large move vectors killing the server
@@ -14660,7 +15051,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
  
  
                  // CraftBukkit start - handle custom speeds and skipped ticks
-@@ -568,7 +574,9 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -570,7 +576,9 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  speed *= 2f; // TODO: Get the speed of the vehicle instead of the player
  
                  // Paper start - Prevent moving into unloaded chunks
@@ -14671,7 +15062,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
                      this.networkManager.sendPacket(new PacketPlayOutVehicleMove(entity));
                      return;
                  }
-@@ -581,12 +589,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -583,12 +591,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      return;
                  }
  
@@ -14690,7 +15081,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
                  double d11 = d7;
  
                  d6 = d3 - entity.locX();
-@@ -600,16 +610,25 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -602,16 +612,25 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  boolean flag1 = false;
  
                  if (d10 > org.spigotmc.SpigotConfig.movedWronglyThreshold) { // Spigot
@@ -14720,7 +15111,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
                      entity.setLocation(d0, d1, d2, f, f1);
                      player.setLocation(d0, d1, d2, this.player.yaw, this.player.pitch); // CraftBukkit
                      this.networkManager.sendPacket(new PacketPlayOutVehicleMove(entity));
-@@ -695,7 +714,32 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -697,7 +716,32 @@ public class PlayerConnection implements PacketListenerPlayIn {
      }
  
      private boolean a(Entity entity) {
@@ -14754,7 +15145,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
      }
  
      @Override
-@@ -1217,7 +1261,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1219,7 +1263,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  }
  
                  if (this.teleportPos != null) {
@@ -14763,7 +15154,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
                          this.A = this.e;
                          this.a(this.teleportPos.x, this.teleportPos.y, this.teleportPos.z, this.player.yaw, this.player.pitch);
                      }
-@@ -1255,6 +1299,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1257,6 +1301,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
                          double currDeltaZ = toZ - prevZ;
                          double d11 = Math.max(d7 * d7 + d8 * d8 + d9 * d9, (currDeltaX * currDeltaX + currDeltaY * currDeltaY + currDeltaZ * currDeltaZ) - 1);
                          // Paper end - fix large move vectors killing the server
@@ -14776,7 +15167,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
  
                          if (this.player.isSleeping()) {
                              if (d11 > 1.0D) {
-@@ -1287,7 +1337,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1289,7 +1339,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                                  speed = player.abilities.walkSpeed * 10f;
                              }
                              // Paper start - Prevent moving into unloaded chunks
@@ -14785,7 +15176,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
                                  this.internalTeleport(this.player.locX(), this.player.locY(), this.player.locZ(), this.player.yaw, this.player.pitch, Collections.emptySet());
                                  return;
                              }
-@@ -1304,11 +1354,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1306,11 +1356,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
                                  }
                              }
  
@@ -14801,7 +15192,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
                              boolean flag = d8 > 0.0D;
  
                              if (this.player.isOnGround() && !packetplayinflying.b() && flag) {
-@@ -1343,6 +1393,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1345,6 +1395,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                              }
  
                              this.player.move(EnumMoveType.PLAYER, new Vec3D(d7, d8, d9));
@@ -14809,7 +15200,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
                              this.player.setOnGround(packetplayinflying.b()); // CraftBukkit - SPIGOT-5810, SPIGOT-5835: reset by this.player.move
                              // Paper start - prevent position desync
                              if (this.teleportPos != null) {
-@@ -1362,12 +1413,23 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1364,12 +1415,23 @@ public class PlayerConnection implements PacketListenerPlayIn {
                              boolean flag1 = false;
  
                              if (!this.player.H() && d11 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.playerInteractManager.isCreative() && this.player.playerInteractManager.getGameMode() != EnumGamemode.SPECTATOR) { // Spigot
@@ -14835,7 +15226,7 @@ index e6ea84ba098b4d77bc68e99862992a10ef4585b5..83ad913e46f44aabb41b7e441cba2ef2
                                  this.a(d0, d1, d2, f, f1);
                              } else {
                                  // CraftBukkit start - fire PlayerMoveEvent
-@@ -1454,6 +1516,26 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1456,6 +1518,26 @@ public class PlayerConnection implements PacketListenerPlayIn {
          }
      }
  
@@ -14879,7 +15270,7 @@ index dc362724ea0cc1b2f9d9ceffff483217b4356c40..70fde7bad2e0a6d7432d8509fdb7c46d
                  protected void initChannel(Channel channel) throws Exception {
                      try {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 2df8e914f66176e22aeddf8b94a83af5ea921d88..0b5cf23932c3c626d8805d4db97d2bbab63634cf 100644
+index f8f0212497ad4fbb1273820a06a4ae6721053b8e..c705bf1e651a764d56b87ebc5a86a938d8bd34bb 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -179,6 +179,7 @@ public abstract class PlayerList {
@@ -14908,7 +15299,7 @@ index 2df8e914f66176e22aeddf8b94a83af5ea921d88..0b5cf23932c3c626d8805d4db97d2bba
          Player player = entity.getBukkitEntity();
          PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.networkManager.getRawAddress()).getAddress());
  
-@@ -943,13 +944,13 @@ public abstract class PlayerList {
+@@ -945,13 +946,13 @@ public abstract class PlayerList {
  
          worldserver1.getChunkProvider().addTicket(TicketType.POST_TELEPORT, new ChunkCoordIntPair(location.getBlockX() >> 4, location.getBlockZ() >> 4), 1, entityplayer.getId()); // Paper
          entityplayer1.forceCheckHighPriority(); // Player
@@ -14924,7 +15315,7 @@ index 2df8e914f66176e22aeddf8b94a83af5ea921d88..0b5cf23932c3c626d8805d4db97d2bba
          entityplayer1.spawnIn(worldserver1);
          entityplayer1.dead = false;
          entityplayer1.playerConnection.teleport(new Location(worldserver1.getWorld(), entityplayer1.locX(), entityplayer1.locY(), entityplayer1.locZ(), entityplayer1.yaw, entityplayer1.pitch));
-@@ -1218,7 +1219,7 @@ public abstract class PlayerList {
+@@ -1220,7 +1221,7 @@ public abstract class PlayerList {
              // Really shouldn't happen...
              backingSet = world != null ? world.players.toArray() : players.toArray();
          } else {
@@ -15509,7 +15900,7 @@ index 85f571a791bce63989890f277857bc7bdeec0cb5..9e4137768c7d8966759324a4b368330c
                  double deltaZ = this.locZ() - player.locZ();
                  double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 21341eeb8148be119fbc1dd370c1beaf70a319e0..d933323d57a2a7ff283408f12d4650699f8177e7 100644
+index 2537c9fcf155253da53ada3829c3caca765f35f4..96cc46a26eef701b0579f3407e67af9176e1743b 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -2973,7 +2973,11 @@ public abstract class EntityLiving extends Entity {
@@ -16414,10 +16805,10 @@ index 575833807ff647f30d7c2b7abcd01701c7dec85b..5dc3670f35b04d933e96c4b42aa9fbcf
              x = MathHelper.floorLong(x * 4096.0D) * (1 / 4096.0D);
              y = MathHelper.floorLong(y * 4096.0D) * (1 / 4096.0D);
 diff --git a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-index ec0956a98c133bcd3d4f92f696c667eab6ff98f1..44038dd278b988508047023107683e5370af54ad 100644
+index c39c50e53549e9cb9d3520bc7e8b7e89cfa20163..5bce47fa8f191bc1d33c04c9865cb0efd492a9a2 100644
 --- a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 +++ b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-@@ -453,6 +453,12 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -458,6 +458,12 @@ public abstract class EntityHuman extends EntityLiving {
          this.activeContainer = this.defaultContainer;
      }
      // Paper end
@@ -17758,7 +18149,7 @@ index 3c25021835d6d8fd112fc89636616bfd744e7f1a..aa49565cd364db3781a110ee138ee1a4
          return this.j.d();
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/Chunk.java b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
-index 0727b12b5ff146b4efa9204bf4f495f2f1aa20b9..df35ae12ecbe88ab396bed9850ef80433ff42fd4 100644
+index 0727b12b5ff146b4efa9204bf4f495f2f1aa20b9..fc07e2014e961da5d97095c4ee6f972e2ece3ec3 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 @@ -137,6 +137,158 @@ public class Chunk implements IChunkAccess {
@@ -17944,7 +18335,7 @@ index 0727b12b5ff146b4efa9204bf4f495f2f1aa20b9..df35ae12ecbe88ab396bed9850ef8043
                      }
                  });
              }
-@@ -266,31 +419,7 @@ public class Chunk implements IChunkAccess {
+@@ -266,31 +419,18 @@ public class Chunk implements IChunkAccess {
  
          // this code handles the chunk sending
          if (!areNeighboursLoaded(bitsetBefore, 1) && areNeighboursLoaded(bitsetAfter, 1)) {
@@ -17973,11 +18364,22 @@ index 0727b12b5ff146b4efa9204bf4f495f2f1aa20b9..df35ae12ecbe88ab396bed9850ef8043
 -                    }
 -                })));
 -            }
-+            chunkMap.playerChunkManager.onChunkSendReady(this.loc.x, this.loc.z); // Tuinity - replace old player chunk loading system
++            // Tuinity start - replace old player chunk loading system
++            chunkProviderServer.serverThreadQueue.execute(() -> {
++                if (!Chunk.this.areNeighboursLoaded(1)) {
++                    return;
++                }
++                Chunk.this.A();
++                if (!Chunk.this.areNeighboursLoaded(1)) {
++                    return;
++                }
++                chunkMap.playerChunkManager.onChunkSendReady(this.loc.x, this.loc.z);
++            });
++            // Tuinity end - replace old player chunk loading system
          }
          // Paper end - no-tick view distance
      }
-@@ -344,6 +473,12 @@ public class Chunk implements IChunkAccess {
+@@ -344,6 +484,12 @@ public class Chunk implements IChunkAccess {
  
      public Chunk(World world, ProtoChunk protochunk) {
          this(world, protochunk.getPos(), protochunk.getBiomeIndex(), protochunk.p(), protochunk.n(), protochunk.o(), protochunk.getInhabitedTime(), protochunk.getSections(), (Consumer) null);
@@ -17990,7 +18392,7 @@ index 0727b12b5ff146b4efa9204bf4f495f2f1aa20b9..df35ae12ecbe88ab396bed9850ef8043
          Iterator iterator = protochunk.y().iterator();
  
          while (iterator.hasNext()) {
-@@ -640,8 +775,9 @@ public class Chunk implements IChunkAccess {
+@@ -640,8 +786,9 @@ public class Chunk implements IChunkAccess {
          entity.chunkX = this.loc.x;
          entity.chunkY = k;
          entity.chunkZ = this.loc.z;
@@ -18002,7 +18404,7 @@ index 0727b12b5ff146b4efa9204bf4f495f2f1aa20b9..df35ae12ecbe88ab396bed9850ef8043
          // Paper start
          if (entity instanceof EntityItem) {
              itemCounts[k]++;
-@@ -679,7 +815,8 @@ public class Chunk implements IChunkAccess {
+@@ -679,7 +826,8 @@ public class Chunk implements IChunkAccess {
              entity.entitySlice = null;
              entity.inChunk = false;
          }
@@ -18012,7 +18414,7 @@ index 0727b12b5ff146b4efa9204bf4f495f2f1aa20b9..df35ae12ecbe88ab396bed9850ef8043
              return;
          }
          if (entity instanceof EntityItem) {
-@@ -866,6 +1003,7 @@ public class Chunk implements IChunkAccess {
+@@ -866,6 +1014,7 @@ public class Chunk implements IChunkAccess {
          // Paper end - neighbour cache
          org.bukkit.Server server = this.world.getServer();
          ((WorldServer)this.world).getChunkProvider().addLoadedChunk(this); // Paper
@@ -18020,7 +18422,7 @@ index 0727b12b5ff146b4efa9204bf4f495f2f1aa20b9..df35ae12ecbe88ab396bed9850ef8043
          if (server != null) {
              /*
               * If it's a new world, the first few chunks are generated inside
-@@ -930,116 +1068,18 @@ public class Chunk implements IChunkAccess {
+@@ -930,116 +1079,18 @@ public class Chunk implements IChunkAccess {
      }
  
      public void a(@Nullable Entity entity, AxisAlignedBB axisalignedbb, List<Entity> list, @Nullable Predicate<? super Entity> predicate) {
@@ -18325,10 +18727,19 @@ index 0fec15e141051863dbf51a2b3e1ace5028cd2fc1..d7757e60402be9939fc2d90ad79b2bb7
  
      public String toString() {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
-index 7bfac4e852c4a6697435647dab173913df6034e9..692658893f9d33938fc4fed854ad31c14c920e95 100644
+index 7bfac4e852c4a6697435647dab173913df6034e9..c90f530b9cf556da950d8f61156159941815bd99 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
-@@ -66,6 +66,54 @@ public class ProtoChunk implements IChunkAccess {
+@@ -54,7 +54,7 @@ public class ProtoChunk implements IChunkAccess {
+     private final Map<BlockPosition, NBTTagCompound> i;
+     private final ChunkSection[] j;
+     private final List<NBTTagCompound> k;
+-    private final List<BlockPosition> l;
++    private final List<BlockPosition> l; private final java.util.concurrent.atomic.AtomicBoolean lightSourcesLocked = new java.util.concurrent.atomic.AtomicBoolean(); // Tuinity - warn when light sources are accessed while locked
+     private final ShortList[] m;
+     private final Map<StructureGenerator<?>, StructureStart<?>> n;
+     private final Map<StructureGenerator<?>, LongSet> o;
+@@ -66,6 +66,73 @@ public class ProtoChunk implements IChunkAccess {
      private volatile boolean u;
      final World world; // Paper - Anti-Xray - Add world // Paper - private -> default
  
@@ -18378,12 +18789,49 @@ index 7bfac4e852c4a6697435647dab173913df6034e9..692658893f9d33938fc4fed854ad31c1
 +        this.blockEmptinessMap = emptinessMap;
 +    }
 +
++    private void checkLightSourceLock() {
++        if (!this.lightSourcesLocked.get()) {
++            return;
++        }
++
++        IllegalStateException thr = new IllegalStateException("Concurrent access of light sources by thread '" + Thread.currentThread().getName() + "'");
++        LOGGER.fatal(thr.getMessage(), thr);
++        throw thr;
++    }
++
++    public void lockLightSources() {
++        if (this.lightSourcesLocked.getAndSet(true)) {
++            throw new IllegalStateException("Light sources is already locked!");
++        }
++    }
++
++    public void releaseLightSources() {
++        this.lightSourcesLocked.set(false);
++    }
 +    // Tuinity end - rewrite light engine
 +
      // Paper start - Anti-Xray - Add world
      @Deprecated public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter) { this(chunkcoordintpair, chunkconverter, null); } // Notice for updates: Please make sure this constructor isn't used anywhere
      public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter, World world) {
-@@ -191,20 +239,17 @@ public class ProtoChunk implements IChunkAccess {
+@@ -170,7 +237,9 @@ public class ProtoChunk implements IChunkAccess {
+     }
+ 
+     public void k(BlockPosition blockposition) {
++        this.checkLightSourceLock(); // Tuinity - make sure we don't access this concurrently
+         this.l.add(blockposition.immutableCopy());
++        this.checkLightSourceLock(); // Tuinity - make sure we don't access this concurrently
+     }
+ 
+     @Nullable
+@@ -185,26 +254,25 @@ public class ProtoChunk implements IChunkAccess {
+                 return iblockdata;
+             } else {
+                 if (iblockdata.f() > 0) {
++                    this.checkLightSourceLock(); // Tuinity - make sure we don't access this concurrently
+                     this.l.add(new BlockPosition((i & 15) + this.getPos().d(), j, (k & 15) + this.getPos().e()));
++                    this.checkLightSourceLock(); // Tuinity - make sure we don't access this concurrently
+                 }
+ 
                  ChunkSection chunksection = this.a(j >> 4);
                  IBlockData iblockdata1 = chunksection.setType(i & 15, j & 15, k & 15, iblockdata);
  
@@ -18398,17 +18846,17 @@ index 7bfac4e852c4a6697435647dab173913df6034e9..692658893f9d33938fc4fed854ad31c1
 +                HeightMap.Type[] enumset = this.getChunkStatus().heightMaps; // Tuinity - reduce iterator creation
                  EnumSet<HeightMap.Type> enumset1 = null;
 -                Iterator iterator = enumset.iterator();
--
--                HeightMap.Type heightmap_type;
 +                // Tuinity - reduce iterator creation
  
+-                HeightMap.Type heightmap_type;
+-
 -                while (iterator.hasNext()) {
 -                    heightmap_type = (HeightMap.Type) iterator.next();
 +                for (HeightMap.Type heightmap_type : enumset) { // Tuinity - reduce iterator creation
                      HeightMap heightmap = (HeightMap) this.f.get(heightmap_type);
  
                      if (heightmap == null) {
-@@ -220,10 +265,9 @@ public class ProtoChunk implements IChunkAccess {
+@@ -220,10 +288,9 @@ public class ProtoChunk implements IChunkAccess {
                      HeightMap.a(this, enumset1);
                  }
  
@@ -18651,7 +19099,7 @@ index 4eaf497d048324a85ce49fc1c6e9559991c20df7..ec2b238480413ba9c123d9ddeaa787d9
  
          BiomeStorage biomestorage = ichunkaccess.getBiomeIndex();
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/IChunkLoader.java b/src/main/java/net/minecraft/world/level/chunk/storage/IChunkLoader.java
-index 890362d28ab9cb760c73fe5014e144fb08ada6b8..21c8530c77161b5f8cfd0bae3126c8fd394dcae2 100644
+index 890362d28ab9cb760c73fe5014e144fb08ada6b8..8c4e87b9404cfe2fedd0c345983f64cad16f32a0 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/IChunkLoader.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/IChunkLoader.java
 @@ -39,13 +39,14 @@ public class IChunkLoader implements AutoCloseable {
@@ -18666,7 +19114,7 @@ index 890362d28ab9cb760c73fe5014e144fb08ada6b8..21c8530c77161b5f8cfd0bae3126c8fd
  
      // CraftBukkit start
      private boolean check(ChunkProviderServer cps, int x, int z) throws IOException {
-+        if (true) return false; // Tuinity - this isn't even needed anymore, light is purged updating to 1.14+, why are we holding up the conversion process reading chunk data off disk
++        if (true) return true; // Tuinity - this isn't even needed anymore, light is purged updating to 1.14+, why are we holding up the conversion process reading chunk data off disk - return true, we need to set light populated to true so the converter recognizes the chunk as being "full"
          ChunkCoordIntPair pos = new ChunkCoordIntPair(x, z);
          if (cps != null) {
              //com.google.common.base.Preconditions.checkState(org.bukkit.Bukkit.isPrimaryThread(), "primary thread"); // Paper - this function is now MT-Safe
@@ -20428,9 +20876,27 @@ index 03b8d67a5f0088c0254b2099f27e8dcae32a6221..fd3333fef4112e6469ccd316ba2c8292
          public void restart() {
              org.spigotmc.RestartCommand.restart();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 62513d3acb930c4c9fa3d875a1fc94bb4d948951..91005e112950d79e1120e5595570970b94cd3c67 100644
+index 80de9f687d9acd7425e7c8a453c2759450869497..29f2c253e420a400736eec54f0e9c80bcc621fa1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -298,7 +298,7 @@ public class CraftWorld implements World {
+     public int getTileEntityCount() {
+         return net.minecraft.server.MCUtil.ensureMain(() -> {
+         // We don't use the full world tile entity list, so we must iterate chunks
+-        Long2ObjectLinkedOpenHashMap<PlayerChunk> chunks = world.getChunkProvider().playerChunkMap.visibleChunks;
++        Long2ObjectLinkedOpenHashMap<PlayerChunk> chunks = world.getChunkProvider().playerChunkMap.updatingChunks.getVisibleMap(); // Tuinity - change updating chunks map
+         int size = 0;
+         for (PlayerChunk playerchunk : chunks.values()) {
+             net.minecraft.world.level.chunk.Chunk chunk = playerchunk.getChunk();
+@@ -317,7 +317,7 @@ public class CraftWorld implements World {
+         return net.minecraft.server.MCUtil.ensureMain(() -> {
+         int ret = 0;
+ 
+-        for (PlayerChunk chunkHolder : world.getChunkProvider().playerChunkMap.visibleChunks.values()) {
++        for (PlayerChunk chunkHolder : world.getChunkProvider().playerChunkMap.updatingChunks.getVisibleMap().values()) { // Tuinity - change updating chunks map
+             if (chunkHolder.getChunk() != null) {
+                 ++ret;
+             }
 @@ -342,6 +342,14 @@ public class CraftWorld implements World {
          this.generator = gen;
  
@@ -20462,7 +20928,28 @@ index 62513d3acb930c4c9fa3d875a1fc94bb4d948951..91005e112950d79e1120e5595570970b
      }
  
      // Paper start
-@@ -505,6 +506,7 @@ public class CraftWorld implements World {
+@@ -470,13 +471,16 @@ public class CraftWorld implements World {
+     public Chunk[] getLoadedChunks() {
+         // Paper start
+         if (Thread.currentThread() != world.getMinecraftWorld().serverThread) {
+-            synchronized (world.getChunkProvider().playerChunkMap.visibleChunks) {
+-                Long2ObjectLinkedOpenHashMap<PlayerChunk> chunks = world.getChunkProvider().playerChunkMap.visibleChunks;
+-                return chunks.values().stream().map(PlayerChunk::getFullChunk).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.Chunk::getBukkitChunk).toArray(Chunk[]::new);
++            // Tuinity start - change updating chunks map
++            Long2ObjectLinkedOpenHashMap<PlayerChunk> chunks;
++            synchronized (world.getChunkProvider().playerChunkMap.updatingChunks) {
++                chunks = world.getChunkProvider().playerChunkMap.updatingChunks.getVisibleMap().clone();
+             }
++            return chunks.values().stream().map(PlayerChunk::getFullChunk).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.Chunk::getBukkitChunk).toArray(Chunk[]::new);
++            // Tuinity end - change updating chunks map
+         }
+         // Paper end
+-        Long2ObjectLinkedOpenHashMap<PlayerChunk> chunks = world.getChunkProvider().playerChunkMap.visibleChunks;
++        Long2ObjectLinkedOpenHashMap<PlayerChunk> chunks = world.getChunkProvider().playerChunkMap.updatingChunks.getVisibleMap(); // Tuinity - change updating chunks map
+         return chunks.values().stream().map(PlayerChunk::getFullChunk).filter(Objects::nonNull).map(net.minecraft.world.level.chunk.Chunk::getBukkitChunk).toArray(Chunk[]::new);
+     }
+ 
+@@ -505,6 +509,7 @@ public class CraftWorld implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (isChunkLoaded(x, z)) {
              world.getChunkProvider().removeTicket(TicketType.PLUGIN, new ChunkCoordIntPair(x, z), 0, Unit.INSTANCE); // Paper
@@ -20470,7 +20957,7 @@ index 62513d3acb930c4c9fa3d875a1fc94bb4d948951..91005e112950d79e1120e5595570970b
          }
  
          return true;
-@@ -718,6 +720,30 @@ public class CraftWorld implements World {
+@@ -718,6 +723,30 @@ public class CraftWorld implements World {
          return ret.entrySet().stream().collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, (entry) -> entry.getValue().build()));
      }
  
@@ -20501,7 +20988,7 @@ index 62513d3acb930c4c9fa3d875a1fc94bb4d948951..91005e112950d79e1120e5595570970b
      @Override
      public boolean isChunkForceLoaded(int x, int z) {
          return getHandle().getForceLoadedChunks().contains(ChunkCoordIntPair.pair(x, z));
-@@ -2587,7 +2613,7 @@ public class CraftWorld implements World {
+@@ -2650,7 +2679,7 @@ public class CraftWorld implements World {
          }
          return this.world.getChunkProvider().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.Chunk chunk = (net.minecraft.world.level.chunk.Chunk) either.left().orElse(null);
@@ -20510,7 +20997,7 @@ index 62513d3acb930c4c9fa3d875a1fc94bb4d948951..91005e112950d79e1120e5595570970b
              return CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }
-@@ -2612,14 +2638,14 @@ public class CraftWorld implements World {
+@@ -2675,14 +2704,14 @@ public class CraftWorld implements World {
              throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
          }
          PlayerChunkMap chunkMap = getHandle().getChunkProvider().playerChunkMap;
@@ -20527,7 +21014,7 @@ index 62513d3acb930c4c9fa3d875a1fc94bb4d948951..91005e112950d79e1120e5595570970b
      }
  
      @Override
-@@ -2628,11 +2654,22 @@ public class CraftWorld implements World {
+@@ -2691,11 +2720,22 @@ public class CraftWorld implements World {
              throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
          }
          PlayerChunkMap chunkMap = getHandle().getChunkProvider().playerChunkMap;

--- a/patches/server/0002-Airplane-Server-Changes.patch
+++ b/patches/server/0002-Airplane-Server-Changes.patch
@@ -684,7 +684,7 @@ index 52c0ab1ce46e1f3233ef746d9bc699356fa9fae4..b480bd3044370b8eb733166f0c4b7373
                  metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {
                      Map<String, Map<String, Integer>> map = new HashMap<>();
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index c56e7fb18f9a56c8025eb70a524f028b5942da37..f39452535b2807a226ada095f5c21b19ea238e5c 100644
+index efc1e42d606e1c9feb1a4871c0714933ae92a1b2..14ac28d4d6b1ab0f0a70dfefc589f7723a1d2e1a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -202,6 +202,15 @@ public class PaperConfig {
@@ -791,10 +791,10 @@ index 0000000000000000000000000000000000000000..89c89e633f14b5820147e734b1b7ad8c
 +}
 diff --git a/src/main/java/gg/airplane/AirplaneConfig.java b/src/main/java/gg/airplane/AirplaneConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a77e628518920e84b03a8a00e1308a9a53a00896
+index 0000000000000000000000000000000000000000..7ec84ef1d1cbb1fabf4c590a2f2c1da3cc181010
 --- /dev/null
 +++ b/src/main/java/gg/airplane/AirplaneConfig.java
-@@ -0,0 +1,99 @@
+@@ -0,0 +1,105 @@
 +package gg.airplane;
 +
 +import co.technove.air.AIR;
@@ -845,42 +845,48 @@ index 0000000000000000000000000000000000000000..a77e628518920e84b03a8a00e1308a9a
 +    }
 +
 +
-+    public static int maximumActivationPrio = 20;
-+    public static int activationDistanceMod = 9;
-+    public static boolean dynamicVillagerBehavior = true;
-+    public static boolean dynamicPiglinBehavior = true;
-+    public static boolean dynamicHoglinBehavior = true;
++    public static int startDistance;
++    public static int startDistanceSquared;
++    public static int maximumActivationPrio;
++    public static int activationDistanceMod;
++    public static boolean dynamicVillagerBehavior;
++    public static boolean dynamicPiglinBehavior;
++    public static boolean dynamicHoglinBehavior;
 +
 +    private static void dynamicActivationRange() {
 +        config.setComment("activation-range", "Optimizes how entities act when", "they're far away from the player");
 +
-+        maximumActivationPrio = config.getInt("activation-range.max-tick-freq", maximumActivationPrio,
++        startDistance = config.getInt("activation-range.start-distance", 12,
++          "This value determines how far away an entity has to be",
++          "from the player to start being effected by DEAR.");
++        startDistanceSquared = startDistance * startDistance;
++        maximumActivationPrio = config.getInt("activation-range.max-tick-freq", 20,
 +          "This value defines how often in ticks, the furthest entity",
 +          "will get their pathfinders and behaviors ticked. 20 = 1s");
-+        activationDistanceMod = config.getInt("activation-range.activation-dist-mod", activationDistanceMod,
++        activationDistanceMod = config.getInt("activation-range.activation-dist-mod", 8,
 +          "This value defines how much distance modifies an entity's",
 +          "tick frequency. freq = (distanceToPlayer^2) / (2^value)",
-+          "If you want further away entities to tick less often, use 8.",
-+          "If you want further away entities to tick more often, try 10.");
++          "If you want further away entities to tick less often, use 7.",
++          "If you want further away entities to tick more often, try 9.");
 +
 +        config.setComment("behavior-activation", "A list of entities to use the dynamic activation range", "to modify how often their behaviors are ticked");
 +
-+        dynamicVillagerBehavior = config.getBoolean("behavior-activation.villager", dynamicVillagerBehavior);
-+        dynamicPiglinBehavior = config.getBoolean("behavior-activation.piglin", dynamicPiglinBehavior);
-+        dynamicHoglinBehavior = config.getBoolean("behavior-activation.hoglin", dynamicHoglinBehavior);
++        dynamicVillagerBehavior = config.getBoolean("behavior-activation.villager", true);
++        dynamicPiglinBehavior = config.getBoolean("behavior-activation.piglin", true);
++        dynamicHoglinBehavior = config.getBoolean("behavior-activation.hoglin", true);
 +    }
 +
 +
-+    public static String profileWebUrl = "https://flare.airplane.gg";
++    public static String profileWebUrl;
 +
 +    private static void profilerOptions() {
 +        config.setComment("flare", "Configures Flare, the built-in profiler");
 +
-+        profileWebUrl = config.getString("flare.url", profileWebUrl, "Sets the server to use for profiles.");
++        profileWebUrl = config.getString("flare.url", "https://flare.airplane.gg", "Sets the server to use for profiles.");
 +    }
 +
 +
-+    public static String accessToken = "";
++    public static String accessToken;
 +
 +    private static void airplaneWebServices() {
 +        config.setComment("web-services", "Options for connecting to Airplane's online utilities");
@@ -1396,11 +1402,159 @@ index 0000000000000000000000000000000000000000..86d6650d174a7794a7ebe793cad033b4
 +    }
 +
 +}
+diff --git a/src/main/java/gg/airplane/structs/FluidDirectionCache.java b/src/main/java/gg/airplane/structs/FluidDirectionCache.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..11279fb136bbaf3e51d9b080a9e283d8ff0cbb47
+--- /dev/null
++++ b/src/main/java/gg/airplane/structs/FluidDirectionCache.java
+@@ -0,0 +1,142 @@
++package gg.airplane.structs;
++
++import it.unimi.dsi.fastutil.HashCommon;
++
++/**
++ * This is a replacement for the cache used in FluidTypeFlowing.
++ * The requirements for the previous cache were:
++ *  - Store 200 entries
++ *  - Look for the flag in the cache
++ *  - If it exists, move to front of cache
++ *  - If it doesn't exist, remove last entry in cache and insert in front
++ *
++ * This class accomplishes something similar, however has a few different
++ * requirements put into place to make this more optimize:
++ *
++ *  - maxDistance is the most amount of entries to be checked, instead
++ *    of having to check the entire list.
++ *  - In combination with that, entries are all tracked by age and how
++ *    frequently they're used. This enables us to remove old entries,
++ *    without constantly shifting any around.
++ *
++ * Usage of the previous map would have to reset the head every single usage,
++ * shifting the entire map. Here, nothing happens except an increment when
++ * the cache is hit, and when it needs to replace an old element only a single
++ * element is modified.
++ */
++public class FluidDirectionCache<T> {
++
++    private static class FluidDirectionEntry<T> {
++        private final T data;
++        private final boolean flag;
++        private short uses = 0;
++        private short age = 0;
++
++        private FluidDirectionEntry(T data, boolean flag) {
++            this.data = data;
++            this.flag = flag;
++        }
++
++        public int getValue() {
++            return this.uses - (this.age >> 1); // age isn't as important as uses
++        }
++
++        public void incrementUses() {
++            if (this.uses < Short.MAX_VALUE) {
++                this.uses++;
++            }
++        }
++
++        public void incrementAge() {
++            if (this.age < Short.MAX_VALUE) {
++                this.age++;
++            }
++        }
++    }
++
++    private final FluidDirectionEntry[] entries;
++    private final int mask;
++    private final int maxDistance; // the most amount of entries to check for a value
++
++    public FluidDirectionCache(int size) {
++        float fill = 0.75f;
++
++        int arraySize = HashCommon.arraySize(size, fill);
++        this.entries = new FluidDirectionEntry[arraySize];
++        this.mask = arraySize - 1;
++        this.maxDistance = Math.max(4, arraySize >> 4);
++    }
++
++    public Boolean getValue(T data) {
++        FluidDirectionEntry curr;
++        int pos;
++
++        if ((curr = this.entries[pos = HashCommon.mix(data.hashCode()) & this.mask]) == null) {
++            return null;
++        } else if (data.equals(curr.data)) {
++            curr.incrementUses();
++            return curr.flag;
++        }
++
++        int checked = 1; // start at 1 because we already checked the first spot above
++
++        while ((curr = this.entries[pos = (pos + 1) & this.mask]) != null) {
++            if (data.equals(curr.data)) {
++                curr.incrementUses();
++                return curr.flag;
++            } else if (++checked >= this.maxDistance) {
++                break;
++            }
++        }
++
++        return null;
++    }
++
++    public void putValue(T data, boolean flag) {
++        FluidDirectionEntry<T> curr;
++        int pos;
++
++        if ((curr = this.entries[pos = HashCommon.mix(data.hashCode()) & this.mask]) == null) {
++            this.entries[pos] = new FluidDirectionEntry<>(data, flag); // add
++            return;
++        } else if (data.equals(curr.data)) {
++            curr.incrementUses();
++            return;
++        }
++
++        int checked = 1; // start at 1 because we already checked the first spot above
++
++        while ((curr = this.entries[pos = (pos + 1) & this.mask]) != null) {
++            if (data.equals(curr.data)) {
++                curr.incrementUses();
++                return;
++            } else if (++checked >= this.maxDistance) {
++                this.forceAdd(data, flag);
++                return;
++            }
++        }
++
++        this.entries[pos] = new FluidDirectionEntry<>(data, flag); // add
++    }
++
++    private void forceAdd(T data, boolean flag) {
++        int expectedPos = HashCommon.mix(data.hashCode()) & this.mask;
++
++        int toRemovePos = expectedPos;
++        FluidDirectionEntry<T> entryToRemove = this.entries[toRemovePos];
++
++        for (int i = expectedPos + 1; i < expectedPos + this.maxDistance; i++) {
++            int pos = i & this.mask;
++            FluidDirectionEntry<T> entry = this.entries[pos];
++            if (entry.getValue() < entryToRemove.getValue()) {
++                toRemovePos = pos;
++                entryToRemove = entry;
++            }
++
++            entry.incrementAge(); // use this as a mechanism to age the other entries
++        }
++
++        // remove the least used/oldest entry
++        this.entries[toRemovePos] = new FluidDirectionEntry(data, flag);
++    }
++}
 diff --git a/src/main/java/net/minecraft/core/BlockPosition.java b/src/main/java/net/minecraft/core/BlockPosition.java
-index 8edc279e7a3fdfb7e10718f1deee34b7e3fb2f28..73ec17dea5d5668e49c9a6ad679bd3a362960c72 100644
+index 8edc279e7a3fdfb7e10718f1deee34b7e3fb2f28..3c51ee00aa53e561c02bb779c7115d8475d70ed7 100644
 --- a/src/main/java/net/minecraft/core/BlockPosition.java
 +++ b/src/main/java/net/minecraft/core/BlockPosition.java
-@@ -438,6 +438,14 @@ public class BlockPosition extends BaseBlockPosition {
+@@ -438,12 +438,26 @@ public class BlockPosition extends BaseBlockPosition {
          public BlockPosition b(int i, int j, int k) {
              return super.b(i, j, k).immutableCopy();
          }
@@ -1415,8 +1569,33 @@ index 8edc279e7a3fdfb7e10718f1deee34b7e3fb2f28..73ec17dea5d5668e49c9a6ad679bd3a3
  
          @Override
          public BlockPosition shift(EnumDirection enumdirection, int i) {
+             return super.shift(enumdirection, i).immutableCopy();
+         }
+ 
++        // Airplane start - mutable shift method
++        public MutableBlockPosition mutableShift(EnumDirection enumdirection, int i) {
++            return this.setValues(this.getX() + enumdirection.getAdjacentX() * i, this.getY() + enumdirection.getAdjacentY() * i, this.getZ() + enumdirection.getAdjacentZ() * i);
++        }
++        // Airplane end
++
+         @Override
+         public BlockPosition a(EnumDirection.EnumAxis enumdirection_enumaxis, int i) {
+             return super.a(enumdirection_enumaxis, i).immutableCopy();
+diff --git a/src/main/java/net/minecraft/core/EnumDirection.java b/src/main/java/net/minecraft/core/EnumDirection.java
+index 7918d830a4aef09c9f517284e83a9376299116ad..0a40df2151bd388b6633a6f50b14f1f41ed4ce62 100644
+--- a/src/main/java/net/minecraft/core/EnumDirection.java
++++ b/src/main/java/net/minecraft/core/EnumDirection.java
+@@ -30,7 +30,7 @@ public enum EnumDirection implements INamable {
+     private final EnumDirection.EnumAxis k;
+     private final EnumDirection.EnumAxisDirection l;
+     private final BaseBlockPosition m;
+-    private static final EnumDirection[] n = values();
++    private static final EnumDirection[] n = values(); public static EnumDirection[] getValues() { return n; } // Airplane - getter
+     private static final Map<String, EnumDirection> o = (Map) Arrays.stream(EnumDirection.n).collect(Collectors.toMap(EnumDirection::m, (enumdirection) -> {
+         return enumdirection;
+     }));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7b0b416c73c8914f3c8c570f2020490ef2babf64..246fcc9b40152964810ceef356ecb2eee3551135 100644
+index 2767a9369ddc922f1d9c7cb6c7acc8270545535a..7b4b9f54510b3a05aad3f7e50e32ee0bf977244a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -1429,11 +1608,11 @@ index 7b0b416c73c8914f3c8c570f2020490ef2babf64..246fcc9b40152964810ceef356ecb2ee
  
      public CrashReport b(CrashReport crashreport) {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index d902efdb8f2d42ea4c3933f7fa76ebe135ee09db..24a46ad36613faa5f5a1a12b70f7af886e1608ae 100644
+index fa7a78549a9bb92b93c305dc16f43a9ace7f6f43..858bd62d2a17c15ee573c5cd607a876d3a99c2b1 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -215,6 +215,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
-         com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
+@@ -216,6 +216,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+         io.papermc.paper.brigadier.PaperBrigadierProviderImpl.INSTANCE.getClass(); // init PaperBrigadierProvider
          // Paper end
          com.tuinity.tuinity.config.TuinityConfig.init((java.io.File) options.valueOf("tuinity-settings")); // Tuinity - Server Config
 +        gg.airplane.AirplaneConfig.load(); // Airplane - config
@@ -1441,8 +1620,21 @@ index d902efdb8f2d42ea4c3933f7fa76ebe135ee09db..24a46ad36613faa5f5a1a12b70f7af88
  
          this.setPVP(dedicatedserverproperties.pvp);
          this.setAllowFlight(dedicatedserverproperties.allowFlight);
+diff --git a/src/main/java/net/minecraft/server/level/ChunkMapDistance.java b/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
+index a5fc023312c99e591fc269999c28a766a46f8849..fb4d006f86229fd093f1a9ea8cab2add0a4cacfa 100644
+--- a/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
++++ b/src/main/java/net/minecraft/server/level/ChunkMapDistance.java
+@@ -215,7 +215,7 @@ public abstract class ChunkMapDistance {
+     public boolean a(PlayerChunkMap playerchunkmap) {
+         com.tuinity.tuinity.util.TickThread.softEnsureTickThread("Cannot tick ChunkMapDistance off of the main-thread");// Tuinity
+         //this.f.a(); // Paper - no longer used
+-        AsyncCatcher.catchOp("DistanceManagerTick"); // Paper
++        //AsyncCatcher.catchOp("DistanceManagerTick"); // Paper // Airplane - leave up to softEnsures
+         //this.g.a(); // Tuinity - no longer used
+         boolean flag = this.ticketLevelPropagator.propagateUpdates(); // Tuinity - replace ticket level propagator
+ 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
-index cb83f1152c52a99d25e4e80cc8bf18c6793e8b50..87c87b9767003652814c3726eece64470dbb69a8 100644
+index fe040615ff03478a20cdf8376f89a6b7d100ba61..207a9c3928aad7c6e89a120b54d87e003ebd232c 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 @@ -1000,6 +1000,7 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -1453,8 +1645,57 @@ index cb83f1152c52a99d25e4e80cc8bf18c6793e8b50..87c87b9767003652814c3726eece6447
              int k = this.world.getGameRules().getInt(GameRules.RANDOM_TICK_SPEED);
              boolean flag2 = world.ticksPerAnimalSpawns != 0L && worlddata.getTime() % world.ticksPerAnimalSpawns == 0L; // CraftBukkit
  
+diff --git a/src/main/java/net/minecraft/server/level/PlayerChunk.java b/src/main/java/net/minecraft/server/level/PlayerChunk.java
+index 86f156587a0939b28c5cf6f64907255c1c4f8b35..516b77edab4d737fa947e051c463bbd65d0e9e49 100644
+--- a/src/main/java/net/minecraft/server/level/PlayerChunk.java
++++ b/src/main/java/net/minecraft/server/level/PlayerChunk.java
+@@ -269,6 +269,23 @@ public class PlayerChunk {
+         return either == null ? null : either.left().orElse(null);
+     }
+ 
++    // Airplane start - update entity ticking on entities
++    private void setEntityTickingReady(boolean isEntityTickingReady) {
++        this.isEntityTickingReady = isEntityTickingReady;
++        Chunk chunk = this.getFullReadyChunk();
++        if (chunk != null) {
++            // update all entities in chunk
++            List<net.minecraft.world.entity.Entity>[] entitySlices = chunk.getEntitySlices();
++            for (int i = 0, entitySlicesLength = entitySlices.length; i < entitySlicesLength; i++) {
++                List<net.minecraft.world.entity.Entity> entitySlice = entitySlices[i];
++                for (net.minecraft.world.entity.Entity entity : entitySlice) {
++                    entity.inEntityTickingChunk = isEntityTickingReady;
++                    entity.lastEntityTickingChunkKey = chunk.coordinateKey;
++                }
++            }
++        }
++    }
++    // Airplane end
+     public final boolean isEntityTickingReady() {
+         return this.isEntityTickingReady;
+     }
+@@ -763,7 +780,10 @@ public class PlayerChunk {
+                 if (either.left().isPresent()) {
+                     // note: Here is a very good place to add callbacks to logic waiting on this.
+                     Chunk entityTickingChunk = either.left().get();
+-                    PlayerChunk.this.isEntityTickingReady = true;
++                    // Airplane start
++                    //PlayerChunk.this.isEntityTickingReady = true;
++                    PlayerChunk.this.setEntityTickingReady(true);
++                    // Airplane end
+ 
+                     // Tuinity start - entity ticking chunk set
+                     PlayerChunk.this.chunkMap.world.getChunkProvider().entityTickingChunks.add(entityTickingChunk);
+@@ -777,7 +797,7 @@ public class PlayerChunk {
+         }
+ 
+         if (flag6 && !flag7) {
+-            this.entityTickingFuture.complete(PlayerChunk.UNLOADED_CHUNK); this.isEntityTickingReady = false; // Paper - cache chunk ticking stage
++            this.entityTickingFuture.complete(PlayerChunk.UNLOADED_CHUNK); this.setEntityTickingReady(false); /*this.isEntityTickingReady = false;*/ // Paper - cache chunk ticking stage // Airplane
+             this.entityTickingFuture = PlayerChunk.UNLOADED_CHUNK_FUTURE;
+             // Tuinity start - entity ticking chunk set
+             Chunk chunkIfCached = this.getFullChunkIfCached();
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index d7eede51f1c4ebbe8e00b16efd6331c87db53bb4..bc18b9c3aac4c5feeb1603554e0ac009af9b457e 100644
+index b28995ecfd7f45e6b6197be96c418aa0d05d3383..914c7a1b18151f29183cfe9474313ce18e7c4ae2 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -705,7 +705,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -1489,7 +1730,7 @@ index d7eede51f1c4ebbe8e00b16efd6331c87db53bb4..bc18b9c3aac4c5feeb1603554e0ac009
  
          return Math.max(Math.abs(k), Math.abs(l));
      }
-@@ -2571,11 +2577,17 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2541,11 +2547,17 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                      boolean flag1 = this.tracker.attachedToPlayer;
  
                      if (!flag1) {
@@ -1509,7 +1750,7 @@ index d7eede51f1c4ebbe8e00b16efd6331c87db53bb4..bc18b9c3aac4c5feeb1603554e0ac009
                          }
                      }
  
-@@ -2605,8 +2617,10 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2575,8 +2587,10 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
          }
  
          private int b() {
@@ -1521,7 +1762,7 @@ index d7eede51f1c4ebbe8e00b16efd6331c87db53bb4..bc18b9c3aac4c5feeb1603554e0ac009
              Iterator iterator = collection.iterator();
  
              while (iterator.hasNext()) {
-@@ -2618,6 +2632,8 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2588,6 +2602,8 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                      i = j;
                  }
              }
@@ -1531,14 +1772,24 @@ index d7eede51f1c4ebbe8e00b16efd6331c87db53bb4..bc18b9c3aac4c5feeb1603554e0ac009
              return this.a(i);
          }
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94cf166e7e3 100644
+index 58e61aa19d71011c40c69a691f5644b3e823ad68..e159a08b3cde339bf95d8b3ded4c35511451879f 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
-@@ -1083,11 +1083,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1083,11 +1083,22 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  // CraftBukkit end */
  
                  gameprofilerfiller.enter("checkDespawn");
-+                boolean entityTickingChunk = false; if (!entity.dead) entityTickingChunk = this.getChunkProvider().isInEntityTickingChunk(entity); // Airplane - check once, chunks won't unload ticking entities
++                // Airplane start
++                boolean entityTickingChunk = false;
++                if (!entity.dead) {
++                    long key = MCUtil.getCoordinateKey(entity);
++                    if (entity.lastEntityTickingChunkKey != key) {
++                        entity.lastEntityTickingChunkKey = key;
++                        entity.inEntityTickingChunk = this.getChunkProvider().isInEntityTickingChunk(entity);
++                    }
++                    entityTickingChunk = entity.inEntityTickingChunk;
++                }
++                // Airplane end
                  if (!entity.dead) {
                      entity.checkDespawn();
                      // Tuinity start - optimise notify()
@@ -1548,7 +1799,7 @@ index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94c
                              this.updateNavigatorsInRegion(entity);
                          }
                      } else {
-@@ -1107,7 +1108,28 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1107,7 +1118,28 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
                  gameprofilerfiller.enter("tick");
                  if (!entity.dead && !(entity instanceof EntityComplexPart)) {
@@ -1577,7 +1828,7 @@ index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94c
                  }
  
                  gameprofilerfiller.exit();
-@@ -1117,7 +1139,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1117,7 +1149,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                      this.entitiesById.remove(entity.getId()); // Tuinity
                      this.unregisterEntity(entity);
                  } else if (entity.inChunk && entity.valid) { // Tuinity start - optimise notify()
@@ -1586,7 +1837,7 @@ index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94c
                          this.updateNavigatorsInRegion(entity);
                      }
                  } else {
-@@ -1202,6 +1224,8 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1202,6 +1234,8 @@ public class WorldServer extends World implements GeneratorAccessSeed {
      private final BiomeBase[] biomeBaseCache = new BiomeBase[1];
      // Tuinity end - optimise chunk ice snow ticking
  
@@ -1595,7 +1846,7 @@ index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94c
      public void a(Chunk chunk, int i) { final int randomTickSpeed = i; // Paper
          ChunkCoordIntPair chunkcoordintpair = chunk.getPos();
          boolean flag = this.isRaining();
-@@ -1212,7 +1236,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1212,7 +1246,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          gameprofilerfiller.enter("thunder");
          final BlockPosition.MutableBlockPosition blockposition = this.chunkTickMutablePosition; // Paper - use mutable to reduce allocation rate, final to force compile fail on change
  
@@ -1604,7 +1855,7 @@ index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94c
              blockposition.setValues(this.a(this.a(j, 0, k, 15))); // Paper
              if (this.isRainingAt(blockposition)) {
                  DifficultyDamageScaler difficultydamagescaler = this.getDamageScaler(blockposition);
-@@ -1236,7 +1260,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1236,7 +1270,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          }
  
          gameprofilerfiller.exitEnter("iceandsnow");
@@ -1613,7 +1864,7 @@ index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94c
              // Paper start - optimise chunk ticking
              // Tuinity start - optimise chunk ice snow ticking
              BiomeBase[] biomeCache = this.biomeBaseCache;
-@@ -1415,7 +1439,9 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1415,7 +1449,9 @@ public class WorldServer extends World implements GeneratorAccessSeed {
      }
      // Tuinity end - log detailed entity tick information
  
@@ -1624,7 +1875,7 @@ index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94c
          // Tuinity start - log detailed entity tick information
          com.tuinity.tuinity.util.TickThread.ensureTickThread("Cannot tick an entity off-main");
          try {
-@@ -1423,7 +1449,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1423,7 +1459,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  currentlyTickingEntity.lazySet(entity);
              }
              // Tuinity end - log detailed entity tick information
@@ -1633,7 +1884,7 @@ index fcf9af44702f34d75185eee0b3259fe0e57001b1..d13c6f4c368ca6fe3326b66d4c3ef94c
              this.chunkCheck(entity);
          } else {
              ++TimingHistory.entityTicks; // Paper - timings
-@@ -1449,9 +1475,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1449,9 +1485,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  ++entity.ticksLived;
                  GameProfilerFiller gameprofilerfiller = this.getMethodProfiler();
  
@@ -1677,19 +1928,70 @@ index cc566784c7dd21cc2c44e0f351347f657e57ddcf..e9e7fcf2b63febe2a7d055826fabb86b
          return d0 == 0.0D ? 0 : (d0 > 0.0D ? 1 : -1);
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index feab0ae1930b5271fe0d06a40c180317dcbc9d1d..c6b4af810fe3bda7797ab94316b2357178c9cd49 100644
+index feab0ae1930b5271fe0d06a40c180317dcbc9d1d..5ac2811c88370a55f055c791baa3804fc9a107a8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -289,6 +289,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -289,6 +289,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public void inactiveTick() { }
      // Spigot end
      public boolean shouldBeRemoved; // Paper
 +    // Airplane start
 +    public int activatedPriority = gg.airplane.AirplaneConfig.maximumActivationPrio; // golf score
++    public boolean inEntityTickingChunk = false;
++    public long lastEntityTickingChunkKey = Long.MIN_VALUE;
 +    // Airplane end
  
      public float getBukkitYaw() {
          return this.yaw;
+@@ -316,10 +321,39 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+         this.isLegacyTrackingEntity = isLegacyTrackingEntity;
+     }
+ 
++    // Airplane start - behavior of getAllPassengers + getting bigger range
++    private org.spigotmc.TrackingRange.TrackingRangeType getBiggestRangeOfPassengers(net.minecraft.server.level.PlayerChunkMap chunkMap, int[] range, Entity entity) {
++        org.spigotmc.TrackingRange.TrackingRangeType type = null;
++
++        for (int i = 0; i < entity.passengers.size(); i++) {
++            Entity passenger = entity.passengers.get(i);
++            org.spigotmc.TrackingRange.TrackingRangeType passengerType = passenger.trackingRangeType;
++            int passengerRange = chunkMap.getEntityTrackerRange(passengerType.ordinal());
++            if (passengerRange > range[0]) {
++                type = passengerType;
++                range[0] = passengerRange;
++            }
++
++            org.spigotmc.TrackingRange.TrackingRangeType childType = this.getBiggestRangeOfPassengers(chunkMap, range, passenger);
++            if (childType != null) {
++                type = childType;
++            }
++        }
++
++        return type;
++    }
++    // Airplane end
++
+     public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> getPlayersInTrackRange() {
++        // Airplane start - replicate behavior of getAllPassengers to skip creating hashset
++        /*
+         Collection<Entity> passengers = this.getAllPassengers();
++        */
+         net.minecraft.server.level.PlayerChunkMap chunkMap = ((WorldServer)this.world).getChunkProvider().playerChunkMap;
+         org.spigotmc.TrackingRange.TrackingRangeType type = this.trackingRangeType;
++        type = this.getBiggestRangeOfPassengers(chunkMap, new int[]{chunkMap.getEntityTrackerRange(type.ordinal())}, this);
++        if (type == null) type = this.trackingRangeType;
++        /*
+         int range = chunkMap.getEntityTrackerRange(type.ordinal());
+ 
+         for (Entity passenger : passengers) {
+@@ -330,6 +364,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+                 range = passengerRange;
+             }
+         }
++         */
++        // Airplane end
+ 
+         return chunkMap.playerEntityTrackerTrackMaps[type.ordinal()].getObjectsInRange(MCUtil.getCoordinateKey(this));
+     }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 index aae13c2e6c2a30b69c33417932c6a4d0aefeb7f5..f4440a5c4aedb1d7d303517f86a07c856dd1309b 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
@@ -1720,7 +2022,7 @@ index aae13c2e6c2a30b69c33417932c6a4d0aefeb7f5..f4440a5c4aedb1d7d303517f86a07c85
          this.world.getMethodProfiler().exit();
          this.world.getMethodProfiler().enter("navigation");
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index d933323d57a2a7ff283408f12d4650699f8177e7..5c983a441cd2a06eae6e79bc07ba5440d294574b 100644
+index 96cc46a26eef701b0579f3407e67af9176e1743b..74f80b6af18c0b91d9613384ca6bafd9c89f23a4 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -111,6 +111,7 @@ import net.minecraft.world.phys.AxisAlignedBB;
@@ -1827,7 +2129,7 @@ index bc8786e2aaeab4dbae4e9c7666ad816bc5bfac3f..09133c5822bc1386bc3d8a5f3c941964
  
          this.g.long2ObjectEntrySet().removeIf((entry) -> {
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/PathfinderGoalSelector.java b/src/main/java/net/minecraft/world/entity/ai/goal/PathfinderGoalSelector.java
-index 637928664f8c7b1c694a234e507c20724294e450..f303c5d6b2e55fc9fd8b49ec21121805e7351034 100644
+index 637928664f8c7b1c694a234e507c20724294e450..02e8288473138dcea008d6157318758e8d7ee3be 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/PathfinderGoalSelector.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/goal/PathfinderGoalSelector.java
 @@ -44,9 +44,14 @@ public class PathfinderGoalSelector {
@@ -1838,7 +2140,7 @@ index 637928664f8c7b1c694a234e507c20724294e450..f303c5d6b2e55fc9fd8b49ec21121805
 -        incRate();
 -        return getCurRate() % getTickRate() == 0;
 +    public boolean inactiveTick(int tickRate) { // Airplane - take tick rate
-+        tickRate = Math.max(tickRate, getTickRate()); // Airplane
++        tickRate = Math.min(tickRate, getTickRate()); // Airplane
 +        if (this.curRate++ % tickRate != 0) { // Airplane - use tick rate / increment curRate every tick
 +            //incRate();
 +            return false;
@@ -2063,7 +2365,7 @@ index 2d0b83923d58cc7b6918b4e2ff2bece13ca26899..d8028675fc82883d716bcfb44431ca6a
          if (this.bF) {
              this.bF = false;
 diff --git a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-index 44038dd278b988508047023107683e5370af54ad..ad85dda5c50b797904824a08513fbcec042128ea 100644
+index 5bce47fa8f191bc1d33c04c9865cb0efd492a9a2..5f9e64df007ebc40f7bcb50be495b10e51d5b87a 100644
 --- a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 +++ b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 @@ -162,7 +162,8 @@ public abstract class EntityHuman extends EntityLiving {
@@ -2076,7 +2378,7 @@ index 44038dd278b988508047023107683e5370af54ad..ad85dda5c50b797904824a08513fbcec
      private ItemStack bL;
      private final ItemCooldown bM;
      @Nullable
-@@ -1828,7 +1829,12 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1840,7 +1841,12 @@ public abstract class EntityHuman extends EntityLiving {
  
      @Override
      public IChatBaseComponent getDisplayName() {
@@ -2494,6 +2796,18 @@ index af01f5d635eada7175b9d7fdb47a65530686a539..51e6cd6119465f9fd638507299797144
      }
      // Paper start - Prevent armor stands from doing entity lookups
      @Override
+diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
+index 596b4597313b87296d39027b13555b5ad1cba9e6..f8a982add50862f1bc977f3039e7e9aeed9138ae 100644
+--- a/src/main/java/net/minecraft/world/level/block/Block.java
++++ b/src/main/java/net/minecraft/world/level/block/Block.java
+@@ -392,6 +392,7 @@ public class Block extends BlockBase implements IMaterial {
+         return this.d;
+     }
+ 
++    /** currently seems to only return true for MOVING_PISTON and SCAFFOLDING */ public boolean isComplexHitbox() { return this.o(); } // Airplane - OBFHELPER
+     public boolean o() {
+         return this.aA;
+     }
 diff --git a/src/main/java/net/minecraft/world/level/block/BlockDirtSnowSpreadable.java b/src/main/java/net/minecraft/world/level/block/BlockDirtSnowSpreadable.java
 index 712596420af83e6e1b9d147ae2fd8d8a1f36e1b9..9c29fa3efac7e16df81b8a44934e3286bb37f1f6 100644
 --- a/src/main/java/net/minecraft/world/level/block/BlockDirtSnowSpreadable.java
@@ -2513,8 +2827,30 @@ index 712596420af83e6e1b9d147ae2fd8d8a1f36e1b9..9c29fa3efac7e16df81b8a44934e3286
  
                      if (worldserver.getType(blockposition1).a(Blocks.DIRT) && c(iblockdata1, (IWorldReader) worldserver, blockposition1)) {
                          org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockSpreadEvent(worldserver, blockposition, blockposition1, (IBlockData) iblockdata1.set(BlockDirtSnowSpreadable.a, worldserver.getType(blockposition1.up()).a(Blocks.SNOW))); // CraftBukkit
+diff --git a/src/main/java/net/minecraft/world/level/block/BlockFire.java b/src/main/java/net/minecraft/world/level/block/BlockFire.java
+index 70c32b7a53a1107cced3491ebac19b0eaf4fec2e..3f3e241f3b24d9df9d57760c5515ff021718065a 100644
+--- a/src/main/java/net/minecraft/world/level/block/BlockFire.java
++++ b/src/main/java/net/minecraft/world/level/block/BlockFire.java
+@@ -340,13 +340,15 @@ public class BlockFire extends BlockFireAbstract {
+             return 0;
+         } else {
+             int i = 0;
+-            EnumDirection[] aenumdirection = EnumDirection.values();
++            EnumDirection[] aenumdirection = EnumDirection.getValues(); // Airplane - don't allocate new array here
+             int j = aenumdirection.length;
+ 
++            BlockPosition.MutableBlockPosition copy = new BlockPosition.MutableBlockPosition(); // Airplane - single allocation for this method
+             for (int k = 0; k < j; ++k) {
++                copy.setValues(blockposition); // Airplane - reset values
+                 EnumDirection enumdirection = aenumdirection[k];
+                 // Paper start
+-                IBlockData iblockdata = iworldreader.getTypeIfLoaded(blockposition.shift(enumdirection));
++                IBlockData iblockdata = iworldreader.getTypeIfLoaded(copy.mutableShift(enumdirection, 1)); // Airplane - mutable shift
+                 if (iblockdata == null) {
+                     continue;
+                 }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/Chunk.java b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
-index df35ae12ecbe88ab396bed9850ef80433ff42fd4..7474c070598bc093e06f02f19d49f3a6fa6b3d4e 100644
+index fc07e2014e961da5d97095c4ee6f972e2ece3ec3..9ba7c5080ce0cacf438bdd6e11f75cb34fbc5759 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 @@ -99,6 +99,18 @@ public class Chunk implements IChunkAccess {
@@ -2544,6 +2880,17 @@ index df35ae12ecbe88ab396bed9850ef80433ff42fd4..7474c070598bc093e06f02f19d49f3a6
      }
  
      public org.bukkit.Chunk bukkitChunk;
+@@ -786,6 +799,10 @@ public class Chunk implements IChunkAccess {
+         entity.chunkX = this.loc.x;
+         entity.chunkY = k;
+         entity.chunkZ = this.loc.z;
++        // Airplane start
++        entity.inEntityTickingChunk = this.world.getChunkProvider().isInEntityTickingChunk(entity);
++        entity.lastEntityTickingChunkKey = this.coordinateKey;
++        // Airplane end
+         this.entities.add(entity); // Tuinity
+         this.entitySlices[k].add(entity);  // Tuinity
+         this.entitySlicesManager.addEntity(entity, k); // Tuinity
 diff --git a/src/main/java/net/minecraft/world/level/chunk/DataPaletteBlock.java b/src/main/java/net/minecraft/world/level/chunk/DataPaletteBlock.java
 index a6937366cd9c9d708edb5cd1ab3ac096e7b2032e..a579c5bf9e20c74aa3bf8ef6bc00576409805ca6 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/DataPaletteBlock.java
@@ -2595,6 +2942,94 @@ index ec2b238480413ba9c123d9ddeaa787d9520e1b74..bf96f9e538fc29ca914536e8a7ce727e
                  }
  
                  if (nibblearray != null && !nibblearray.c()) {
+diff --git a/src/main/java/net/minecraft/world/level/material/FluidTypeFlowing.java b/src/main/java/net/minecraft/world/level/material/FluidTypeFlowing.java
+index 6bb4ec00e40795ced73648fefcd1f5027e0113cd..b14b0134b42aa6d1eb285aa453ec6067cc702878 100644
+--- a/src/main/java/net/minecraft/world/level/material/FluidTypeFlowing.java
++++ b/src/main/java/net/minecraft/world/level/material/FluidTypeFlowing.java
+@@ -45,6 +45,8 @@ public abstract class FluidTypeFlowing extends FluidType {
+ 
+     public static final BlockStateBoolean FALLING = BlockProperties.i;
+     public static final BlockStateInteger LEVEL = BlockProperties.at;
++    // Airplane start - use our own threadlocal cache
++    /*
+     private static final ThreadLocal<Object2ByteLinkedOpenHashMap<Block.a>> e = ThreadLocal.withInitial(() -> {
+         Object2ByteLinkedOpenHashMap<Block.a> object2bytelinkedopenhashmap = new Object2ByteLinkedOpenHashMap<Block.a>(200) {
+             protected void rehash(int i) {}
+@@ -53,6 +55,13 @@ public abstract class FluidTypeFlowing extends FluidType {
+         object2bytelinkedopenhashmap.defaultReturnValue((byte) 127);
+         return object2bytelinkedopenhashmap;
+     });
++     */
++    private static final ThreadLocal<gg.airplane.structs.FluidDirectionCache<Block.a>> localFluidDirectionCache = ThreadLocal.withInitial(() -> {
++        // Airplane todo - mess with this number for performance
++        //  with 1024 it seems very infrequent on a small world that it has to remove old entries
++        return new gg.airplane.structs.FluidDirectionCache<>(1024);
++    });
++    // Airplane end
+     private final Map<Fluid, VoxelShape> f = Maps.newIdentityHashMap();
+ 
+     public FluidTypeFlowing() {}
+@@ -240,6 +249,8 @@ public abstract class FluidTypeFlowing extends FluidType {
+     }
+ 
+     private boolean a(EnumDirection enumdirection, IBlockAccess iblockaccess, BlockPosition blockposition, IBlockData iblockdata, BlockPosition blockposition1, IBlockData iblockdata1) {
++        // Airplane start - modify to use our cache
++        /*
+         Object2ByteLinkedOpenHashMap object2bytelinkedopenhashmap;
+ 
+         if (!iblockdata.getBlock().o() && !iblockdata1.getBlock().o()) {
+@@ -247,9 +258,16 @@ public abstract class FluidTypeFlowing extends FluidType {
+         } else {
+             object2bytelinkedopenhashmap = null;
+         }
++         */
++        gg.airplane.structs.FluidDirectionCache<Block.a> cache = null;
++
++        if (!iblockdata.getBlock().isComplexHitbox() && !iblockdata1.getBlock().isComplexHitbox()) {
++            cache = localFluidDirectionCache.get();
++        }
+ 
+         Block.a block_a;
+ 
++        /*
+         if (object2bytelinkedopenhashmap != null) {
+             block_a = new Block.a(iblockdata, iblockdata1, enumdirection);
+             byte b0 = object2bytelinkedopenhashmap.getAndMoveToFirst(block_a);
+@@ -260,11 +278,22 @@ public abstract class FluidTypeFlowing extends FluidType {
+         } else {
+             block_a = null;
+         }
++         */
++        if (cache != null) {
++            block_a = new Block.a(iblockdata, iblockdata1, enumdirection);
++            Boolean flag = cache.getValue(block_a);
++            if (flag != null) {
++                return flag;
++            }
++        } else {
++            block_a = null;
++        }
+ 
+         VoxelShape voxelshape = iblockdata.getCollisionShape(iblockaccess, blockposition);
+         VoxelShape voxelshape1 = iblockdata1.getCollisionShape(iblockaccess, blockposition1);
+         boolean flag = !VoxelShapes.b(voxelshape, voxelshape1, enumdirection);
+ 
++        /*
+         if (object2bytelinkedopenhashmap != null) {
+             if (object2bytelinkedopenhashmap.size() == 200) {
+                 object2bytelinkedopenhashmap.removeLastByte();
+@@ -272,6 +301,11 @@ public abstract class FluidTypeFlowing extends FluidType {
+ 
+             object2bytelinkedopenhashmap.putAndMoveToFirst(block_a, (byte) (flag ? 1 : 0));
+         }
++         */
++        if (cache != null) {
++            cache.putValue(block_a, flag);
++        }
++        // Airplane end
+ 
+         return flag;
+     }
 diff --git a/src/main/java/net/minecraft/world/level/storage/loot/LootTableInfo.java b/src/main/java/net/minecraft/world/level/storage/loot/LootTableInfo.java
 index 95d0c9f22d79194ca83ca6f6a8e6d91180a3c8da..20cc04be75ab202d4c4ee9a07e9876ceff8422ca 100644
 --- a/src/main/java/net/minecraft/world/level/storage/loot/LootTableInfo.java
@@ -2725,7 +3160,7 @@ index 001b1e5197eaa51bfff9031aa6c69876c9a47960..1788d79ea489e446d3d9f541693d4ba3
  
          if (stream != null) {
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 5c2eaca0bc63c7880ee928aba6a24761737aa649..6c4c4580faef39e48de5af4db003cf2e3b8a99b5 100644
+index 5c2eaca0bc63c7880ee928aba6a24761737aa649..8b36ca5062f8e0e8bd58aa506e91704a747de81b 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -47,6 +47,9 @@ import net.minecraft.world.entity.schedule.Activity;
@@ -2756,23 +3191,19 @@ index 5c2eaca0bc63c7880ee928aba6a24761737aa649..6c4c4580faef39e48de5af4db003cf2e
      {
          // Paper start
          Entity[] rawData = chunk.entities.getRawData();
-@@ -249,11 +252,19 @@ public class ActivationRange
+@@ -249,6 +252,15 @@ public class ActivationRange
              //for ( Entity entity : (Collection<Entity>) slice )
              // Paper end
              {
 +                // Airplane start
 +                Vec3D entityVec = entity.getPositionVector();
 +                double diffX = playerVec.x - entityVec.x, diffY = playerVec.y - entityVec.y, diffZ = playerVec.z - entityVec.z;
-+                int priority = Math.max(1, (int) (diffX * diffX + diffY * diffY + diffZ * diffZ) >> gg.airplane.AirplaneConfig.activationDistanceMod);
++                int squaredDistance = (int) (diffX * diffX + diffY * diffY + diffZ * diffZ);
++                entity.activatedPriority = squaredDistance > gg.airplane.AirplaneConfig.startDistanceSquared ?
++                  Math.max(1, Math.min(squaredDistance >> gg.airplane.AirplaneConfig.activationDistanceMod, gg.airplane.AirplaneConfig.maximumActivationPrio)) :
++                  1;
++                // Airplane end
++
                  if (MinecraftServer.currentTick > entity.activatedTick) {
                      if (entity.defaultActivationState || entity.activationType.boundingBox.c(entity.getBoundingBox())) { // Paper
                          entity.activatedTick = MinecraftServer.currentTick;
-                     }
-+                    entity.activatedPriority = Math.min(gg.airplane.AirplaneConfig.maximumActivationPrio, priority);
-+                } else {
-+                    entity.activatedPriority = Math.min(gg.airplane.AirplaneConfig.maximumActivationPrio, Math.min(priority, entity.activatedPriority));
-                 }
-+                // Airplane end
-             }
-         }
-     }

--- a/patches/server/0003-Multithreaded-entity-tracking.patch
+++ b/patches/server/0003-Multithreaded-entity-tracking.patch
@@ -42,10 +42,10 @@ index be408aebbccbda46e8aa82ef337574137cfa0096..739839314fd8a88b5fca8b9678e1df07
      private final boolean threadRestricted;
  
 diff --git a/src/main/java/gg/airplane/AirplaneConfig.java b/src/main/java/gg/airplane/AirplaneConfig.java
-index a77e628518920e84b03a8a00e1308a9a53a00896..5a20ad857b7c550281000e8d94dac78d72591f31 100644
+index 7ec84ef1d1cbb1fabf4c590a2f2c1da3cc181010..b9118cc08ac38e0813d0677700d3d7dcf9b74159 100644
 --- a/src/main/java/gg/airplane/AirplaneConfig.java
 +++ b/src/main/java/gg/airplane/AirplaneConfig.java
-@@ -96,4 +96,17 @@ public class AirplaneConfig {
+@@ -102,4 +102,17 @@ public class AirplaneConfig {
      }
  
  
@@ -197,7 +197,7 @@ index 0000000000000000000000000000000000000000..4419fbe94041f4b8a0ea848880798289
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
-index 87c87b9767003652814c3726eece64470dbb69a8..dc1b7db4d39d4dfa65d60e5a059d3b94def6cf62 100644
+index 207a9c3928aad7c6e89a120b54d87e003ebd232c..424cd048f905cd0ed3f7a4545a26ffde8da1f91f 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 @@ -388,7 +388,7 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -210,7 +210,7 @@ index 87c87b9767003652814c3726eece64470dbb69a8..dc1b7db4d39d4dfa65d60e5a059d3b94
  
      public ChunkProviderServer(WorldServer worldserver, Convertable.ConversionSession convertable_conversionsession, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, ChunkGenerator chunkgenerator, int i, boolean flag, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier) {
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 62b95dcba8606330fbb3239e74c5eaf8baa3c51d..fd6dbbf619b828c4ef3d00f8dc30d3893007db7b 100644
+index fb61b6ac167b34486282a24e598020fb96081f28..b2e21e7034ad83a4ba1c99f860be5a0f5ee6a75f 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -182,7 +182,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -316,22 +316,22 @@ index 67ca28463f5add7c18f7f16b918c3f36f8feeeda..37e64e24ca3a90370cdf12e5ff9cd1fc
          if (this.tracker instanceof EntityPlayer) {
              ((EntityPlayer) this.tracker).playerConnection.sendPacket(packet);
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index bc18b9c3aac4c5feeb1603554e0ac009af9b457e..c9d6ddd8874195c07b3573c6b1f61ffdcff2dddd 100644
+index 914c7a1b18151f29183cfe9474313ce18e7c4ae2..737851cde7752e7cccf226f1868a38d6411bfb31 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -791,6 +791,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-         return (PlayerChunk) (this.hasPendingVisibleUpdate ? this.pendingVisibleChunks.get(i) : ((ProtectedVisibleChunksMap)this.visibleChunks).safeGet(i));
-         // Paper end
+@@ -769,6 +769,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         return this.updatingChunks.getVisibleAsync(i);
+         // Tuinity end - Don't copy
      }
 +    // Airplane start - since neither map can be updated during tracker tick, it's safe to allow direct retrieval here
 +    private PlayerChunk trackerGetVisibleChunk(long i) {
-+        return this.hasPendingVisibleUpdate ? this.pendingVisibleChunks.get(i) : ((ProtectedVisibleChunksMap) this.visibleChunks).safeGet(i);
++        return this.updatingChunks.getVisibleAsync(i);
 +    }
 +    // Airplane end
  
      protected final IntSupplier getPrioritySupplier(long i) { return c(i); } // Paper - OBFHELPER
      protected IntSupplier c(long i) {
-@@ -2194,10 +2199,30 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -2164,10 +2169,30 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          entity.tracker = null; // Paper - We're no longer tracked
      }
  
@@ -362,7 +362,7 @@ index bc18b9c3aac4c5feeb1603554e0ac009af9b457e..c9d6ddd8874195c07b3573c6b1f61ffd
              com.tuinity.tuinity.util.maplist.IteratorSafeOrderedReferenceSet.Iterator<Chunk> iterator = this.world.getChunkProvider().entityTickingChunks.iterator();
              try {
              while (iterator.hasNext()) {
-@@ -2463,7 +2488,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2433,7 +2458,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
      public class EntityTracker {
  
          final EntityTrackerEntry trackerEntry; // Paper - private -> package private
@@ -371,7 +371,7 @@ index bc18b9c3aac4c5feeb1603554e0ac009af9b457e..c9d6ddd8874195c07b3573c6b1f61ffd
          private final int trackingDistance;
          private SectionPosition e;
          // Paper start
-@@ -2482,7 +2507,9 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2452,7 +2477,9 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
          // Paper start - use distance map to optimise tracker
          com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> lastTrackerCandidates;
  
@@ -382,7 +382,7 @@ index bc18b9c3aac4c5feeb1603554e0ac009af9b457e..c9d6ddd8874195c07b3573c6b1f61ffd
              com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> oldTrackerCandidates = this.lastTrackerCandidates;
              this.lastTrackerCandidates = newTrackerCandidates;
  
-@@ -2523,7 +2550,13 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2493,7 +2520,13 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
              return this.tracker.getId();
          }
  
@@ -397,7 +397,7 @@ index bc18b9c3aac4c5feeb1603554e0ac009af9b457e..c9d6ddd8874195c07b3573c6b1f61ffd
              Iterator iterator = this.trackedPlayers.iterator();
  
              while (iterator.hasNext()) {
-@@ -2535,6 +2568,12 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2505,6 +2538,12 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
          }
  
          public void broadcastIncludingSelf(Packet<?> packet) {
@@ -410,7 +410,7 @@ index bc18b9c3aac4c5feeb1603554e0ac009af9b457e..c9d6ddd8874195c07b3573c6b1f61ffd
              this.broadcast(packet);
              if (this.tracker instanceof EntityPlayer) {
                  ((EntityPlayer) this.tracker).playerConnection.sendPacket(packet);
-@@ -2561,8 +2600,8 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2531,8 +2570,8 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
  
          }
  
@@ -421,7 +421,7 @@ index bc18b9c3aac4c5feeb1603554e0ac009af9b457e..c9d6ddd8874195c07b3573c6b1f61ffd
              if (entityplayer != this.tracker) {
                  // Paper start - remove allocation of Vec3D here
                  //Vec3D vec3d = entityplayer.getPositionVector().d(this.tracker.getPositionVector()); // MC-155077, SPIGOT-5113
-@@ -2583,7 +2622,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2553,7 +2592,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                           */
                          int x = this.tracker.chunkX, z = this.tracker.chunkZ;
                          long chunkcoordintpair = ChunkCoordIntPair.pair(x, z);
@@ -431,7 +431,7 @@ index bc18b9c3aac4c5feeb1603554e0ac009af9b457e..c9d6ddd8874195c07b3573c6b1f61ffd
                          if (playerchunk != null && playerchunk.getSendingChunk() != null && PlayerChunkMap.this.playerChunkManager.isChunkSent(entityplayer, MathHelper.floor(this.tracker.locX()) >> 4, MathHelper.floor(this.tracker.locZ()) >> 4)) { // Paper - no-tick view distance // Tuinity - don't broadcast in chunks the player hasn't received
                              flag1 = PlayerChunkMap.someDistanceCalculation(x, z, entityplayer, false) <= PlayerChunkMap.this.viewDistance;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/Chunk.java b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
-index 7474c070598bc093e06f02f19d49f3a6fa6b3d4e..c07fb5ca761c0f2067bd103026ded618a8620947 100644
+index 9ba7c5080ce0cacf438bdd6e11f75cb34fbc5759..cef0462fadb305ebc2b53d37e0c17514626df99d 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 @@ -111,6 +111,26 @@ public class Chunk implements IChunkAccess {

--- a/patches/server/0004-Rebrand.patch
+++ b/patches/server/0004-Rebrand.patch
@@ -54,18 +54,18 @@ index c917f825378dd16a329105b4e7fcc8882755bc5a..6fe8dad8df109531f2b38fbfcb58b680
              </plugin>
              <plugin>
 diff --git a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
-index 89eeb9d202405747409e65fcf226d95379987e29..4d9e685c691a37078ff7452e50ab8c13999dbe10 100644
+index ad87b575a0261200b280884e054a59e3ce59c41c..e56ebeaaa12494817d31099eed54ef2c50b98b9e 100644
 --- a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
 +++ b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
-@@ -17,7 +17,7 @@ public final class PaperConsole extends SimpleTerminalConsole {
+@@ -19,7 +19,7 @@ public final class PaperConsole extends SimpleTerminalConsole {
      @Override
      protected LineReader buildReader(LineReaderBuilder builder) {
-         return super.buildReader(builder
+         builder
 -                .appName("Paper")
 +                .appName("Purpur") // Purpur
                  .variable(LineReader.HISTORY_FILE, java.nio.file.Paths.get(".console_history"))
                  .completer(new ConsoleCommandCompleter(this.server))
-         );
+                 .option(LineReader.Option.COMPLETE_IN_WORD, true);
 diff --git a/src/main/java/gg/airplane/compat/ServerConfigurations.java b/src/main/java/gg/airplane/compat/ServerConfigurations.java
 index f4976428bc721319d2926e97cbe0f64c6e9e503c..044ad28bd1fd1c1e25061f9f811fc10baf7f5f72 100644
 --- a/src/main/java/gg/airplane/compat/ServerConfigurations.java
@@ -92,7 +92,7 @@ index 3bc5cd1e53dd7c94b948e7f57f0dc8e073e349b0..87891161f5b06bb8be0e2016b490484e
                      throwable = throwable1;
                      throw throwable1;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 246fcc9b40152964810ceef356ecb2eee3551135..8620bbcc7c555e4760777397063f0392c9acc35e 100644
+index 7b4b9f54510b3a05aad3f7e50e32ee0bf977244a..e816069db7574996073b932498232c5c6dd40f01 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -243,10 +243,10 @@ index aec6c036ed42078a6cc3540f1f6e46a551e87a2f..f9913d7bd66935f975b756f31e26153e
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 6bfba82b428250e6725688d196b3dc6ac11a5e01..38e1bd3893b9dfcf1bac1333d06b4e9792793ec6 100644
+index 6141e86278d876e42dbed6e8f2275280babcef77..67f93f252a26f8b598a4b48c63c321728b246cae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -377,7 +377,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -397,7 +397,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
  
      @Override
      public com.destroystokyo.paper.util.VersionFetcher getVersionFetcher() {

--- a/patches/server/0005-Purpur-config-files.patch
+++ b/patches/server/0005-Purpur-config-files.patch
@@ -29,7 +29,7 @@ index b480bd3044370b8eb733166f0c4b737344475993..4d8740678049aa749b42618470e9cc83
                  metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {
                      Map<String, Map<String, Integer>> map = new HashMap<>();
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f39452535b2807a226ada095f5c21b19ea238e5c..ad7df9e8a2cfc6fe65b193adfb65c7b32d6c92b3 100644
+index 14ac28d4d6b1ab0f0a70dfefc589f7723a1d2e1a..4eb122cfd31902df9789d2e8ff2615207a65ab06 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -118,6 +118,11 @@ public class PaperConfig {
@@ -45,7 +45,7 @@ index f39452535b2807a226ada095f5c21b19ea238e5c..ad7df9e8a2cfc6fe65b193adfb65c7b3
              config.save(CONFIG_FILE);
          } catch (IOException ex) {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 24a46ad36613faa5f5a1a12b70f7af886e1608ae..28d47ef97939309ce26b6e4cae14925b510755fd 100644
+index 858bd62d2a17c15ee573c5cd607a876d3a99c2b1..a76219e59c24862b9c1e09e4a2a29cf2a6260514 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -212,6 +212,15 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -62,8 +62,8 @@ index 24a46ad36613faa5f5a1a12b70f7af886e1608ae..28d47ef97939309ce26b6e4cae14925b
 +        net.pl3x.purpur.PurpurConfig.registerCommands();
 +        // Purpur end
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
+         io.papermc.paper.brigadier.PaperBrigadierProviderImpl.INSTANCE.getClass(); // init PaperBrigadierProvider
          // Paper end
-         com.tuinity.tuinity.config.TuinityConfig.init((java.io.File) options.valueOf("tuinity-settings")); // Tuinity - Server Config
 diff --git a/src/main/java/net/minecraft/world/level/World.java b/src/main/java/net/minecraft/world/level/World.java
 index 51e6cd6119465f9fd6385072997971449afb5f42..f8261e21a84bf8c29d72116fc3166dc745a59c02 100644
 --- a/src/main/java/net/minecraft/world/level/World.java

--- a/patches/server/0010-AFK-API.patch
+++ b/patches/server/0010-AFK-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] AFK API
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index fd6dbbf619b828c4ef3d00f8dc30d3893007db7b..7e388dcca2d4e78b49d5fc5fce0b962e74839fa3 100644
+index b2e21e7034ad83a4ba1c99f860be5a0f5ee6a75f..598b30244e74a56d62dc4ace5362225447860a0a 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -2070,8 +2070,54 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2071,8 +2071,54 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      public void resetIdleTimer() {
          this.ca = SystemUtils.getMonotonicMillis();
@@ -64,7 +64,7 @@ index fd6dbbf619b828c4ef3d00f8dc30d3893007db7b..7e388dcca2d4e78b49d5fc5fce0b962e
          return this.serverStatisticManager;
      }
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index d13c6f4c368ca6fe3326b66d4c3ef94cf166e7e3..946c49ef50ed9360467b6e29d7121da676832156 100644
+index e159a08b3cde339bf95d8b3ded4c35511451879f..18ff28973cb543334946fb066ff77502f4582330 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -1002,7 +1002,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -76,7 +76,7 @@ index d13c6f4c368ca6fe3326b66d4c3ef94cf166e7e3..946c49ef50ed9360467b6e29d7121da6
          })) {
              // CraftBukkit start
              long l = this.worldData.getDayTime() + 24000L;
-@@ -1369,7 +1369,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1379,7 +1379,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              while (iterator.hasNext()) {
                  EntityPlayer entityplayer = (EntityPlayer) iterator.next();
  
@@ -86,10 +86,10 @@ index d13c6f4c368ca6fe3326b66d4c3ef94cf166e7e3..946c49ef50ed9360467b6e29d7121da6
                  } else if (entityplayer.isSleeping()) {
                      ++j;
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index 83ad913e46f44aabb41b7e441cba2ef2f7bcbc46..400d682a3b314705501cd652593317e8fe096db7 100644
+index 159c38618d7745ea513ad179b1217d76c2c4897a..15349a7bddcad5a4a6db07a8aa6ae8d06163b1f6 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -397,6 +397,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -399,6 +399,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
          }
  
          if (this.player.F() > 0L && this.minecraftServer.getIdleTimeout() > 0 && SystemUtils.getMonotonicMillis() - this.player.F() > (long) (this.minecraftServer.getIdleTimeout() * 1000 * 60)) {
@@ -102,7 +102,7 @@ index 83ad913e46f44aabb41b7e441cba2ef2f7bcbc46..400d682a3b314705501cd652593317e8
              this.player.resetIdleTimer(); // CraftBukkit - SPIGOT-854
              this.disconnect(new ChatMessage("multiplayer.disconnect.idling"));
          }
-@@ -672,6 +678,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -674,6 +680,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      this.lastYaw = to.getYaw();
                      this.lastPitch = to.getPitch();
  
@@ -111,7 +111,7 @@ index 83ad913e46f44aabb41b7e441cba2ef2f7bcbc46..400d682a3b314705501cd652593317e8
                      // Skip the first time we do this
                      if (true) { // Spigot - don't skip any move events
                          Location oldTo = to.clone();
-@@ -1414,7 +1422,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1416,7 +1424,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
                              if (!this.player.H() && d11 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.playerInteractManager.isCreative() && this.player.playerInteractManager.getGameMode() != EnumGamemode.SPECTATOR) { // Spigot
                                  flag1 = true; // Tuinity - diff on change, this should be moved wrongly
@@ -120,7 +120,7 @@ index 83ad913e46f44aabb41b7e441cba2ef2f7bcbc46..400d682a3b314705501cd652593317e8
                              }
  
                              this.player.setLocation(d4, d5, d6, f, f1);
-@@ -1464,6 +1472,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1466,6 +1474,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
                                      this.lastYaw = to.getYaw();
                                      this.lastPitch = to.getPitch();
  
@@ -150,7 +150,7 @@ index f5e32faeb6d937cf90b1f3ea251b5cfc91f2338d..f9908fb7cc27a8947030c2100dccf1dc
      // Paper start
      public static final Predicate<Entity> affectsSpawning = (entity) -> {
 diff --git a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-index ad85dda5c50b797904824a08513fbcec042128ea..8f9d0769e7855c3565a34927f3f3741c43e45f35 100644
+index 5f9e64df007ebc40f7bcb50be495b10e51d5b87a..17e6f476e60a4f5dc278894a0a874ca5ae45ee22 100644
 --- a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 +++ b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 @@ -182,6 +182,15 @@ public abstract class EntityHuman extends EntityLiving {
@@ -289,7 +289,7 @@ index 45e786565ac988abadffda2e7ba3ff1e2880b786..f4052aaa2235894b996d65c569a083f1
 +    // Purpur end
  }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 6c4c4580faef39e48de5af4db003cf2e3b8a99b5..dc2d880ded328f8377c207ce15f604ec5c25176c 100644
+index 8b36ca5062f8e0e8bd58aa506e91704a747de81b..c94cd5a95f28190e88d31b522035fc7c74a2ac33 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -207,6 +207,7 @@ public class ActivationRange

--- a/patches/server/0012-Configurable-server-mod-name.patch
+++ b/patches/server/0012-Configurable-server-mod-name.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable server mod name
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8620bbcc7c555e4760777397063f0392c9acc35e..83b98a18a8b726621068b5fd2bed046852dccf2d 100644
+index e816069db7574996073b932498232c5c6dd40f01..b4ddedf80aded5b8daebd0c62fb806658af368b2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0013-LivingEntity-safeFallDistance.patch
+++ b/patches/server/0013-LivingEntity-safeFallDistance.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] LivingEntity safeFallDistance
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 5c983a441cd2a06eae6e79bc07ba5440d294574b..b987cee913bf909fa0daa6280376838e9429fe5d 100644
+index 74f80b6af18c0b91d9613384ca6bafd9c89f23a4..2777bd3ea82b214fc15c5ce3ce47c90c1e5fe538 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -228,6 +228,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0014-Lagging-threshold.patch
+++ b/patches/server/0014-Lagging-threshold.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Lagging threshold
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 83b98a18a8b726621068b5fd2bed046852dccf2d..a75a8322829f36045243d5fd61d28b126af1f0af 100644
+index b4ddedf80aded5b8daebd0c62fb806658af368b2..00f5a38f810bc9963b3ecf697dad2b4968bad33d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -279,6 +279,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0018-Player-invulnerabilities.patch
+++ b/patches/server/0018-Player-invulnerabilities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player invulnerabilities
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 7e388dcca2d4e78b49d5fc5fce0b962e74839fa3..e875671ce985199bc37de131280935a859253954 100644
+index 598b30244e74a56d62dc4ace5362225447860a0a..f59d7e245aa3768004c7f82837a7482260a53406 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -284,6 +284,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -47,7 +47,7 @@ index 7e388dcca2d4e78b49d5fc5fce0b962e74839fa3..e875671ce985199bc37de131280935a8
              return this;
          }
      }
-@@ -2488,9 +2497,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2489,9 +2498,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      @Override
      public boolean isFrozen() { // Paper - protected > public
@@ -67,10 +67,10 @@ index 7e388dcca2d4e78b49d5fc5fce0b962e74839fa3..e875671ce985199bc37de131280935a8
      public Scoreboard getScoreboard() {
          return getBukkitEntity().getScoreboard().getHandle();
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index 400d682a3b314705501cd652593317e8fe096db7..f1ebb59f328bffa80a5b9b6504535e711c1d5c9b 100644
+index 15349a7bddcad5a4a6db07a8aa6ae8d06163b1f6..37663436c1ffed4552cdcdac7a5c09fe9b632fee 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -1894,6 +1894,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1896,6 +1896,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          PlayerConnectionUtils.ensureMainThread(packetplayinresourcepackstatus, this, this.player.getWorldServer());
          // Paper start
          PlayerResourcePackStatusEvent.Status packStatus = PlayerResourcePackStatusEvent.Status.values()[packetplayinresourcepackstatus.status.ordinal()];
@@ -79,10 +79,10 @@ index 400d682a3b314705501cd652593317e8fe096db7..f1ebb59f328bffa80a5b9b6504535e71
          this.server.getPluginManager().callEvent(new PlayerResourcePackStatusEvent(getPlayer(), packStatus));
          // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0b5cf23932c3c626d8805d4db97d2bbab63634cf..a285d0594e61190a751a96f22afeb12d2dcce3fe 100644
+index c705bf1e651a764d56b87ebc5a86a938d8bd34bb..9360d35581c6961a768973cc31341381ee26e234 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1007,6 +1007,8 @@ public abstract class PlayerList {
+@@ -1009,6 +1009,8 @@ public abstract class PlayerList {
          }
          // Paper end
  

--- a/patches/server/0021-Alternative-Keepalive-Handling.patch
+++ b/patches/server/0021-Alternative-Keepalive-Handling.patch
@@ -17,10 +17,10 @@ index b4c37287362907b8507d156b978ba5b9d961bb7b..9e6e6636539702507abb78515e002819
          return this.a;
      }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index f1ebb59f328bffa80a5b9b6504535e711c1d5c9b..ac36ca9251e3acb663c62ad7af05bfaf2fd68f5c 100644
+index 37663436c1ffed4552cdcdac7a5c09fe9b632fee..f5ada346a11ac3becda4b87416beebd680ca16fa 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -231,6 +231,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -233,6 +233,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private long lastKeepAlive = SystemUtils.getMonotonicMillis(); private void setLastPing(long lastPing) { this.lastKeepAlive = lastPing;}; private long getLastPing() { return this.lastKeepAlive;}; // Paper - OBFHELPER
      private boolean awaitingKeepAlive; private void setPendingPing(boolean isPending) { this.awaitingKeepAlive = isPending;}; private boolean isPendingPing() { return this.awaitingKeepAlive;}; // Paper - OBFHELPER
      private long h; private void setKeepAliveID(long keepAliveID) { this.h = keepAliveID;}; private long getKeepAliveID() {return this.h; };  // Paper - OBFHELPER
@@ -28,7 +28,7 @@ index f1ebb59f328bffa80a5b9b6504535e711c1d5c9b..ac36ca9251e3acb663c62ad7af05bfaf
      // CraftBukkit start - multithreaded fields
      private volatile int chatThrottle;
      private static final AtomicIntegerFieldUpdater chatSpamField = AtomicIntegerFieldUpdater.newUpdater(PlayerConnection.class, "chatThrottle");
-@@ -365,6 +366,21 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -367,6 +368,21 @@ public class PlayerConnection implements PacketListenerPlayIn {
          long currentTime = SystemUtils.getMonotonicMillis();
          long elapsedTime = currentTime - this.getLastPing();
  
@@ -50,7 +50,7 @@ index f1ebb59f328bffa80a5b9b6504535e711c1d5c9b..ac36ca9251e3acb663c62ad7af05bfaf
          if (this.isPendingPing()) {
              if (!this.processedDisconnect && elapsedTime >= KEEPALIVE_LIMIT) { // check keepalive limit, don't fire if already disconnected
                  PlayerConnection.LOGGER.warn("{} was kicked due to keepalive timeout!", this.player.getName()); // more info
-@@ -3065,6 +3081,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -3079,6 +3095,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
      @Override
      public void a(PacketPlayInKeepAlive packetplayinkeepalive) {

--- a/patches/server/0022-Silk-touch-spawners.patch
+++ b/patches/server/0022-Silk-touch-spawners.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Silk touch spawners
 
 
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
-index 71938ad7b3494e803beca7e4022aad12a51f2096..0b77884d8134c328f8fd1bbb8230d260606dc5ee 100644
+index cd2da276c09dcf98c1c50dc66aa30dd3b67b43af..2ef13ce5cb7df206753f41a692d74c8d68354cfc 100644
 --- a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 @@ -81,6 +81,7 @@ public final class PaperAdventure {
@@ -14,7 +14,7 @@ index 71938ad7b3494e803beca7e4022aad12a51f2096..0b77884d8134c328f8fd1bbb8230d260
      public static final LegacyComponentSerializer LEGACY_SECTION_UXRC = LegacyComponentSerializer.builder().flattener(FLATTENER).hexColors().useUnusualXRepeatedCharacterHexFormat().build();
 +    public static final LegacyComponentSerializer LEGACY_AMPERSAND = LegacyComponentSerializer.builder().character(LegacyComponentSerializer.AMPERSAND_CHAR).hexColors().build(); // Purpur
      public static final PlainComponentSerializer PLAIN = PlainComponentSerializer.builder().flattener(FLATTENER).build();
-     static final GsonComponentSerializer GSON = GsonComponentSerializer.builder()
+     public static final GsonComponentSerializer GSON = GsonComponentSerializer.builder()
          .legacyHoverEventSerializer(NBTLegacyHoverEventSerializer.INSTANCE)
 diff --git a/src/main/java/net/minecraft/server/ItemSpawner.java b/src/main/java/net/minecraft/server/ItemSpawner.java
 new file mode 100644

--- a/patches/server/0027-Giants-AI-settings.patch
+++ b/patches/server/0027-Giants-AI-settings.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Giants AI settings
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c6b4af810fe3bda7797ab94316b2357178c9cd49..b7c72eaf5715a30bb8f82891f9830f9f62ec03c9 100644
+index 5ac2811c88370a55f055c791baa3804fc9a107a8..c9ae1db4dc982f135e8b2174c59988273a271a77 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -228,7 +228,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -38,7 +38,7 @@ index f4440a5c4aedb1d7d303517f86a07c856dd1309b..7443fe924486404931c11793acc67e2f
          float f = difficultydamagescaler.d();
  
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index b987cee913bf909fa0daa6280376838e9429fe5d..7720cf9dcbc5a9680c68f47aef08ff1c3b154022 100644
+index 2777bd3ea82b214fc15c5ce3ce47c90c1e5fe538..f5bc04059c24f57530653c8845cfe4daa5fed843 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -261,6 +261,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0029-Zombie-horse-naturally-spawn.patch
+++ b/patches/server/0029-Zombie-horse-naturally-spawn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Zombie horse naturally spawn
 
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 946c49ef50ed9360467b6e29d7121da676832156..12bac4dbf7164c4d674897ed067958965a862864 100644
+index 18ff28973cb543334946fb066ff77502f4582330..4df02479e3443becfa3ce91c00f51c2c19059e54 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -96,6 +96,7 @@ import net.minecraft.world.entity.ai.village.poi.VillagePlace;
@@ -16,7 +16,7 @@ index 946c49ef50ed9360467b6e29d7121da676832156..12bac4dbf7164c4d674897ed06795896
  import net.minecraft.world.entity.animal.horse.EntityHorseSkeleton;
  import net.minecraft.world.entity.boss.EntityComplexPart;
  import net.minecraft.world.entity.boss.enderdragon.EntityEnderDragon;
-@@ -1243,12 +1244,18 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1253,12 +1254,18 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  boolean flag1 = this.getGameRules().getBoolean(GameRules.DO_MOB_SPAWNING) && this.random.nextDouble() < (double) difficultydamagescaler.b() * paperConfig.skeleHorseSpawnChance; // Paper
  
                  if (flag1) {

--- a/patches/server/0041-Cows-eat-mushrooms.patch
+++ b/patches/server/0041-Cows-eat-mushrooms.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cows eat mushrooms
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b7c72eaf5715a30bb8f82891f9830f9f62ec03c9..c8071e2909c03bd8eafb92fbf8fd8701642df1f9 100644
+index c9ae1db4dc982f135e8b2174c59988273a271a77..aeade4d52a98aac03c086ecb598326e55930d9d3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2886,6 +2886,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2919,6 +2919,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.invulnerable = flag;
      }
  
@@ -17,7 +17,7 @@ index b7c72eaf5715a30bb8f82891f9830f9f62ec03c9..c8071e2909c03bd8eafb92fbf8fd8701
          this.setPositionRotation(entity.locX(), entity.locY(), entity.locZ(), entity.yaw, entity.pitch);
      }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 7720cf9dcbc5a9680c68f47aef08ff1c3b154022..ee42f3d97c3453bacfe0be40ee99f08649d44acf 100644
+index f5bc04059c24f57530653c8845cfe4daa5fed843..5cdefe2a1b4085e3aae7dbbb751cfd368593ebd7 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -176,7 +176,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0047-Signs-allow-color-codes.patch
+++ b/patches/server/0047-Signs-allow-color-codes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Signs allow color codes
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index e875671ce985199bc37de131280935a859253954..ba71636527f173dfc5ddae9ef0f7c73d0423d9b3 100644
+index f59d7e245aa3768004c7f82837a7482260a53406..c337b22a2f8ce5c76a1699956f6c06721046e814 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -1579,6 +1579,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -17,10 +17,10 @@ index e875671ce985199bc37de131280935a859253954..ba71636527f173dfc5ddae9ef0f7c73d
          this.playerConnection.sendPacket(new PacketPlayOutOpenSignEditor(tileentitysign.getPosition()));
      }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index ac36ca9251e3acb663c62ad7af05bfaf2fd68f5c..f45bbf7a4ab4d841a12270c1399fb09538b9fe90 100644
+index f5ada346a11ac3becda4b87416beebd680ca16fa..4f094f026b118775cae84024b2ba6c33e14784e6 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -3059,6 +3059,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -3073,6 +3073,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      }
                  }
                  // Paper end

--- a/patches/server/0049-Controllable-Minecarts.patch
+++ b/patches/server/0049-Controllable-Minecarts.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Controllable Minecarts
 
 
 diff --git a/src/main/java/net/minecraft/core/BlockPosition.java b/src/main/java/net/minecraft/core/BlockPosition.java
-index 73ec17dea5d5668e49c9a6ad679bd3a362960c72..54e97ae219d49a595441af6c5bae8ecef6bfc1ad 100644
+index 3c51ee00aa53e561c02bb779c7115d8475d70ed7..456253043cca1b07e7e4791d096682f23749473d 100644
 --- a/src/main/java/net/minecraft/core/BlockPosition.java
 +++ b/src/main/java/net/minecraft/core/BlockPosition.java
 @@ -11,6 +11,7 @@ import java.util.stream.StreamSupport;
@@ -30,7 +30,7 @@ index 73ec17dea5d5668e49c9a6ad679bd3a362960c72..54e97ae219d49a595441af6c5bae8ece
          super(i, j, k);
      }
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index ba71636527f173dfc5ddae9ef0f7c73d0423d9b3..c2e987808ae5ccb23cc7bcc5221faea11153bc7f 100644
+index c337b22a2f8ce5c76a1699956f6c06721046e814..e8f39bcf57e960be4a87acfa49910ab6ede8842f 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -106,6 +106,7 @@ import net.minecraft.world.entity.monster.EntityMonster;
@@ -50,7 +50,7 @@ index ba71636527f173dfc5ddae9ef0f7c73d0423d9b3..c2e987808ae5ccb23cc7bcc5221faea1
  
              if (!flag && isSpawnInvulnerable() && damagesource != DamageSource.OUT_OF_WORLD) { // Purpur
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index ee42f3d97c3453bacfe0be40ee99f08649d44acf..09c00dae1d25878a7d55bdc2498b7d6e325dc45a 100644
+index 5cdefe2a1b4085e3aae7dbbb751cfd368593ebd7..f1781c2100bf3a8fa7123b66f9ab682177d6490e 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -194,9 +194,9 @@ public abstract class EntityLiving extends Entity {
@@ -159,7 +159,7 @@ index 527f3ed664854cdd938c34f00a064bc2f77148cc..d50a1093aa9b6d7187b59566309a3abd
      }
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index 596b4597313b87296d39027b13555b5ad1cba9e6..5ea059cde9e1a089c2ade12512e4a7abd07c5b8a 100644
+index f8a982add50862f1bc977f3039e7e9aeed9138ae..e18b3b575e4fe3fde869e749070feefb31548a25 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
 @@ -41,6 +41,7 @@ import net.minecraft.world.level.block.entity.TileEntity;

--- a/patches/server/0050-Disable-loot-drops-on-death-by-cramming.patch
+++ b/patches/server/0050-Disable-loot-drops-on-death-by-cramming.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Disable loot drops on death by cramming
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 09c00dae1d25878a7d55bdc2498b7d6e325dc45a..f338c3fc638d76eb6850573517c6123584bc7e04 100644
+index f1781c2100bf3a8fa7123b66f9ab682177d6490e..906791fc6180e011ce029ac95a63c92553f0377e 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -1598,8 +1598,10 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0051-Players-should-not-cram-to-death.patch
+++ b/patches/server/0051-Players-should-not-cram-to-death.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Players should not cram to death
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index c2e987808ae5ccb23cc7bcc5221faea11153bc7f..97f82ac9fb8f91aea11660ad6d7284faed8e9434 100644
+index e8f39bcf57e960be4a87acfa49910ab6ede8842f..1878d09553e2c9013e1c135b5449ce9fe88ecfd5 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -1557,7 +1557,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0054-Fix-the-dead-lagging-the-server.patch
+++ b/patches/server/0054-Fix-the-dead-lagging-the-server.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix the dead lagging the server
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c8071e2909c03bd8eafb92fbf8fd8701642df1f9..7c9fc120d2b58ca969b8a0ff9619e96f4f34b1c4 100644
+index aeade4d52a98aac03c086ecb598326e55930d9d3..18e65d77a5e999ed60d32b91a1cd6a7b380d38d0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1631,6 +1631,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1664,6 +1664,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.pitch = MathHelper.a(f1, -90.0F, 90.0F) % 360.0F;
          this.lastYaw = this.yaw;
          this.lastPitch = this.pitch;
@@ -17,7 +17,7 @@ index c8071e2909c03bd8eafb92fbf8fd8701642df1f9..7c9fc120d2b58ca969b8a0ff9619e96f
  
      public void f(double d0, double d1, double d2) {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index f338c3fc638d76eb6850573517c6123584bc7e04..7d1b5c992521ae1dae94d3e658d73491387e1d98 100644
+index 906791fc6180e011ce029ac95a63c92553f0377e..6fb4b06df010c3099a1af3b145749ea439a4aa39 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -2597,7 +2597,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0055-Skip-events-if-there-s-no-listeners.patch
+++ b/patches/server/0055-Skip-events-if-there-s-no-listeners.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Skip events if there's no listeners
 
 
 diff --git a/src/main/java/net/minecraft/commands/CommandDispatcher.java b/src/main/java/net/minecraft/commands/CommandDispatcher.java
-index a70e0761aeddee8fafff971b5cbd0422ab560fb5..6fc5ee06c3bed8d9aa0e13dd7fa8d70ff6711f85 100644
+index 988d1c9e9f4f29325043eb083123d12dd5f8081d..c25440e810e61bcdc299a0caebaec54b6862dd3c 100644
 --- a/src/main/java/net/minecraft/commands/CommandDispatcher.java
 +++ b/src/main/java/net/minecraft/commands/CommandDispatcher.java
 @@ -362,6 +362,7 @@ public class CommandDispatcher {

--- a/patches/server/0056-Add-permission-for-F3-N-debug.patch
+++ b/patches/server/0056-Add-permission-for-F3-N-debug.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add permission for F3+N debug
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index a285d0594e61190a751a96f22afeb12d2dcce3fe..3a46a673349de9d9d725516a0fcdb3ebb9b372b3 100644
+index 9360d35581c6961a768973cc31341381ee26e234..c742647c0c5e3e4925e4ee6d195a54a85435e65e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1166,6 +1166,7 @@ public abstract class PlayerList {
+@@ -1168,6 +1168,7 @@ public abstract class PlayerList {
              } else {
                  b0 = (byte) (24 + i);
              }

--- a/patches/server/0058-Configurable-TPS-Catchup.patch
+++ b/patches/server/0058-Configurable-TPS-Catchup.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable TPS Catchup
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a75a8322829f36045243d5fd61d28b126af1f0af..ab2424a868a3d29af96f36ce037f1ab9b9b2a635 100644
+index 00f5a38f810bc9963b3ecf697dad2b4968bad33d..07cc501a45669edbb27f1cd5336dcb91b91b877a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1132,7 +1132,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0066-Implement-infinite-lava.patch
+++ b/patches/server/0066-Implement-infinite-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement infinite lava
 
 
 diff --git a/src/main/java/net/minecraft/world/level/material/FluidTypeFlowing.java b/src/main/java/net/minecraft/world/level/material/FluidTypeFlowing.java
-index 6bb4ec00e40795ced73648fefcd1f5027e0113cd..963b7edab813cd32f04c51fd2c6c137988e2a754 100644
+index b14b0134b42aa6d1eb285aa453ec6067cc702878..46187d18f797f834deef3685c857e88a8c4f5659 100644
 --- a/src/main/java/net/minecraft/world/level/material/FluidTypeFlowing.java
 +++ b/src/main/java/net/minecraft/world/level/material/FluidTypeFlowing.java
-@@ -217,7 +217,7 @@ public abstract class FluidTypeFlowing extends FluidType {
+@@ -226,7 +226,7 @@ public abstract class FluidTypeFlowing extends FluidType {
              }
          }
  
@@ -17,7 +17,7 @@ index 6bb4ec00e40795ced73648fefcd1f5027e0113cd..963b7edab813cd32f04c51fd2c6c1379
              IBlockData iblockdata2 = iworldreader.getType(blockposition.down());
              Fluid fluid1 = iblockdata2.getFluid();
  
-@@ -288,6 +288,17 @@ public abstract class FluidTypeFlowing extends FluidType {
+@@ -322,6 +322,17 @@ public abstract class FluidTypeFlowing extends FluidType {
          return (Fluid) this.e().h().set(FluidTypeFlowing.FALLING, flag);
      }
  

--- a/patches/server/0068-Add-player-death-exp-control-options.patch
+++ b/patches/server/0068-Add-player-death-exp-control-options.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add player death exp control options
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-index 8f9d0769e7855c3565a34927f3f3741c43e45f35..2ee7daa155d812af8f84ba646106d801d2fb0fec 100644
+index 17e6f476e60a4f5dc278894a0a874ca5ae45ee22..1b130b50888113d515ce1e200a157c3bbff3b625 100644
 --- a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 +++ b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 @@ -183,6 +183,8 @@ public abstract class EntityHuman extends EntityLiving {
@@ -17,7 +17,7 @@ index 8f9d0769e7855c3565a34927f3f3741c43e45f35..2ee7daa155d812af8f84ba646106d801
      public void setAfk(boolean setAfk){
      }
  
-@@ -1814,9 +1816,18 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1826,9 +1828,18 @@ public abstract class EntityHuman extends EntityLiving {
      @Override
      protected int getExpValue(EntityHuman entityhuman) {
          if (!this.world.getGameRules().getBoolean(GameRules.KEEP_INVENTORY) && !this.isSpectator()) {

--- a/patches/server/0069-Add-canSaveToDisk-to-Entity.patch
+++ b/patches/server/0069-Add-canSaveToDisk-to-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add canSaveToDisk to Entity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7c9fc120d2b58ca969b8a0ff9619e96f4f34b1c4..4e6ec59c982fe0870f514b59082ab0a7de4d93ef 100644
+index 18e65d77a5e999ed60d32b91a1cd6a7b380d38d0..03b8b669ea8047ba1fa2b493b10fce2c37060c3b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -416,6 +416,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -449,6 +449,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.headHeight = this.getHeadHeight(EntityPose.STANDING, this.size);
      }
  

--- a/patches/server/0070-Configurable-void-damage-height.patch
+++ b/patches/server/0070-Configurable-void-damage-height.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable void damage height
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4e6ec59c982fe0870f514b59082ab0a7de4d93ef..b114d12d9d17071fb96f5ab225b85cdd5ad06861 100644
+index 03b8b669ea8047ba1fa2b493b10fce2c37060c3b..21977036eb9e7eda408d0cd27b0a27adb9815c22 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -719,7 +719,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -752,7 +752,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      // Paper start
      protected void performVoidDamage() {

--- a/patches/server/0075-Add-5-second-tps-average-in-tps.patch
+++ b/patches/server/0075-Add-5-second-tps-average-in-tps.patch
@@ -27,7 +27,7 @@ index dc6bc1910ad0f9b27144d5750078c3ca607d03d3..e8be35f836ede2630d44902e99a21489
          setListData(vector);
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ab2424a868a3d29af96f36ce037f1ab9b9b2a635..cdddae4ff5178112d4523079144803f2694267d5 100644
+index 07cc501a45669edbb27f1cd5336dcb91b91b877a..59dbc74f78eb8e065e815b6d4efc39350b2479ec 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -278,7 +278,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0076-Implement-elytra-settings.patch
+++ b/patches/server/0076-Implement-elytra-settings.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement elytra settings
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 7d1b5c992521ae1dae94d3e658d73491387e1d98..35936f4651484c495a43529638d79b5df65b82ee 100644
+index 6fb4b06df010c3099a1af3b145749ea439a4aa39..e2124f60b37436d2514f92e180e914b4d4a8470c 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -2955,7 +2955,16 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0077-Item-entity-immunities.patch
+++ b/patches/server/0077-Item-entity-immunities.patch
@@ -42,10 +42,10 @@ index f63ec5fa5a1cb34f4809a06a29d01603efb178f1..b773480baef218d0aab2f524e7e305c1
              int i;
              int j;
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index c9d6ddd8874195c07b3573c6b1f61ffdcff2dddd..4f11a19137531a0406a5214cd0cce0bea06d0088 100644
+index 737851cde7752e7cccf226f1868a38d6411bfb31..ae32fe66a70d583993fe81de4c95b7b2fe8a6fc8 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -2487,7 +2487,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2457,7 +2457,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
  
      public class EntityTracker {
  
@@ -55,10 +55,10 @@ index c9d6ddd8874195c07b3573c6b1f61ffdcff2dddd..4f11a19137531a0406a5214cd0cce0be
          private final int trackingDistance;
          private SectionPosition e;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b114d12d9d17071fb96f5ab225b85cdd5ad06861..7f897bebdc1fe2b7ce9528db9a7dd0fc0cf6c008 100644
+index 21977036eb9e7eda408d0cd27b0a27adb9815c22..43ccdf9aabb2457308beac8e04222117b2740598 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1580,6 +1580,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1613,6 +1613,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      }
  

--- a/patches/server/0078-Add-ping-command.patch
+++ b/patches/server/0078-Add-ping-command.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add /ping command
 
 
 diff --git a/src/main/java/net/minecraft/commands/CommandDispatcher.java b/src/main/java/net/minecraft/commands/CommandDispatcher.java
-index 6fc5ee06c3bed8d9aa0e13dd7fa8d70ff6711f85..e8fe4984fdc67536561a1ad08b328a30b30b8717 100644
+index c25440e810e61bcdc299a0caebaec54b6862dd3c..cf3776591446ad7b3d1ee1285c5aeffcb5e9495e 100644
 --- a/src/main/java/net/minecraft/commands/CommandDispatcher.java
 +++ b/src/main/java/net/minecraft/commands/CommandDispatcher.java
 @@ -191,6 +191,7 @@ public class CommandDispatcher {
@@ -34,7 +34,7 @@ index 6fc5ee06c3bed8d9aa0e13dd7fa8d70ff6711f85..e8fe4984fdc67536561a1ad08b328a30
      }
  
 +    public com.mojang.brigadier.CommandDispatcher<CommandListenerWrapper> getDispatcher() { return a(); } // Purpur - OBFHELPER
-     public com.mojang.brigadier.CommandDispatcher<CommandListenerWrapper> a() {
+     public com.mojang.brigadier.CommandDispatcher<CommandListenerWrapper> a() { return this.dispatcher(); } public com.mojang.brigadier.CommandDispatcher<CommandListenerWrapper> dispatcher() { // Paper - OBFHELPER
          return this.b;
      }
 diff --git a/src/main/java/net/minecraft/commands/CommandListenerWrapper.java b/src/main/java/net/minecraft/commands/CommandListenerWrapper.java

--- a/patches/server/0079-Configurable-jockey-options.patch
+++ b/patches/server/0079-Configurable-jockey-options.patch
@@ -33,10 +33,10 @@ index e4794760fc918cccbdc3f8d10ab21dd9b6f29e8e..ea776755767f29e49de2792afa30f794
      protected void m() {
          this.goalSelector.a(1, new EntityDrowned.c(this, 1.0D));
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java b/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
-index cc1bff409cad2eb6264d4b691599576960080ccd..af00a4245ca39f208810d1ec758e512cbf5648f3 100644
+index d10d1b768601236b9892461ee41d61c7239d1a07..ee17e62d996d81ea149a5c0eae2e29404e363dcf 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
-@@ -55,6 +55,23 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
+@@ -56,6 +56,23 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
          this.a(PathType.LAVA, 8.0F);
      }
  

--- a/patches/server/0080-Phantoms-attracted-to-crystals-and-crystals-shoot-ph.patch
+++ b/patches/server/0080-Phantoms-attracted-to-crystals-and-crystals-shoot-ph.patch
@@ -17,10 +17,10 @@ index 53ea8a6d90faf4f7f8fd0819be4499422bdd4cbe..6ba14f603b8ec69597c70677cc317f80
          return (new EntityDamageSourceIndirect("indirectMagic", entity, entity1)).setIgnoreArmor().setMagic();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7f897bebdc1fe2b7ce9528db9a7dd0fc0cf6c008..5ac6b7759cf43dbbad1bcf74d5d86efd69883cf5 100644
+index 43ccdf9aabb2457308beac8e04222117b2740598..0336946172c2a9b08d5b0b7c3f155d3eae0385db 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2246,8 +2246,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2279,8 +2279,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.a(new ItemStack(imaterial), (float) i);
      }
  

--- a/patches/server/0082-Implement-bed-explosion-options.patch
+++ b/patches/server/0082-Implement-bed-explosion-options.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement bed explosion options
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/BlockBed.java b/src/main/java/net/minecraft/world/level/block/BlockBed.java
-index eca84595342756e3550883551e487aaf79574fde..d81c05c092173b7e74045cfab1018d2eed28c401 100644
+index abe0a1c309d526de37efcac44922fa259e1d112c..db9ef25d0578538fd7c7950a3b3d03453da336f1 100644
 --- a/src/main/java/net/minecraft/world/level/block/BlockBed.java
 +++ b/src/main/java/net/minecraft/world/level/block/BlockBed.java
-@@ -127,7 +127,7 @@ public class BlockBed extends BlockFacingHorizontal implements ITileEntity {
+@@ -137,7 +137,7 @@ public class BlockBed extends BlockFacingHorizontal implements ITileEntity {
                      world.a(blockposition1, false);
                  }
  

--- a/patches/server/0085-Allow-color-codes-in-books.patch
+++ b/patches/server/0085-Allow-color-codes-in-books.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow color codes in books
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index f45bbf7a4ab4d841a12270c1399fb09538b9fe90..38273c73610b23ba75db658763cbb2e4c4871d58 100644
+index 4f094f026b118775cae84024b2ba6c33e14784e6..c4ef3fef4db2326a531694e6798bab6103c7061c 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -1209,7 +1209,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1211,7 +1211,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
          if (itemstack.getItem() == Items.WRITABLE_BOOK) {
              NBTTagList nbttaglist = new NBTTagList();
  
@@ -18,7 +18,7 @@ index f45bbf7a4ab4d841a12270c1399fb09538b9fe90..38273c73610b23ba75db658763cbb2e4
              ItemStack old = itemstack.cloneItemStack(); // CraftBukkit
              itemstack.a("pages", (NBTBase) nbttaglist);
              this.player.inventory.setItem(i, CraftEventFactory.handleEditBookEvent(player, i, old, itemstack)); // CraftBukkit // Paper - Don't ignore result (see other callsite for handleEditBookEvent)
-@@ -1227,13 +1228,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1229,13 +1230,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  itemstack1.setTag(nbttagcompound.clone());
              }
  
@@ -35,7 +35,7 @@ index f45bbf7a4ab4d841a12270c1399fb09538b9fe90..38273c73610b23ba75db658763cbb2e4
                  ChatComponentText chatcomponenttext = new ChatComponentText(s1);
                  String s2 = IChatBaseComponent.ChatSerializer.a((IChatBaseComponent) chatcomponenttext);
  
-@@ -1245,6 +1247,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1247,6 +1249,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
          }
      }
  

--- a/patches/server/0086-Entity-lifespan.patch
+++ b/patches/server/0086-Entity-lifespan.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity lifespan
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index 38273c73610b23ba75db658763cbb2e4c4871d58..d30a9ef98cbe214c0258e7d5e8527ff8fd956ddd 100644
+index c4ef3fef4db2326a531694e6798bab6103c7061c..92437cf4413ea76ef139b007adf2b76c2729dad2 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -2455,6 +2455,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2458,6 +2458,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      boolean triggerLeashUpdate = itemInHand != null && itemInHand.getItem() == Items.LEAD && entity instanceof EntityInsentient;
                      Item origItem = this.player.inventory.getItemInHand() == null ? null : this.player.inventory.getItemInHand().getItem();
                      PlayerInteractEntityEvent event;

--- a/patches/server/0087-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
+++ b/patches/server/0087-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to teleport to spawn if outside world border
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 97f82ac9fb8f91aea11660ad6d7284faed8e9434..8e76c11e6bec5357322ea906af9e30f71e5718be 100644
+index 1878d09553e2c9013e1c135b5449ce9fe88ecfd5..77a49f76927e65874ae35f7709bef1b041bf77a6 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -2556,4 +2556,26 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2557,4 +2557,26 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          return (CraftPlayer) super.getBukkitEntity();
      }
      // CraftBukkit end
@@ -36,7 +36,7 @@ index 97f82ac9fb8f91aea11660ad6d7284faed8e9434..8e76c11e6bec5357322ea906af9e30f7
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 35936f4651484c495a43529638d79b5df65b82ee..a2073fd6fc5c2a5fd2835445019c7ecf86c5eb47 100644
+index e2124f60b37436d2514f92e180e914b4d4a8470c..f4407cd0865b0e4861930645615c057d11079034 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -45,6 +45,7 @@ import net.minecraft.network.syncher.DataWatcher;

--- a/patches/server/0088-Squid-EAR-immunity.patch
+++ b/patches/server/0088-Squid-EAR-immunity.patch
@@ -21,7 +21,7 @@ index b9e252c3db715c288493d5b98fc20d84de46c4e4..cdb7a97ecececa78a200acc898535d33
      public boolean villagerUseBrainTicksOnlyWhenLagging = true;
      public boolean villagerCanBeLeashed = false;
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index dc2d880ded328f8377c207ce15f604ec5c25176c..5881497825b3c11ce5d23e4f609fd769ba6a76e1 100644
+index c94cd5a95f28190e88d31b522035fc7c74a2ac33..d04a21b93374c287b271deb6618b984abc8831bb 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -11,6 +11,7 @@ import net.minecraft.world.entity.EntityLiving;
@@ -32,7 +32,7 @@ index dc2d880ded328f8377c207ce15f604ec5c25176c..5881497825b3c11ce5d23e4f609fd769
  import net.minecraft.world.entity.boss.EntityComplexPart;
  import net.minecraft.world.entity.boss.enderdragon.EntityEnderCrystal;
  import net.minecraft.world.entity.boss.enderdragon.EntityEnderDragon;
-@@ -386,6 +387,7 @@ public class ActivationRange
+@@ -387,6 +388,7 @@ public class ActivationRange
       */
      public static boolean checkIfActive(Entity entity)
      {

--- a/patches/server/0094-Totems-work-in-inventory.patch
+++ b/patches/server/0094-Totems-work-in-inventory.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Totems work in inventory
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index a2073fd6fc5c2a5fd2835445019c7ecf86c5eb47..451a28b1950bad61de7181a2fb89549063d8e2bf 100644
+index f4407cd0865b0e4861930645615c057d11079034..8930ab8a39c50eaa84372f0e8caf8b92789bb0c4 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -1426,6 +1426,19 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0095-Populator-seed-controls.patch
+++ b/patches/server/0095-Populator-seed-controls.patch
@@ -18,7 +18,7 @@ index 5e672a0660d0aceffcdb26d185590ca18aa4f023..4b171a2a60e24947e884f8988920f335
              }
              final Object val = config.get(key);
 diff --git a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
-index d0433feeb274f474af04ba1e09f9f75d5b4dcfea..ea0a292c93bd7d777a5979f930822a8912c2f8d0 100644
+index a30bb38144acb74f41638cc2b573e09265cde0e1..6b20eb6f2a0a5bcaa88438cf14e1fbfe31c00627 100644
 --- a/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 +++ b/src/main/java/com/tuinity/tuinity/config/TuinityConfig.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0098-Dispensers-place-anvils-option.patch
+++ b/patches/server/0098-Dispensers-place-anvils-option.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Dispensers place anvils option
 
 
 diff --git a/src/main/java/net/minecraft/core/EnumDirection.java b/src/main/java/net/minecraft/core/EnumDirection.java
-index 7918d830a4aef09c9f517284e83a9376299116ad..29d747f7fc5824a222755ebf96dfe053896d43d0 100644
+index 0a40df2151bd388b6633a6f50b14f1f41ed4ce62..3ff1d8b3dfaeb875e5e70b97abb79a21f671f328 100644
 --- a/src/main/java/net/minecraft/core/EnumDirection.java
 +++ b/src/main/java/net/minecraft/core/EnumDirection.java
 @@ -116,6 +116,7 @@ public enum EnumDirection implements INamable {

--- a/patches/server/0100-Add-no-random-tick-block-list.patch
+++ b/patches/server/0100-Add-no-random-tick-block-list.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add no-random-tick block list
 
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 12bac4dbf7164c4d674897ed067958965a862864..cbce2dec89dbf86e619d1d7721f53946f4a72929 100644
+index 4df02479e3443becfa3ce91c00f51c2c19059e54..5e5645865a7be673995d395db20077ee2ea6660e 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -532,14 +532,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0103-Stop-squids-floating-on-top-of-water.patch
+++ b/patches/server/0103-Stop-squids-floating-on-top-of-water.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Stop squids floating on top of water
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5ac6b7759cf43dbbad1bcf74d5d86efd69883cf5..240f30f6ca6007ba8e7de1c3e033b2a8493838e7 100644
+index 0336946172c2a9b08d5b0b7c3f155d3eae0385db..15daeadc81bfbbef09755d0117b5939163f3ee4a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3556,8 +3556,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3589,8 +3589,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.lastYaw = this.yaw;
      }
  

--- a/patches/server/0104-Ridables.patch
+++ b/patches/server/0104-Ridables.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ridables
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index cdddae4ff5178112d4523079144803f2694267d5..f6637353fb358e7720edabc355ea036d37d039ca 100644
+index 59dbc74f78eb8e065e815b6d4efc39350b2479ec..9dfcfffeaab976d00d27e75857715c2113661b9c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1540,6 +1540,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -68,7 +68,7 @@ index 0000000000000000000000000000000000000000..8b66d1215a6eef1302b5ecb46a4b3d50
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 8e76c11e6bec5357322ea906af9e30f71e5718be..86bd39af6e3240b82f5afd6e7c554471f7bbd6ba 100644
+index 77a49f76927e65874ae35f7709bef1b041bf77a6..4f641d43c3d26c50b58caf8d6c2f05a9e077236a 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -643,6 +643,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -88,7 +88,7 @@ index 8e76c11e6bec5357322ea906af9e30f71e5718be..86bd39af6e3240b82f5afd6e7c554471
  
      public void playerTick() {
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index cbce2dec89dbf86e619d1d7721f53946f4a72929..83f3250b2e9661bb1c0f8adaf02c91d04a15853f 100644
+index 5e5645865a7be673995d395db20077ee2ea6660e..36b374187fcdec619c0a8f5511ddcff1f76f7e30 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -216,6 +216,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -100,10 +100,10 @@ index cbce2dec89dbf86e619d1d7721f53946f4a72929..83f3250b2e9661bb1c0f8adaf02c91d0
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index d30a9ef98cbe214c0258e7d5e8527ff8fd956ddd..e39e46cf3cb646dd100b698cbc6d4f9b6896696d 100644
+index 92437cf4413ea76ef139b007adf2b76c2729dad2..07541f23ee853dae137440129e600d345774cd90 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -2464,6 +2464,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2467,6 +2467,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      }
                      this.server.getPluginManager().callEvent(event);
  
@@ -133,7 +133,7 @@ index 6ba14f603b8ec69597c70677cc317f802d6afae9..24fd920394774bf38d2818a4cd013670
          this.B = true;
          return this;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a8e8eb962 100644
+index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff367786e697859 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -22,6 +22,7 @@ import net.minecraft.BlockUtil;
@@ -171,7 +171,7 @@ index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a
      private float headHeight;
      // CraftBukkit start
      public boolean persist = true;
-@@ -1590,6 +1591,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1623,6 +1624,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return !this.justCreated && this.M.getDouble(TagsFluid.LAVA) > 0.0D;
      }
  
@@ -179,7 +179,7 @@ index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a
      public void a(float f, Vec3D vec3d) {
          Vec3D vec3d1 = a(vec3d, f, this.yaw);
  
-@@ -2346,6 +2348,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2379,6 +2381,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.a(entity, false);
      }
  
@@ -187,7 +187,7 @@ index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a
      public boolean a(Entity entity, boolean flag) {
          for (Entity entity1 = entity; entity1.vehicle != null; entity1 = entity1.vehicle) {
              if (entity1.vehicle == this) {
-@@ -2441,6 +2444,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2474,6 +2477,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  this.passengers.add(entity);
              }
  
@@ -201,7 +201,7 @@ index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a
          }
          return true; // CraftBukkit
      }
-@@ -2481,6 +2491,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2514,6 +2524,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  return false;
              }
              // Spigot end
@@ -214,7 +214,7 @@ index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a
              this.passengers.remove(entity);
              entity.j = 60;
          }
-@@ -2646,6 +2662,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2679,6 +2695,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.setFlag(4, flag);
      }
  
@@ -222,7 +222,7 @@ index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a
      public boolean bE() {
          return this.glowing || this.world.isClientSide && this.getFlag(6);
      }
-@@ -2868,6 +2885,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2901,6 +2918,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      public void setHeadRotation(float f) {}
  
@@ -230,7 +230,7 @@ index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a
      public void n(float f) {}
  
      public boolean bL() {
-@@ -3309,6 +3327,18 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3342,6 +3360,18 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return false;
      }
  
@@ -249,7 +249,7 @@ index 240f30f6ca6007ba8e7de1c3e033b2a8493838e7..d1bbf4127a2e0836bedb33a81e3fd18a
      @Override
      public void sendMessage(IChatBaseComponent ichatbasecomponent, UUID uuid) {}
  
-@@ -3761,4 +3791,47 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3794,4 +3824,47 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return ((ChunkProviderServer) world.getChunkProvider()).isInEntityTickingChunk(this);
      }
      // Paper end
@@ -419,7 +419,7 @@ index c9136f1b54ff0620a621b703b4e7487f4a63b01d..8b7f840bb1b24996b40c9bef85f4c1e9
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 451a28b1950bad61de7181a2fb89549063d8e2bf..c0a6bbe570e95f4449b404b21855860c7aba057a 100644
+index 8930ab8a39c50eaa84372f0e8caf8b92789bb0c4..bcf1d77f627e800b9dbbfd7f9ed99887e2aca714 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -559,7 +559,7 @@ public abstract class EntityLiving extends Entity {
@@ -1266,7 +1266,7 @@ index e0a9b931c26dbd4e7739d09ae45e1cee72ab210c..880c3aaf4e684209879dc921480619e7
                  this.i.setMot(this.i.getMot().add(0.0D, 0.005D, 0.0D));
              }
 diff --git a/src/main/java/net/minecraft/world/entity/animal/EntityFish.java b/src/main/java/net/minecraft/world/entity/animal/EntityFish.java
-index e28f84be745647960c936c7208a87713dfa75682..e1e4ea73f42a09ac20d36a58f4d7232d4e1a2f08 100644
+index cbd7c37cd1d6f5dddcbc515ecc2d9df46e109bfa..bdbb389407a68d7f9fd7db366d710777ec3e2649 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/EntityFish.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/EntityFish.java
 @@ -8,6 +8,7 @@ import net.minecraft.nbt.NBTTagCompound;
@@ -1277,7 +1277,7 @@ index e28f84be745647960c936c7208a87713dfa75682..e1e4ea73f42a09ac20d36a58f4d7232d
  import net.minecraft.server.level.EntityPlayer;
  import net.minecraft.sounds.SoundEffect;
  import net.minecraft.sounds.SoundEffects;
-@@ -108,13 +109,12 @@ public abstract class EntityFish extends EntityWaterAnimal {
+@@ -116,13 +117,12 @@ public abstract class EntityFish extends EntityWaterAnimal {
      @Override
      protected void initPathfinder() {
          super.initPathfinder();
@@ -1297,7 +1297,7 @@ index e28f84be745647960c936c7208a87713dfa75682..e1e4ea73f42a09ac20d36a58f4d7232d
      }
  
      @Override
-@@ -125,7 +125,7 @@ public abstract class EntityFish extends EntityWaterAnimal {
+@@ -133,7 +133,7 @@ public abstract class EntityFish extends EntityWaterAnimal {
      @Override
      public void g(Vec3D vec3d) {
          if (this.doAITick() && this.isInWater()) {
@@ -1306,7 +1306,7 @@ index e28f84be745647960c936c7208a87713dfa75682..e1e4ea73f42a09ac20d36a58f4d7232d
              this.move(EnumMoveType.SELF, this.getMot());
              this.setMot(this.getMot().a(0.9D));
              if (this.getGoalTarget() == null) {
-@@ -199,9 +199,9 @@ public abstract class EntityFish extends EntityWaterAnimal {
+@@ -220,9 +220,9 @@ public abstract class EntityFish extends EntityWaterAnimal {
      @Override
      protected void b(BlockPosition blockposition, IBlockData iblockdata) {}
  
@@ -1318,7 +1318,7 @@ index e28f84be745647960c936c7208a87713dfa75682..e1e4ea73f42a09ac20d36a58f4d7232d
  
          a(EntityFish entityfish) {
              super(entityfish);
-@@ -209,7 +209,15 @@ public abstract class EntityFish extends EntityWaterAnimal {
+@@ -230,7 +230,15 @@ public abstract class EntityFish extends EntityWaterAnimal {
          }
  
          @Override
@@ -4347,10 +4347,10 @@ index 07ede7b75a65a5815f1ae1ebf03ec0fdb4621afb..a836839b17cbda8ac269f032b141ba44
                  EntityPhantom.this.yaw += 180.0F;
                  this.j = 0.1F;
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java b/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
-index af00a4245ca39f208810d1ec758e512cbf5648f3..816a2bd7438f66a5d7ff761b8fcf8b42483561c7 100644
+index ee17e62d996d81ea149a5c0eae2e29404e363dcf..9f50054211db48e7fe764434e8d71aab0995e57a 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
-@@ -56,6 +56,16 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
+@@ -57,6 +57,16 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
      }
  
      // Purpur start
@@ -5415,7 +5415,7 @@ index e0324cdb2d4c85714eaad490a7a5c826b38e6b16..90cbef7fe8803295f82bddd6709fdf30
                      this.setTradingPlayer(entityhuman);
                      this.openTrade(entityhuman, this.getScoreboardDisplayName(), 1);
 diff --git a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-index 2ee7daa155d812af8f84ba646106d801d2fb0fec..644f94002bfe2686f4c765251c3804c854b27869 100644
+index 1b130b50888113d515ce1e200a157c3bbff3b625..fedfb18e71300807a83e2ed2729fe192a8f9aa33 100644
 --- a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 +++ b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 @@ -183,6 +183,8 @@ public abstract class EntityHuman extends EntityLiving {
@@ -5427,7 +5427,7 @@ index 2ee7daa155d812af8f84ba646106d801d2fb0fec..644f94002bfe2686f4c765251c3804c8
      private javax.script.ScriptEngine scriptEngine = new javax.script.ScriptEngineManager().getEngineByName("rhino");
  
      public void setAfk(boolean setAfk){
-@@ -2258,4 +2260,15 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -2271,4 +2273,15 @@ public abstract class EntityHuman extends EntityLiving {
              return this.g;
          }
      }
@@ -6885,10 +6885,10 @@ index dee4d12a49468d38f077784b219199f0070786f2..c524a0994f1c9ef1d0534403efa4e448
 +    // Purpur end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9084aa4b7c0059c995a3d1a89188379b52c9d620..7341b1956123d8e5d45d9041e7319de8ee8b768a 100644
+index ac89b7f0de0e5015c599648dc93cbcae760744f2..c44a15cd7b2d67c77eac7a1d2a7e9569f9dce48c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -530,6 +530,18 @@ public class CraftEventFactory {
+@@ -544,6 +544,18 @@ public class CraftEventFactory {
          }
          craftServer.getPluginManager().callEvent(event);
  
@@ -6907,7 +6907,7 @@ index 9084aa4b7c0059c995a3d1a89188379b52c9d620..7341b1956123d8e5d45d9041e7319de8
          return event;
      }
  
-@@ -930,6 +942,7 @@ public class CraftEventFactory {
+@@ -944,6 +956,7 @@ public class CraftEventFactory {
                      damageCause = DamageCause.ENTITY_EXPLOSION;
                  }
                  event = new EntityDamageByEntityEvent(damager.getBukkitEntity(), entity.getBukkitEntity(), damageCause, modifiers, modifierFunctions);
@@ -6915,7 +6915,7 @@ index 9084aa4b7c0059c995a3d1a89188379b52c9d620..7341b1956123d8e5d45d9041e7319de8
              }
              event.setCancelled(cancelled);
  
-@@ -1014,6 +1027,7 @@ public class CraftEventFactory {
+@@ -1028,6 +1041,7 @@ public class CraftEventFactory {
              if (!event.isCancelled()) {
                  event.getEntity().setLastDamageCause(event);
              }
@@ -6923,7 +6923,7 @@ index 9084aa4b7c0059c995a3d1a89188379b52c9d620..7341b1956123d8e5d45d9041e7319de8
              return event;
          }
  
-@@ -1063,6 +1077,7 @@ public class CraftEventFactory {
+@@ -1077,6 +1091,7 @@ public class CraftEventFactory {
          EntityDamageEvent event;
          if (damager != null) {
              event = new EntityDamageByEntityEvent(damager.getBukkitEntity(), damagee.getBukkitEntity(), cause, modifiers, modifierFunctions);

--- a/patches/server/0106-Crying-obsidian-valid-for-portal-frames.patch
+++ b/patches/server/0106-Crying-obsidian-valid-for-portal-frames.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Crying obsidian valid for portal frames
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index 5ea059cde9e1a089c2ade12512e4a7abd07c5b8a..97eb81338207c93125bea082256384946a8305bb 100644
+index e18b3b575e4fe3fde869e749070feefb31548a25..26cda907063f104fd4a3fbd2286b37fb539f741a 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
 @@ -141,6 +141,7 @@ public class Block extends BlockBase implements IMaterial {

--- a/patches/server/0107-Entities-can-use-portals-configuration.patch
+++ b/patches/server/0107-Entities-can-use-portals-configuration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entities can use portals configuration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d1bbf4127a2e0836bedb33a81e3fd18a8e8eb962..4b4c6477122c51871ce98f34c6e5874048eaa227 100644
+index 586c65f026d3b4f5b6e1ebcd1ff367786e697859..543a2d209726ef57e7ba542f11b1087611b3ae8e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2523,7 +2523,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2556,7 +2556,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public void d(BlockPosition blockposition) {
          if (this.ai()) {
              this.resetPortalCooldown();
@@ -17,7 +17,7 @@ index d1bbf4127a2e0836bedb33a81e3fd18a8e8eb962..4b4c6477122c51871ce98f34c6e58740
              if (!this.world.isClientSide && !blockposition.equals(this.ac)) {
                  this.ac = blockposition.immutableCopy();
              }
-@@ -3103,7 +3103,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3136,7 +3136,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean canPortal() {

--- a/patches/server/0110-Allow-toggling-special-MobSpawners-per-world.patch
+++ b/patches/server/0110-Allow-toggling-special-MobSpawners-per-world.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow toggling special MobSpawners per world
 In vanilla, these are all hardcoded on for world type 0 (overworld) and hardcoded off for every other world type. Default config behaviour matches this.
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 83f3250b2e9661bb1c0f8adaf02c91d04a15853f..6340831852f07af8d93a4d0a3605d7b1b2f5d009 100644
+index 36b374187fcdec619c0a8f5511ddcff1f76f7e30..29b7c8ee5158e4c5aec1809ef083916a1914d5fb 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -92,6 +92,7 @@ import net.minecraft.world.entity.EnumCreatureType;

--- a/patches/server/0114-Persistent-TileEntity-Lore-and-DisplayName.patch
+++ b/patches/server/0114-Persistent-TileEntity-Lore-and-DisplayName.patch
@@ -61,7 +61,7 @@ index 59d52c252b2e59923b8e513dd4d2e1ec9ce34dc7..4be1c8ee85f411a8b01be50b8cc3dc38
  
      @Nullable
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index 97eb81338207c93125bea082256384946a8305bb..eecb17e887bf0d1680a5fb5198a8b4246c14e548 100644
+index 26cda907063f104fd4a3fbd2286b37fb539f741a..fab55929f72c5784291b3bc87f7717ac24b7806f 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
 @@ -15,10 +15,15 @@ import net.minecraft.core.EnumDirection;
@@ -149,10 +149,10 @@ index 97eb81338207c93125bea082256384946a8305bb..eecb17e887bf0d1680a5fb5198a8b424
          if (!world.isClientSide && !itemstack.isEmpty() && world.getGameRules().getBoolean(GameRules.DO_TILE_DROPS)) {
              float f = 0.5F;
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TileEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TileEntity.java
-index f1e586754396439dfb70a4d63e3b8b34fb36ebf4..8a049d3de8937a6c8afe178ccd134e2511fb3baf 100644
+index 93d02ccb87c17404c55884f52ae40c7b7ddfb103..35c4d5414db66b977a354ac50d35a6aa0fcd4cf8 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TileEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TileEntity.java
-@@ -5,6 +5,8 @@ import net.minecraft.CrashReportSystemDetails;
+@@ -6,6 +6,8 @@ import net.minecraft.ResourceKeyInvalidException;
  import net.minecraft.core.BlockPosition;
  import net.minecraft.core.IRegistry;
  import net.minecraft.nbt.NBTTagCompound;
@@ -161,7 +161,7 @@ index f1e586754396439dfb70a4d63e3b8b34fb36ebf4..8a049d3de8937a6c8afe178ccd134e25
  import net.minecraft.network.protocol.game.PacketPlayOutTileEntityData;
  import net.minecraft.resources.MinecraftKey;
  import net.minecraft.world.level.World;
-@@ -104,9 +106,25 @@ public abstract class TileEntity implements net.minecraft.server.KeyedObject { /
+@@ -105,9 +107,25 @@ public abstract class TileEntity implements net.minecraft.server.KeyedObject { /
              this.persistentDataContainer.putAll((NBTTagCompound) persistentDataTag);
          }
          // CraftBukkit end
@@ -187,7 +187,7 @@ index f1e586754396439dfb70a4d63e3b8b34fb36ebf4..8a049d3de8937a6c8afe178ccd134e25
          return this.b(nbttagcompound);
      }
  
-@@ -267,4 +285,25 @@ public abstract class TileEntity implements net.minecraft.server.KeyedObject { /
+@@ -274,4 +292,25 @@ public abstract class TileEntity implements net.minecraft.server.KeyedObject { /
          return null;
      }
      // CraftBukkit end

--- a/patches/server/0119-Configurable-daylight-cycle.patch
+++ b/patches/server/0119-Configurable-daylight-cycle.patch
@@ -18,7 +18,7 @@ index 3086ee023685781d94e2fb99fc8dff5264f01165..74c1047305cac5673e274096709c757e
      public PacketPlayOutUpdateTime() {}
  
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 6340831852f07af8d93a4d0a3605d7b1b2f5d009..f6d6387588f98049a2e94e73edee14250a6efb9e 100644
+index 29b7c8ee5158e4c5aec1809ef083916a1914d5fb..b2eba3d8d973285fec51a12ba0151406750d3ac6 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -64,6 +64,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutExplosion;
@@ -45,7 +45,7 @@ index 6340831852f07af8d93a4d0a3605d7b1b2f5d009..f6d6387588f98049a2e94e73edee1425
      }
  
      // Tuinity start - optimise collision
-@@ -1212,7 +1215,21 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1222,7 +1225,21 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              this.nextTickListBlock.nextTick(); // Paper
              this.nextTickListFluid.nextTick(); // Paper
              this.worldDataServer.u().a(this.server, i);
@@ -68,7 +68,7 @@ index 6340831852f07af8d93a4d0a3605d7b1b2f5d009..f6d6387588f98049a2e94e73edee1425
                  this.setDayTime(this.worldData.getDayTime() + 1L);
              }
  
-@@ -1221,6 +1238,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1231,6 +1248,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
      public void setDayTime(long i) {
          this.worldDataServer.setDayTime(i);

--- a/patches/server/0121-Infinite-fuel-furnace.patch
+++ b/patches/server/0121-Infinite-fuel-furnace.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Infinite fuel furnace
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TileEntityFurnace.java b/src/main/java/net/minecraft/world/level/block/entity/TileEntityFurnace.java
-index 1997139fb87dc1947acfdf02e1f116577c3fa943..cd7bcedf8474dcb565b5b1157e167706c031a7f1 100644
+index 9ce19b89c16eb6edd3d5d5cc87a966a37f66895c..ac42fd627009a87709448354f232d8b5ed7fa6b9 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TileEntityFurnace.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TileEntityFurnace.java
 @@ -12,6 +12,7 @@ import java.util.Map;

--- a/patches/server/0123-Add-tablist-suffix-option-for-afk.patch
+++ b/patches/server/0123-Add-tablist-suffix-option-for-afk.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tablist suffix option for afk
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 86bd39af6e3240b82f5afd6e7c554471f7bbd6ba..7faf393954b703efda7290c831ff75b6a02a4dc1 100644
+index 4f641d43c3d26c50b58caf8d6c2f05a9e077236a..14442a53750f67235bc6a1e14e83c9fdb733b5eb 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -2122,7 +2122,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2123,7 +2123,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          }
  
          if (world.purpurConfig.idleTimeoutUpdateTabList) {

--- a/patches/server/0132-Add-critical-hit-check-to-EntityDamagedByEntityEvent.patch
+++ b/patches/server/0132-Add-critical-hit-check-to-EntityDamagedByEntityEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add critical hit check to EntityDamagedByEntityEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-index 644f94002bfe2686f4c765251c3804c854b27869..8b956fb01cff3e1990823430333e5d707bf9addf 100644
+index fedfb18e71300807a83e2ed2729fe192a8f9aa33..af10d5aea7909ee9f38982264233f0a45c153003 100644
 --- a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 +++ b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 @@ -171,6 +171,7 @@ public abstract class EntityHuman extends EntityLiving {
@@ -16,7 +16,7 @@ index 644f94002bfe2686f4c765251c3804c854b27869..8b956fb01cff3e1990823430333e5d70
  
      // CraftBukkit start
      public boolean fauxSleeping;
-@@ -1166,6 +1167,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1178,6 +1179,7 @@ public abstract class EntityHuman extends EntityLiving {
                      flag2 = flag2 && !world.paperConfig.disablePlayerCrits; // Paper
                      flag2 = flag2 && !this.isSprinting();
                      if (flag2) {
@@ -24,7 +24,7 @@ index 644f94002bfe2686f4c765251c3804c854b27869..8b956fb01cff3e1990823430333e5d70
                          f *= 1.5F;
                      }
  
-@@ -1202,6 +1204,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1214,6 +1216,7 @@ public abstract class EntityHuman extends EntityLiving {
  
                      Vec3D vec3d = entity.getMot();
                      boolean flag5 = entity.damageEntity(DamageSource.playerAttack(this), f);
@@ -33,10 +33,10 @@ index 644f94002bfe2686f4c765251c3804c854b27869..8b956fb01cff3e1990823430333e5d70
                      if (flag5) {
                          if (i > 0) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7341b1956123d8e5d45d9041e7319de8ee8b768a..470ae06db18a78327cc3218f1f7180bcc859a198 100644
+index c44a15cd7b2d67c77eac7a1d2a7e9569f9dce48c..ad325f58198fcae7b9cae55e4c9675c8498838d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1076,7 +1076,7 @@ public class CraftEventFactory {
+@@ -1090,7 +1090,7 @@ public class CraftEventFactory {
      private static EntityDamageEvent callEntityDamageEvent(Entity damager, Entity damagee, DamageCause cause, Map<DamageModifier, Double> modifiers, Map<DamageModifier, Function<? super Double, Double>> modifierFunctions, boolean cancelled) {
          EntityDamageEvent event;
          if (damager != null) {

--- a/patches/server/0135-Add-demo-command.patch
+++ b/patches/server/0135-Add-demo-command.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add demo command
 
 
 diff --git a/src/main/java/net/minecraft/commands/CommandDispatcher.java b/src/main/java/net/minecraft/commands/CommandDispatcher.java
-index e8fe4984fdc67536561a1ad08b328a30b30b8717..a551636c2c59e68a5abb1cd5611c1d5c7e36f514 100644
+index cf3776591446ad7b3d1ee1285c5aeffcb5e9495e..0982b14a4b39c40a68ee900d506b4e44f840299d 100644
 --- a/src/main/java/net/minecraft/commands/CommandDispatcher.java
 +++ b/src/main/java/net/minecraft/commands/CommandDispatcher.java
 @@ -191,6 +191,7 @@ public class CommandDispatcher {

--- a/patches/server/0139-Add-boat-fall-damage-config.patch
+++ b/patches/server/0139-Add-boat-fall-damage-config.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add boat fall damage config
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 7faf393954b703efda7290c831ff75b6a02a4dc1..35b26e520be7c06b296ae219be18ef38a1de5dfc 100644
+index 14442a53750f67235bc6a1e14e83c9fdb733b5eb..e0694ff71102313634c9d3836ea9f48e7f41c23a 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -106,6 +106,7 @@ import net.minecraft.world.entity.monster.EntityMonster;

--- a/patches/server/0143-EMC-Configurable-disable-give-dropping.patch
+++ b/patches/server/0143-EMC-Configurable-disable-give-dropping.patch
@@ -8,7 +8,7 @@ purpur.yml to disable the /give command from dropping items on the
 floor when a player's inventory is full.
 
 diff --git a/src/main/java/net/minecraft/server/commands/CommandGive.java b/src/main/java/net/minecraft/server/commands/CommandGive.java
-index 6685bf1757458d908e32d4069f7a8a22a28c28d7..82d663d3b8bbbb020c3467ea93b54729c3053f9e 100644
+index a10207f7cb9455e29db7e6906cb2138ad5609a1f..9557fd12f87e7e825501759598eaee75cd3891ac 100644
 --- a/src/main/java/net/minecraft/server/commands/CommandGive.java
 +++ b/src/main/java/net/minecraft/server/commands/CommandGive.java
 @@ -47,6 +47,7 @@ public class CommandGive {
@@ -18,7 +18,7 @@ index 6685bf1757458d908e32d4069f7a8a22a28c28d7..82d663d3b8bbbb020c3467ea93b54729
 +                if (net.pl3x.purpur.PurpurConfig.disableGiveCommandDrops) continue; // Purpur - add config option for toggling give command dropping
                  if (flag && itemstack.isEmpty()) {
                      itemstack.setCount(1);
-                     entityitem = entityplayer.drop(itemstack, false);
+                     entityitem = entityplayer.drop(itemstack, false, false, true); // Paper - Fix duplicating /give items on item drop cancel
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 index dc6122ef302055eb2c08fda05be977b045b6debe..f1088638716b4a02eb3b8541a040229da8a6ea24 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java

--- a/patches/server/0145-Lobotomize-stuck-villagers.patch
+++ b/patches/server/0145-Lobotomize-stuck-villagers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Lobotomize stuck villagers
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4b4c6477122c51871ce98f34c6e5874048eaa227..904bca540a42204a9856765e333eee6c5de6a960 100644
+index 543a2d209726ef57e7ba542f11b1087611b3ae8e..ac6f63e22c3c5312855d0263a627a8db7eb33cdd 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -207,7 +207,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne

--- a/patches/server/0147-Toggle-for-Zombified-Piglin-death-always-counting-as.patch
+++ b/patches/server/0147-Toggle-for-Zombified-Piglin-death-always-counting-as.patch
@@ -13,10 +13,10 @@ to the Piglin being angry, even though the player never hit them.
 This patch adds a toggle to disable this behavior.
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java b/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
-index 816a2bd7438f66a5d7ff761b8fcf8b42483561c7..8db9c62093b2f075face65030cb91c24fb6c2dbf 100644
+index 9f50054211db48e7fe764434e8d71aab0995e57a..82279ab2f3c1edec14c24c3a7ad24d097d52dea2 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
-@@ -129,7 +129,7 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
+@@ -130,7 +130,7 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
              this.eY();
          }
  
@@ -25,7 +25,7 @@ index 816a2bd7438f66a5d7ff761b8fcf8b42483561c7..8db9c62093b2f075face65030cb91c24
              this.lastDamageByPlayerTime = this.ticksLived;
          }
  
-@@ -184,7 +184,7 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
+@@ -185,7 +185,7 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
              this.bt = EntityPigZombie.bs.a(this.random);
          }
  

--- a/patches/server/0148-Spread-out-and-optimise-player-list-ticks.patch
+++ b/patches/server/0148-Spread-out-and-optimise-player-list-ticks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Spread out and optimise player list ticks
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3a46a673349de9d9d725516a0fcdb3ebb9b372b3..c316b0468c53825f90d9bc2ad40d655d92857715 100644
+index c742647c0c5e3e4925e4ee6d195a54a85435e65e..8307b44718198f6f2325454f72bd296c33cba58a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -151,7 +151,7 @@ public abstract class PlayerList {
@@ -17,7 +17,7 @@ index 3a46a673349de9d9d725516a0fcdb3ebb9b372b3..c316b0468c53825f90d9bc2ad40d655d
  
      // CraftBukkit start
      private CraftServer cserver;
-@@ -1021,22 +1021,23 @@ public abstract class PlayerList {
+@@ -1023,22 +1023,23 @@ public abstract class PlayerList {
      }
  
      public void tick() {

--- a/patches/server/0149-Configurable-chance-for-wolves-to-spawn-rabid.patch
+++ b/patches/server/0149-Configurable-chance-for-wolves-to-spawn-rabid.patch
@@ -7,7 +7,7 @@ Configurable chance to spawn a wolf that is rabid.
 Rabid wolves attack all players, mobs, and animals.
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index c0a6bbe570e95f4449b404b21855860c7aba057a..04ae8af914e65ae9725d276a9dcc24893cbcabb9 100644
+index bcf1d77f627e800b9dbbfd7f9ed99887e2aca714..c957122f8463fc1eae632730a64bec7f8b0d1055 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -2200,6 +2200,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0151-Configurable-entity-base-attributes.patch
+++ b/patches/server/0151-Configurable-entity-base-attributes.patch
@@ -921,10 +921,10 @@ index a836839b17cbda8ac269f032b141ba448e3bab8c..902b26d609aef8dd46e8875cb7c06f18
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java b/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
-index 8db9c62093b2f075face65030cb91c24fb6c2dbf..736c45bae020158866514bc760c05a929f47c531 100644
+index 82279ab2f3c1edec14c24c3a7ad24d097d52dea2..dfe65943b3a2f744f06b4669590cc203e8419e60 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EntityPigZombie.java
-@@ -80,6 +80,15 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
+@@ -81,6 +81,15 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
      public boolean jockeyTryExistingChickens() {
          return world.purpurConfig.zombifiedPiglinJockeyTryExistingChickens;
      }
@@ -940,7 +940,7 @@ index 8db9c62093b2f075face65030cb91c24fb6c2dbf..736c45bae020158866514bc760c05a92
      // Purpur end
  
      @Override
-@@ -268,7 +277,7 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
+@@ -270,7 +279,7 @@ public class EntityPigZombie extends EntityZombie implements IEntityAngerable {
  
      @Override
      protected void eV() {

--- a/patches/server/0154-Implement-TPSBar.patch
+++ b/patches/server/0154-Implement-TPSBar.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement TPSBar
 
 
 diff --git a/src/main/java/net/minecraft/commands/CommandDispatcher.java b/src/main/java/net/minecraft/commands/CommandDispatcher.java
-index a551636c2c59e68a5abb1cd5611c1d5c7e36f514..b7663a3d64ae5202abb93eabba6ec013bae96334 100644
+index 0982b14a4b39c40a68ee900d506b4e44f840299d..324f475513eecab4242b8900084d7f088bd0e10b 100644
 --- a/src/main/java/net/minecraft/commands/CommandDispatcher.java
 +++ b/src/main/java/net/minecraft/commands/CommandDispatcher.java
 @@ -193,6 +193,7 @@ public class CommandDispatcher {
@@ -17,7 +17,7 @@ index a551636c2c59e68a5abb1cd5611c1d5c7e36f514..b7663a3d64ae5202abb93eabba6ec013
  
          if (commanddispatcher_servertype.d) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f6637353fb358e7720edabc355ea036d37d039ca..5e2c7f3bf9aa99b10260454b9957caff81a7cd26 100644
+index 9dfcfffeaab976d00d27e75857715c2113661b9c..5f8960754f7a04fba66184df47f3f6b49646d302 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -989,6 +989,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -29,10 +29,10 @@ index f6637353fb358e7720edabc355ea036d37d039ca..5e2c7f3bf9aa99b10260454b9957caff
          this.isRestarting = isRestarting;
          this.hasLoggedStop = true; // Paper
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 28d47ef97939309ce26b6e4cae14925b510755fd..6d39b777a0f708d61f611d9c16c3b3c48f89d477 100644
+index a76219e59c24862b9c1e09e4a2a29cf2a6260514..4f7fed0418df17b80cb41e16bb1978c5cb284810 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -323,6 +323,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -324,6 +324,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
                  MinecraftServerBeans.a((MinecraftServer) this);
              }
  
@@ -42,7 +42,7 @@ index 28d47ef97939309ce26b6e4cae14925b510755fd..6d39b777a0f708d61f611d9c16c3b3c4
          }
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c316b0468c53825f90d9bc2ad40d655d92857715..d710834422afa1d4336f68e2425aaffd64d444e2 100644
+index 8307b44718198f6f2325454f72bd296c33cba58a..c1f86c5cb6cf4c42dbc972f9ec14efa8452bad91 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -598,6 +598,8 @@ public abstract class PlayerList {

--- a/patches/server/0156-PlayerBookTooLargeEvent.patch
+++ b/patches/server/0156-PlayerBookTooLargeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerBookTooLargeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index e39e46cf3cb646dd100b698cbc6d4f9b6896696d..f9a232cbc5dc55f3de2286037ca526b15c0842ba 100644
+index 07541f23ee853dae137440129e600d345774cd90..5a2f84cd1456b072084e2db53a24c9863cb75563 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -1121,6 +1121,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1123,6 +1123,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
              NBTTagList pageList = testStack.getTag().getList("pages", 8);
              if (pageList.size() > 100) {
                  PlayerConnection.LOGGER.warn(this.player.getName() + " tried to send a book with too many pages");
@@ -16,7 +16,7 @@ index e39e46cf3cb646dd100b698cbc6d4f9b6896696d..f9a232cbc5dc55f3de2286037ca526b1
                  minecraftServer.scheduleOnMain(() -> this.disconnect("Book too large!"));
                  return;
              }
-@@ -1133,6 +1134,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1135,6 +1136,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  int byteLength = testString.getBytes(java.nio.charset.StandardCharsets.UTF_8).length;
                  if (byteLength > 256 * 4) {
                      PlayerConnection.LOGGER.warn(this.player.getName() + " tried to send a book with with a page too large!");
@@ -24,7 +24,7 @@ index e39e46cf3cb646dd100b698cbc6d4f9b6896696d..f9a232cbc5dc55f3de2286037ca526b1
                      minecraftServer.scheduleOnMain(() -> this.disconnect("Book too large!"));
                      return;
                  }
-@@ -1156,6 +1158,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1158,6 +1160,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
              if (byteTotal > byteAllowed) {
                  PlayerConnection.LOGGER.warn(this.player.getName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());

--- a/patches/server/0157-Full-netherite-armor-grants-fire-resistance.patch
+++ b/patches/server/0157-Full-netherite-armor-grants-fire-resistance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Full netherite armor grants fire resistance
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-index 8b956fb01cff3e1990823430333e5d707bf9addf..89d6bfe81c9fb33e2ba51b9e215d79fac6245d16 100644
+index af10d5aea7909ee9f38982264233f0a45c153003..5a2678cf3a8441344629b6a0bf4b6be538baae4f 100644
 --- a/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
 +++ b/src/main/java/net/minecraft/world/entity/player/EntityHuman.java
-@@ -336,6 +336,16 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -341,6 +341,16 @@ public abstract class EntityHuman extends EntityLiving {
              this.addEffect(new MobEffect(MobEffects.WATER_BREATHING, 200, 0, false, false, true), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.TURTLE_HELMET); // CraftBukkit
          }
  

--- a/patches/server/0158-Fix-rotating-UP-DOWN-CW-and-CCW.patch
+++ b/patches/server/0158-Fix-rotating-UP-DOWN-CW-and-CCW.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix rotating UP/DOWN CW and CCW
 
 
 diff --git a/src/main/java/net/minecraft/core/EnumDirection.java b/src/main/java/net/minecraft/core/EnumDirection.java
-index 29d747f7fc5824a222755ebf96dfe053896d43d0..9f1ea11d0bc15b8b0069fcf46ea2f6751c5e3064 100644
+index 3ff1d8b3dfaeb875e5e70b97abb79a21f671f328..19bc37143140b4e3a06a87297205b702548b0fa3 100644
 --- a/src/main/java/net/minecraft/core/EnumDirection.java
 +++ b/src/main/java/net/minecraft/core/EnumDirection.java
 @@ -127,6 +127,12 @@ public enum EnumDirection implements INamable {

--- a/patches/server/0160-Add-mobGriefing-bypass-to-everything-affected.patch
+++ b/patches/server/0160-Add-mobGriefing-bypass-to-everything-affected.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add mobGriefing bypass to everything affected
 This adds the "bypass-mob-griefing" world config option to everything that is affected by the gamerule.
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 04ae8af914e65ae9725d276a9dcc24893cbcabb9..1757e44ecb9d23fd0ca6f7e7f9c07509b377675f 100644
+index c957122f8463fc1eae632730a64bec7f8b0d1055..52bd6b4a3bcd44166bd4c897756fe06b19120907 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -1571,7 +1571,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0165-Movement-options-for-armor-stands.patch
+++ b/patches/server/0165-Movement-options-for-armor-stands.patch
@@ -17,10 +17,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 904bca540a42204a9856765e333eee6c5de6a960..ee1f0ccce5c5c920b2595ced9e72fd1544e2459a 100644
+index ac6f63e22c3c5312855d0263a627a8db7eb33cdd..9053a36e9397a6cfa49edd5100c0cc77fa1a1e4b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1469,7 +1469,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1502,7 +1502,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.isInWater() || flag;
      }
  

--- a/patches/server/0166-Fix-stuck-in-portals.patch
+++ b/patches/server/0166-Fix-stuck-in-portals.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix stuck in portals
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 35b26e520be7c06b296ae219be18ef38a1de5dfc..9cedd9c7aa79540710ae248c61eeb7076a84fca4 100644
+index e0694ff71102313634c9d3836ea9f48e7f41c23a..79b65c1fa9c5ab7b840172da5d0c2ec2097534a9 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -1293,6 +1293,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -17,10 +17,10 @@ index 35b26e520be7c06b296ae219be18ef38a1de5dfc..9cedd9c7aa79540710ae248c61eeb707
                  // CraftBukkit end
                  this.spawnIn(worldserver);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ee1f0ccce5c5c920b2595ced9e72fd1544e2459a..fcbbf100990faf60250357b744cbd58701da0b0c 100644
+index 9053a36e9397a6cfa49edd5100c0cc77fa1a1e4b..d0537b9deb71b9f064e63caf33dce98d8d0ba205 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2520,12 +2520,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2553,12 +2553,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return new Vec2F(this.pitch, this.yaw);
      }
  

--- a/patches/server/0168-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0168-Toggle-for-water-sensitive-mob-damage.patch
@@ -19,7 +19,7 @@ index 63d93060b350069040876aaacb91c853d674ea7b..e9793954c872baacfe7be80ecf3888e8
              }
              return;
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 1757e44ecb9d23fd0ca6f7e7f9c07509b377675f..26ae5f5d0b8acfd173e3401aa07bc6fcdc860978 100644
+index 52bd6b4a3bcd44166bd4c897756fe06b19120907..f59d18195bf40f5589d50cee8d074005e98416a6 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -2977,6 +2977,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0171-Add-unsafe-Entity-serialization-API.patch
+++ b/patches/server/0171-Add-unsafe-Entity-serialization-API.patch
@@ -46,10 +46,10 @@ index a80f664d2cf713fd751421be3735e2f4779f0056..6c37bf58bd269c2d7e1c84e5791e8245
      // Purpur end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 38e1bd3893b9dfcf1bac1333d06b4e9792793ec6..05d0d2e5bb10bb002c8d7d4783a144ec35e4550f 100644
+index 67f93f252a26f8b598a4b48c63c321728b246cae..b05b6e911026b8b8ad2e12b7a6705364ec90769d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -390,9 +390,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -410,9 +410,14 @@ public final class CraftMagicNumbers implements UnsafeValues {
          Preconditions.checkNotNull(item, "null cannot be serialized");
          Preconditions.checkArgument(item.getType() != Material.AIR, "air cannot be serialized");
  
@@ -66,7 +66,7 @@ index 38e1bd3893b9dfcf1bac1333d06b4e9792793ec6..05d0d2e5bb10bb002c8d7d4783a144ec
          try {
              net.minecraft.nbt.NBTCompressedStreamTools.writeNBT(
                  compound,
-@@ -405,26 +410,58 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -425,26 +430,58 @@ public final class CraftMagicNumbers implements UnsafeValues {
          return outputStream.toByteArray();
      }
  

--- a/patches/server/0173-Configs-for-if-Wither-Ender-Dragon-can-ride-vehicles.patch
+++ b/patches/server/0173-Configs-for-if-Wither-Ender-Dragon-can-ride-vehicles.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configs for if Wither/Ender Dragon can ride vehicles
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fcbbf100990faf60250357b744cbd58701da0b0c..d321616b7f726f4ff307b46ced9efce6cc20b82f 100644
+index d0537b9deb71b9f064e63caf33dce98d8d0ba205..c9001c88a3101c3cbdedcf9bcb61e051adc5bd85 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2370,7 +2370,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2403,7 +2403,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          }
      }
  

--- a/patches/server/0174-Dont-run-with-scissors.patch
+++ b/patches/server/0174-Dont-run-with-scissors.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Dont run with scissors!
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index f9a232cbc5dc55f3de2286037ca526b15c0842ba..1e64c2467c1c96e93f6843a9f7283baf2bd33a61 100644
+index 5a2f84cd1456b072084e2db53a24c9863cb75563..40ad7f050b7f11f2810b07970c9e29354525de98 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-@@ -1545,6 +1545,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1547,6 +1547,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
                                      this.player.fallDistance = 0.0F;
                                  }
  

--- a/patches/server/0175-One-Punch-Man.patch
+++ b/patches/server/0175-One-Punch-Man.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] One Punch Man!
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 26ae5f5d0b8acfd173e3401aa07bc6fcdc860978..2c5280fe13fa962cfa514b41b1da15c019e30715 100644
+index f59d18195bf40f5589d50cee8d074005e98416a6..cbfaa40c327fefe416c4c751846bcf278a36144a 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -2019,6 +2019,23 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0178-Config-to-ignore-nearby-mobs-when-sleeping.patch
+++ b/patches/server/0178-Config-to-ignore-nearby-mobs-when-sleeping.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config to ignore nearby mobs when sleeping
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 9cedd9c7aa79540710ae248c61eeb7076a84fca4..b8c63c25d2ad9692475e8c7cb307f45853b86ca4 100644
+index 79b65c1fa9c5ab7b840172da5d0c2ec2097534a9..bcb0f418be6616bcaf0d25dc24707330dd5ce4dd 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -1443,7 +1443,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/patches/server/0181-Re-enable-timings-by-default.patch
+++ b/patches/server/0181-Re-enable-timings-by-default.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Re-enable timings by default
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ad7df9e8a2cfc6fe65b193adfb65c7b32d6c92b3..4b9fdb4f04b333ce32f7fca8f279bf989e6fd728 100644
+index 4eb122cfd31902df9789d2e8ff2615207a65ab06..a0ed8ed1d6b89a4f10dff645e09eaff303fb3f8a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -207,15 +207,6 @@ public class PaperConfig {

--- a/patches/server/0187-Config-for-skipping-night.patch
+++ b/patches/server/0187-Config-for-skipping-night.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config for skipping night
 
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index f6d6387588f98049a2e94e73edee14250a6efb9e..b97cd15382833dd119d2c6c9930698f3645892c4 100644
+index b2eba3d8d973285fec51a12ba0151406750d3ac6..dfcd55d88d5262a2a64d3f79bb0518a93af8b601 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -1028,7 +1028,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0190-Drowning-Settings.patch
+++ b/patches/server/0190-Drowning-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Drowning Settings
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d321616b7f726f4ff307b46ced9efce6cc20b82f..c20787a20cf6f273092d2b7ef0d7d90abcfdf609 100644
+index c9001c88a3101c3cbdedcf9bcb61e051adc5bd85..7e22d24ce23befd9b992fb4bb528a70b0ec50fe4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2575,7 +2575,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2608,7 +2608,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public int getDefaultPortalCooldown() {
@@ -18,7 +18,7 @@ index d321616b7f726f4ff307b46ced9efce6cc20b82f..c20787a20cf6f273092d2b7ef0d7d90a
  
      public Iterable<ItemStack> bn() {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 2c5280fe13fa962cfa514b41b1da15c019e30715..82d3aaaf9bbb493d54f6bf2d34edafc5498aee88 100644
+index cbfaa40c327fefe416c4c751846bcf278a36144a..be709c961cd85c1db32fb49c71c63814cbe6bd23 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -394,7 +394,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0191-Break-individual-slabs-when-sneaking.patch
+++ b/patches/server/0191-Break-individual-slabs-when-sneaking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Break individual slabs when sneaking
 
 
 diff --git a/src/main/java/net/minecraft/server/level/PlayerInteractManager.java b/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
-index e47a743fd3adc62aa47beec722f49eeaded246bc..1f38bc36e957ca386774b615bc8b7a04470ce46c 100644
+index 238e143277eb75db6d96e1c52db810eb8a9423de..ddff3a31a564cddcebad4531ca1db66fd0949796 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
 @@ -409,6 +409,8 @@ public class PlayerInteractManager {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
809466f2e Fix anchor respawn acting as a bed respawn when using the end portal (#5540)
d219fd642 [Auto] Updated Upstream (Bukkit/CraftBukkit)
db464b099 Implement methods to convert between Component and Brigadier's Message (#5542)
4047cffca Add PlayerBedFailEnterEvent (#4935)
70d697e6e Update Paperpclip
5ed771591 [CI-SKIP] Remove bad null annotation (#5538)
454a4c78e More World API (#3850)
869e02304 Add PlayerDeepSleepEvent (#5525)
fb56fc35e fix non-dummy objectives not updating
dc859a61f [CI-SKIP] [Auto] Rebuild Patches
7d1689f1a  Add missing checkReachable check for shulker boxes (#5453)
ba8eb3d4b Add missing Javadoc for COLORABLE MaterialTag (#5376)
db801cbf3 Fix PlayerItemHeldEvent firing twice (#5534)
14de2b795 fix PigZombieAngerEvent cancellation (fixes #5319) (v2) (#5329)
86d684ad1 Add get-set drop chance to EntityEquipment (#5528)
33fb8cf63 Add consumeFuel to FurnaceBurnEvent (#5532)
9957f4630 Fix duplicating /give items on item drop cancel (#5536)
d94882043 Fix legacyComposer not using AsyncChatEvent messages (#5509)
053bd82cc Don't print spawn load time when not loading spawn (#5467)
a6d78caae Add isDeeplySleeping to HumanEntity (#5470)
711b7a80b Expose more Adventure serializers through PaperComponents (#5443)
3f63bde0c Set Area Effect Cloud Rotation (#5462)
3523f0fda Remove useless check on player interact cancellation (#5448)
6574d1aa8 fix #5526 - use correct type when sending message to clients
dbfa833ec don't throw when loading TE with invalid keys
a9525a6f7 Do not schedule poi task for each block write on chunk gen
39bf5b525 Update teams known as code owners
fbae9dbe0 [Auto] Updated Upstream (Bukkit/CraftBukkit)
ac4a33aab [Auto] Updated Upstream (Bukkit)
c1e07158b [Auto] Updated Upstream (Bukkit/CraftBukkit)
5e4b88e95 Fix dangling sout
23afda179 basic hostname validation
0fb8bdf0e Updated Upstream (Bukkit/CraftBukkit) (#5508)
88ab784da [Auto] Updated Upstream (CraftBukkit)
ca7111d5f Fix PlayerItemConsumeEvent cancelling (fixes #4682) (#5383)
06fb560dc Add support for tab completing and highlighting console input from the Brigadier command tree (#5437)
0a9b89c7a Fix occasional light gen issues for neighbor blocks (#5500)

Tuinity Changes:
b12d0cce3 Replace ticket level propagator
42df8e1e0 Correctly handle recursion for chunkholder updates
73eb2a856 Do not copy visible chunks
8a4f3be69 Do not schedule poi task for each block write on chunk gen
7d36676fc Fix light source locking
f1ec0c20d Add concurrency check to ProtoChunk light sources
159d1468f Improvements to chunk loader system
32b4d526b Updated Upstream (Paper)
ac5adca33 Make sure lit is set for pre 1.14 chunks

Airplane Changes:
31272d80f Flare Update
8f3271328 Remove criterion patch
0fed2df62 Various patches that need to be reorganized later
f78856bde Updated Upstream (Tuinity)
f7d6382ad Flare Update
71d079991 Update gradle configuration
0f7977428 Updated Upstream (Tuinity)
3b3cde7b0 Correctly use DEAR values, fix config reloading
dd6091981 Updated Upstream (Tuinity)
07897895b Updated Upstream (Tuinity)
c1e4d7143 Fluid cache patch