### PR TITLE
Updated Upstream (Paper & Airplane)

### DIFF
--- a/patches/api/0001-Tuinity-API-Changes.patch
+++ b/patches/api/0001-Tuinity-API-Changes.patch
@@ -169,7 +169,7 @@ permanent authorization for you to choose that version for the
 Library.
 
 diff --git a/pom.xml b/pom.xml
-index e66661eb84308dc13faa0d39b7487f40c1180443..6c200882954adc4831307f3d6dfa3202571fb30b 100644
+index c2e9ca1cc7f14d3a696385edc3cb341f902fa2fd..4d826aa8ea1139e66514767da6ba17811f7ecc5c 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -3,18 +3,18 @@

--- a/patches/server/0002-Airplane-Server-Changes.patch
+++ b/patches/server/0002-Airplane-Server-Changes.patch
@@ -791,10 +791,10 @@ index 0000000000000000000000000000000000000000..89c89e633f14b5820147e734b1b7ad8c
 +}
 diff --git a/src/main/java/gg/airplane/AirplaneConfig.java b/src/main/java/gg/airplane/AirplaneConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..7ec84ef1d1cbb1fabf4c590a2f2c1da3cc181010
+index 0000000000000000000000000000000000000000..65adf3ceda012c8cfdea675c40e2bb27d34ebac7
 --- /dev/null
 +++ b/src/main/java/gg/airplane/AirplaneConfig.java
-@@ -0,0 +1,105 @@
+@@ -0,0 +1,123 @@
 +package gg.airplane;
 +
 +import co.technove.air.AIR;
@@ -896,6 +896,24 @@ index 0000000000000000000000000000000000000000..7ec84ef1d1cbb1fabf4c590a2f2c1da3
 +        if (accessToken.length() > 0) {
 +            gg.airplane.flare.FlareSetup.init(); // Airplane
 +        }
++    }
++
++
++    public static byte entityDespawnCheckFrequency;
++
++    private static void entitySettings() {
++        config.setComment("entities", "Configures settings for generic entities");
++
++        entityDespawnCheckFrequency = (byte) Math.max(config.getInt("entities.despawn-check-freq", 8), Byte.MAX_VALUE);
++    }
++
++
++    public static boolean disableMethodProfiler;
++
++    private static void miscSettings() {
++        config.setComment("misc", "Settings for things that don't belong elsewhere");
++
++        disableMethodProfiler = config.getBoolean("misc.disable-method-profiler", true);
 +    }
 +
 +
@@ -1595,7 +1613,7 @@ index 7918d830a4aef09c9f517284e83a9376299116ad..0a40df2151bd388b6633a6f50b14f1f4
          return enumdirection;
      }));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2767a9369ddc922f1d9c7cb6c7acc8270545535a..7b4b9f54510b3a05aad3f7e50e32ee0bf977244a 100644
+index 2767a9369ddc922f1d9c7cb6c7acc8270545535a..2bb00a42492b08036e984d3e1d9a564d4b4226c2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -1607,6 +1625,18 @@ index 2767a9369ddc922f1d9c7cb6c7acc8270545535a..7b4b9f54510b3a05aad3f7e50e32ee0b
      }
  
      public CrashReport b(CrashReport crashreport) {
+@@ -2196,7 +2196,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         }
+     }
+ 
++    // Airplane start
++    private final GameProfilerFiller disabledProfiler = net.minecraft.util.profiling.GameProfilerDisabled.a;
+     public GameProfilerFiller getMethodProfiler() {
++        if (gg.airplane.AirplaneConfig.disableMethodProfiler) return disabledProfiler;
++        // Airplane end
+         return this.methodProfiler;
+     }
+ 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 index fa7a78549a9bb92b93c305dc16f43a9ace7f6f43..858bd62d2a17c15ee573c5cd607a876d3a99c2b1 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
@@ -1646,54 +1676,35 @@ index fe040615ff03478a20cdf8376f89a6b7d100ba61..207a9c3928aad7c6e89a120b54d87e00
              boolean flag2 = world.ticksPerAnimalSpawns != 0L && worlddata.getTime() % world.ticksPerAnimalSpawns == 0L; // CraftBukkit
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunk.java b/src/main/java/net/minecraft/server/level/PlayerChunk.java
-index 86f156587a0939b28c5cf6f64907255c1c4f8b35..516b77edab4d737fa947e051c463bbd65d0e9e49 100644
+index 86f156587a0939b28c5cf6f64907255c1c4f8b35..06157bb07cce3ba24087ceaca7138b5609b37b5b 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunk.java
-@@ -269,6 +269,23 @@ public class PlayerChunk {
-         return either == null ? null : either.left().orElse(null);
-     }
+@@ -58,6 +58,7 @@ public class PlayerChunk {
+     private int ticketLevel; public final void setTicketLevel(final int level) { this.ticketLevel = level; } // Tuinity - OBFHELPER
+     volatile int n; public final int getCurrentPriority() { return n; } // Paper - OBFHELPER - make volatile since this is concurrently accessed
+     public final ChunkCoordIntPair location; // Paper - private -> public
++    private final long coordinateKey; // Airplane - cache key for location
+     private boolean p;
+     private final ShortSet[] dirtyBlocks;
+     private int r;
+@@ -80,7 +81,7 @@ public class PlayerChunk {
+     com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> playersInChunkTickRange;
  
-+    // Airplane start - update entity ticking on entities
-+    private void setEntityTickingReady(boolean isEntityTickingReady) {
-+        this.isEntityTickingReady = isEntityTickingReady;
-+        Chunk chunk = this.getFullReadyChunk();
-+        if (chunk != null) {
-+            // update all entities in chunk
-+            List<net.minecraft.world.entity.Entity>[] entitySlices = chunk.getEntitySlices();
-+            for (int i = 0, entitySlicesLength = entitySlices.length; i < entitySlicesLength; i++) {
-+                List<net.minecraft.world.entity.Entity> entitySlice = entitySlices[i];
-+                for (net.minecraft.world.entity.Entity entity : entitySlice) {
-+                    entity.inEntityTickingChunk = isEntityTickingReady;
-+                    entity.lastEntityTickingChunkKey = chunk.coordinateKey;
-+                }
-+            }
-+        }
-+    }
-+    // Airplane end
-     public final boolean isEntityTickingReady() {
-         return this.isEntityTickingReady;
-     }
-@@ -763,7 +780,10 @@ public class PlayerChunk {
-                 if (either.left().isPresent()) {
-                     // note: Here is a very good place to add callbacks to logic waiting on this.
-                     Chunk entityTickingChunk = either.left().get();
--                    PlayerChunk.this.isEntityTickingReady = true;
-+                    // Airplane start
-+                    //PlayerChunk.this.isEntityTickingReady = true;
-+                    PlayerChunk.this.setEntityTickingReady(true);
-+                    // Airplane end
- 
-                     // Tuinity start - entity ticking chunk set
-                     PlayerChunk.this.chunkMap.world.getChunkProvider().entityTickingChunks.add(entityTickingChunk);
-@@ -777,7 +797,7 @@ public class PlayerChunk {
-         }
- 
-         if (flag6 && !flag7) {
--            this.entityTickingFuture.complete(PlayerChunk.UNLOADED_CHUNK); this.isEntityTickingReady = false; // Paper - cache chunk ticking stage
-+            this.entityTickingFuture.complete(PlayerChunk.UNLOADED_CHUNK); this.setEntityTickingReady(false); /*this.isEntityTickingReady = false;*/ // Paper - cache chunk ticking stage // Airplane
-             this.entityTickingFuture = PlayerChunk.UNLOADED_CHUNK_FUTURE;
-             // Tuinity start - entity ticking chunk set
-             Chunk chunkIfCached = this.getFullChunkIfCached();
+     void updateRanges() {
+-        long key = net.minecraft.server.MCUtil.getCoordinateKey(this.location);
++        long key = this.coordinateKey; //net.minecraft.server.MCUtil.getCoordinateKey(this.location); // Airplane - use cached key
+         this.playersInMobSpawnRange = this.chunkMap.playerMobSpawnMap.getObjectsInRange(key);
+         this.playersInChunkTickRange = this.chunkMap.playerChunkTickRangeMap.getObjectsInRange(key);
+         // Tuinity start - optimise checkDespawn
+@@ -232,7 +233,7 @@ public class PlayerChunk {
+         this.entityTickingFuture = PlayerChunk.UNLOADED_CHUNK_FUTURE;
+         this.chunkSave = CompletableFuture.completedFuture(null); // CraftBukkit - decompile error
+         this.dirtyBlocks = new ShortSet[16];
+-        this.location = chunkcoordintpair;
++        this.location = chunkcoordintpair; this.coordinateKey = net.minecraft.server.MCUtil.getCoordinateKey(this.location); // Airplane
+         this.lightEngine = lightengine;
+         this.u = playerchunk_c;
+         this.players = playerchunk_d;
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 index b28995ecfd7f45e6b6197be96c418aa0d05d3383..914c7a1b18151f29183cfe9474313ce18e7c4ae2 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
@@ -1772,34 +1783,10 @@ index b28995ecfd7f45e6b6197be96c418aa0d05d3383..914c7a1b18151f29183cfe9474313ce1
              return this.a(i);
          }
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 58e61aa19d71011c40c69a691f5644b3e823ad68..e159a08b3cde339bf95d8b3ded4c35511451879f 100644
+index 58e61aa19d71011c40c69a691f5644b3e823ad68..51bb2502e4efb052f55de6eabce07f59e936c9d9 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
-@@ -1083,11 +1083,22 @@ public class WorldServer extends World implements GeneratorAccessSeed {
-                 // CraftBukkit end */
- 
-                 gameprofilerfiller.enter("checkDespawn");
-+                // Airplane start
-+                boolean entityTickingChunk = false;
-+                if (!entity.dead) {
-+                    long key = MCUtil.getCoordinateKey(entity);
-+                    if (entity.lastEntityTickingChunkKey != key) {
-+                        entity.lastEntityTickingChunkKey = key;
-+                        entity.inEntityTickingChunk = this.getChunkProvider().isInEntityTickingChunk(entity);
-+                    }
-+                    entityTickingChunk = entity.inEntityTickingChunk;
-+                }
-+                // Airplane end
-                 if (!entity.dead) {
-                     entity.checkDespawn();
-                     // Tuinity start - optimise notify()
-                     if (entity.inChunk && entity.valid) {
--                        if (this.getChunkProvider().isInEntityTickingChunk(entity)) {
-+                        if (entityTickingChunk) { // Airplane - reuse
-                             this.updateNavigatorsInRegion(entity);
-                         }
-                     } else {
-@@ -1107,7 +1118,28 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1107,7 +1107,28 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
                  gameprofilerfiller.enter("tick");
                  if (!entity.dead && !(entity instanceof EntityComplexPart)) {
@@ -1809,7 +1796,7 @@ index 58e61aa19d71011c40c69a691f5644b3e823ad68..e159a08b3cde339bf95d8b3ded4c3551
 +                     */
 +                    boolean doMidTick = false; // usually there's a returns in the catch, so treat it like that
 +                    try {
-+                        this.entityJoinedWorld(entity, entityTickingChunk); // Airplane - reuse
++                        this.entityJoinedWorld(entity);
 +                        doMidTick = true;
 +                    } catch (Throwable throwable) {
 +                        if (throwable instanceof ThreadDeath) throw throwable; // Paper
@@ -1828,16 +1815,7 @@ index 58e61aa19d71011c40c69a691f5644b3e823ad68..e159a08b3cde339bf95d8b3ded4c3551
                  }
  
                  gameprofilerfiller.exit();
-@@ -1117,7 +1149,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
-                     this.entitiesById.remove(entity.getId()); // Tuinity
-                     this.unregisterEntity(entity);
-                 } else if (entity.inChunk && entity.valid) { // Tuinity start - optimise notify()
--                    if (this.getChunkProvider().isInEntityTickingChunk(entity)) {
-+                    if (entityTickingChunk) { // Airplane - reuse
-                         this.updateNavigatorsInRegion(entity);
-                     }
-                 } else {
-@@ -1202,6 +1234,8 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1202,6 +1223,8 @@ public class WorldServer extends World implements GeneratorAccessSeed {
      private final BiomeBase[] biomeBaseCache = new BiomeBase[1];
      // Tuinity end - optimise chunk ice snow ticking
  
@@ -1846,7 +1824,7 @@ index 58e61aa19d71011c40c69a691f5644b3e823ad68..e159a08b3cde339bf95d8b3ded4c3551
      public void a(Chunk chunk, int i) { final int randomTickSpeed = i; // Paper
          ChunkCoordIntPair chunkcoordintpair = chunk.getPos();
          boolean flag = this.isRaining();
-@@ -1212,7 +1246,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1212,7 +1235,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          gameprofilerfiller.enter("thunder");
          final BlockPosition.MutableBlockPosition blockposition = this.chunkTickMutablePosition; // Paper - use mutable to reduce allocation rate, final to force compile fail on change
  
@@ -1855,7 +1833,7 @@ index 58e61aa19d71011c40c69a691f5644b3e823ad68..e159a08b3cde339bf95d8b3ded4c3551
              blockposition.setValues(this.a(this.a(j, 0, k, 15))); // Paper
              if (this.isRainingAt(blockposition)) {
                  DifficultyDamageScaler difficultydamagescaler = this.getDamageScaler(blockposition);
-@@ -1236,7 +1270,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1236,7 +1259,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
          }
  
          gameprofilerfiller.exitEnter("iceandsnow");
@@ -1864,27 +1842,7 @@ index 58e61aa19d71011c40c69a691f5644b3e823ad68..e159a08b3cde339bf95d8b3ded4c3551
              // Paper start - optimise chunk ticking
              // Tuinity start - optimise chunk ice snow ticking
              BiomeBase[] biomeCache = this.biomeBaseCache;
-@@ -1415,7 +1449,9 @@ public class WorldServer extends World implements GeneratorAccessSeed {
-     }
-     // Tuinity end - log detailed entity tick information
- 
--    public void entityJoinedWorld(Entity entity) {
-+    // Airplane start - reuse check for in entity ticking chunk
-+    public void entityJoinedWorld(Entity entity) { entityJoinedWorld(entity, this.getChunkProvider().isInEntityTickingChunk(entity)); }
-+    public void entityJoinedWorld(Entity entity, boolean entityTickingChunk) { // Airplane end
-         // Tuinity start - log detailed entity tick information
-         com.tuinity.tuinity.util.TickThread.ensureTickThread("Cannot tick an entity off-main");
-         try {
-@@ -1423,7 +1459,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
-                 currentlyTickingEntity.lazySet(entity);
-             }
-             // Tuinity end - log detailed entity tick information
--        if (!(entity instanceof EntityHuman) && !this.getChunkProvider().a(entity)) {
-+        if (!(entity instanceof EntityHuman) && !entityTickingChunk) { // Airplane - reuse
-             this.chunkCheck(entity);
-         } else {
-             ++TimingHistory.entityTicks; // Paper - timings
-@@ -1449,9 +1485,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1449,9 +1472,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  ++entity.ticksLived;
                  GameProfilerFiller gameprofilerfiller = this.getMethodProfiler();
  
@@ -1928,22 +1886,20 @@ index cc566784c7dd21cc2c44e0f351347f657e57ddcf..e9e7fcf2b63febe2a7d055826fabb86b
          return d0 == 0.0D ? 0 : (d0 > 0.0D ? 1 : -1);
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index feab0ae1930b5271fe0d06a40c180317dcbc9d1d..5ac2811c88370a55f055c791baa3804fc9a107a8 100644
+index feab0ae1930b5271fe0d06a40c180317dcbc9d1d..99c93d48726b4b92a341ba98721173df8b4ff30a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -289,6 +289,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -289,6 +289,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public void inactiveTick() { }
      // Spigot end
      public boolean shouldBeRemoved; // Paper
 +    // Airplane start
 +    public int activatedPriority = gg.airplane.AirplaneConfig.maximumActivationPrio; // golf score
-+    public boolean inEntityTickingChunk = false;
-+    public long lastEntityTickingChunkKey = Long.MIN_VALUE;
 +    // Airplane end
  
      public float getBukkitYaw() {
          return this.yaw;
-@@ -316,10 +321,39 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -316,10 +319,39 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.isLegacyTrackingEntity = isLegacyTrackingEntity;
      }
  
@@ -1983,17 +1939,20 @@ index feab0ae1930b5271fe0d06a40c180317dcbc9d1d..5ac2811c88370a55f055c791baa3804f
          int range = chunkMap.getEntityTrackerRange(type.ordinal());
  
          for (Entity passenger : passengers) {
-@@ -330,6 +364,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -330,8 +362,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  range = passengerRange;
              }
          }
 +         */
 +        // Airplane end
  
-         return chunkMap.playerEntityTrackerTrackMaps[type.ordinal()].getObjectsInRange(MCUtil.getCoordinateKey(this));
+-        return chunkMap.playerEntityTrackerTrackMaps[type.ordinal()].getObjectsInRange(MCUtil.getCoordinateKey(this));
++        return chunkMap.playerEntityTrackerTrackMaps[type.ordinal()].getObjectsInRange(MCUtil.getCoordinateKey(this.chunkX, this.chunkZ)); // Airplane - don't convert doubles to ints here
      }
+     // Paper end - optimise entity tracking
+ 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index aae13c2e6c2a30b69c33417932c6a4d0aefeb7f5..f4440a5c4aedb1d7d303517f86a07c856dd1309b 100644
+index aae13c2e6c2a30b69c33417932c6a4d0aefeb7f5..dc78bafeddf6b584181c818b90efa7ff531377a3 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 @@ -201,10 +201,10 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -2009,7 +1968,23 @@ index aae13c2e6c2a30b69c33417932c6a4d0aefeb7f5..f4440a5c4aedb1d7d303517f86a07c85
              this.targetSelector.doTick();
          }
      }
-@@ -829,9 +829,11 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -774,8 +774,15 @@ public abstract class EntityInsentient extends EntityLiving {
+         return false;
+     }
+ 
++    // Airplane start - just reduce frequency of checking for despawn
++    private byte despawnCheck = 0;
+     @Override
+     public void checkDespawn() {
++        if (++despawnCheck < gg.airplane.AirplaneConfig.entityDespawnCheckFrequency) {
++            return;
++        }
++        this.despawnCheck = 0;
++        // Airplane end
+         if (this.world.getDifficulty() == EnumDifficulty.PEACEFUL && this.L()) {
+             this.die();
+         } else if (!this.isPersistent() && !this.isSpecialPersistence()) {
+@@ -829,9 +836,11 @@ public abstract class EntityInsentient extends EntityLiving {
          this.bo.a();
          this.world.getMethodProfiler().exit();
          this.world.getMethodProfiler().enter("targetSelector");
@@ -2022,7 +1997,7 @@ index aae13c2e6c2a30b69c33417932c6a4d0aefeb7f5..f4440a5c4aedb1d7d303517f86a07c85
          this.world.getMethodProfiler().exit();
          this.world.getMethodProfiler().enter("navigation");
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 96cc46a26eef701b0579f3407e67af9176e1743b..74f80b6af18c0b91d9613384ca6bafd9c89f23a4 100644
+index 96cc46a26eef701b0579f3407e67af9176e1743b..003e1f6dc8efbabcb2e0f7a6b379196f02203903 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -111,6 +111,7 @@ import net.minecraft.world.phys.AxisAlignedBB;
@@ -2050,7 +2025,27 @@ index 96cc46a26eef701b0579f3407e67af9176e1743b..74f80b6af18c0b91d9613384ca6bafd9
                  d0 *= 0.5D;
              }
          }
-@@ -3101,7 +3104,7 @@ public abstract class EntityLiving extends Entity {
+@@ -1742,6 +1745,19 @@ public abstract class EntityLiving extends Entity {
+         }
+     }
+ 
++    // Airplane start
++    private boolean cachedIsClimbing = false;
++    private BlockPosition lastClimbingPosition = null;
++
++    public boolean isClimbingCached() {
++        if (!this.getChunkCoordinates().equals(this.lastClimbingPosition)) {
++            this.cachedIsClimbing = this.isClimbing();
++            this.lastClimbingPosition = this.getChunkCoordinates();
++        }
++        return this.cachedIsClimbing;
++    }
++    // Airplane end
++
+     public IBlockData ds() {
+         return this.world.getType(this.getChunkCoordinates());
+     }
+@@ -3101,7 +3117,7 @@ public abstract class EntityLiving extends Entity {
          Vec3D vec3d = new Vec3D(this.locX(), this.getHeadY(), this.locZ());
          Vec3D vec3d1 = new Vec3D(entity.locX(), entity.getHeadY(), entity.locZ());
  
@@ -2850,7 +2845,7 @@ index 70c32b7a53a1107cced3491ebac19b0eaf4fec2e..3f3e241f3b24d9df9d57760c5515ff02
                      continue;
                  }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/Chunk.java b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
-index fc07e2014e961da5d97095c4ee6f972e2ece3ec3..9ba7c5080ce0cacf438bdd6e11f75cb34fbc5759 100644
+index fc07e2014e961da5d97095c4ee6f972e2ece3ec3..8f5809756b4fb358f1207c1d61c5cbe6df3fff00 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 @@ -99,6 +99,18 @@ public class Chunk implements IChunkAccess {
@@ -2880,17 +2875,6 @@ index fc07e2014e961da5d97095c4ee6f972e2ece3ec3..9ba7c5080ce0cacf438bdd6e11f75cb3
      }
  
      public org.bukkit.Chunk bukkitChunk;
-@@ -786,6 +799,10 @@ public class Chunk implements IChunkAccess {
-         entity.chunkX = this.loc.x;
-         entity.chunkY = k;
-         entity.chunkZ = this.loc.z;
-+        // Airplane start
-+        entity.inEntityTickingChunk = this.world.getChunkProvider().isInEntityTickingChunk(entity);
-+        entity.lastEntityTickingChunkKey = this.coordinateKey;
-+        // Airplane end
-         this.entities.add(entity); // Tuinity
-         this.entitySlices[k].add(entity);  // Tuinity
-         this.entitySlicesManager.addEntity(entity, k); // Tuinity
 diff --git a/src/main/java/net/minecraft/world/level/chunk/DataPaletteBlock.java b/src/main/java/net/minecraft/world/level/chunk/DataPaletteBlock.java
 index a6937366cd9c9d708edb5cd1ab3ac096e7b2032e..a579c5bf9e20c74aa3bf8ef6bc00576409805ca6 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/DataPaletteBlock.java
@@ -3160,7 +3144,7 @@ index 001b1e5197eaa51bfff9031aa6c69876c9a47960..1788d79ea489e446d3d9f541693d4ba3
  
          if (stream != null) {
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 5c2eaca0bc63c7880ee928aba6a24761737aa649..8b36ca5062f8e0e8bd58aa506e91704a747de81b 100644
+index 5c2eaca0bc63c7880ee928aba6a24761737aa649..94910bf0c53c79588c55b89e4a023273d6c859ef 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -47,6 +47,9 @@ import net.minecraft.world.entity.schedule.Activity;
@@ -3207,3 +3191,12 @@ index 5c2eaca0bc63c7880ee928aba6a24761737aa649..8b36ca5062f8e0e8bd58aa506e91704a
                  if (MinecraftServer.currentTick > entity.activatedTick) {
                      if (entity.defaultActivationState || entity.activationType.boundingBox.c(entity.getBoundingBox())) { // Paper
                          entity.activatedTick = MinecraftServer.currentTick;
+@@ -297,7 +309,7 @@ public class ActivationRange
+         if ( entity instanceof EntityLiving )
+         {
+             EntityLiving living = (EntityLiving) entity;
+-            if ( living.isClimbing() || living.jumping || living.hurtTicks > 0 || living.effects.size() > 0 ) // Paper
++            if ( living.isClimbingCached() || living.jumping || living.hurtTicks > 0 || living.effects.size() > 0 ) // Paper // Airplane - use cached climbing
+             {
+                 return 1; // Paper
+             }

--- a/patches/server/0003-Multithreaded-entity-tracking.patch
+++ b/patches/server/0003-Multithreaded-entity-tracking.patch
@@ -42,10 +42,10 @@ index be408aebbccbda46e8aa82ef337574137cfa0096..739839314fd8a88b5fca8b9678e1df07
      private final boolean threadRestricted;
  
 diff --git a/src/main/java/gg/airplane/AirplaneConfig.java b/src/main/java/gg/airplane/AirplaneConfig.java
-index 7ec84ef1d1cbb1fabf4c590a2f2c1da3cc181010..b9118cc08ac38e0813d0677700d3d7dcf9b74159 100644
+index 65adf3ceda012c8cfdea675c40e2bb27d34ebac7..bb87d8792fa6f4b888dd562d63353fe90d2bc588 100644
 --- a/src/main/java/gg/airplane/AirplaneConfig.java
 +++ b/src/main/java/gg/airplane/AirplaneConfig.java
-@@ -102,4 +102,17 @@ public class AirplaneConfig {
+@@ -120,4 +120,17 @@ public class AirplaneConfig {
      }
  
  
@@ -431,7 +431,7 @@ index 914c7a1b18151f29183cfe9474313ce18e7c4ae2..737851cde7752e7cccf226f1868a38d6
                          if (playerchunk != null && playerchunk.getSendingChunk() != null && PlayerChunkMap.this.playerChunkManager.isChunkSent(entityplayer, MathHelper.floor(this.tracker.locX()) >> 4, MathHelper.floor(this.tracker.locZ()) >> 4)) { // Paper - no-tick view distance // Tuinity - don't broadcast in chunks the player hasn't received
                              flag1 = PlayerChunkMap.someDistanceCalculation(x, z, entityplayer, false) <= PlayerChunkMap.this.viewDistance;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/Chunk.java b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
-index 9ba7c5080ce0cacf438bdd6e11f75cb34fbc5759..cef0462fadb305ebc2b53d37e0c17514626df99d 100644
+index 8f5809756b4fb358f1207c1d61c5cbe6df3fff00..2e8eb0bb8fb4f7ce6b92fe01a81327da30e614ae 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/Chunk.java
 @@ -111,6 +111,26 @@ public class Chunk implements IChunkAccess {

--- a/patches/server/0004-Rebrand.patch
+++ b/patches/server/0004-Rebrand.patch
@@ -92,7 +92,7 @@ index 3bc5cd1e53dd7c94b948e7f57f0dc8e073e349b0..87891161f5b06bb8be0e2016b490484e
                      throwable = throwable1;
                      throw throwable1;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7b4b9f54510b3a05aad3f7e50e32ee0bf977244a..e816069db7574996073b932498232c5c6dd40f01 100644
+index 2bb00a42492b08036e984d3e1d9a564d4b4226c2..42c24781d058cee94db8f0fa1a6849b41a0394ff 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0010-AFK-API.patch
+++ b/patches/server/0010-AFK-API.patch
@@ -64,7 +64,7 @@ index b2e21e7034ad83a4ba1c99f860be5a0f5ee6a75f..598b30244e74a56d62dc4ace53622254
          return this.serverStatisticManager;
      }
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index e159a08b3cde339bf95d8b3ded4c35511451879f..18ff28973cb543334946fb066ff77502f4582330 100644
+index 51bb2502e4efb052f55de6eabce07f59e936c9d9..4f1b055dfe38f6a48763f75c1795dcd6dae9d378 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -1002,7 +1002,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -76,7 +76,7 @@ index e159a08b3cde339bf95d8b3ded4c35511451879f..18ff28973cb543334946fb066ff77502
          })) {
              // CraftBukkit start
              long l = this.worldData.getDayTime() + 24000L;
-@@ -1379,7 +1379,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1368,7 +1368,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              while (iterator.hasNext()) {
                  EntityPlayer entityplayer = (EntityPlayer) iterator.next();
  
@@ -289,7 +289,7 @@ index 45e786565ac988abadffda2e7ba3ff1e2880b786..f4052aaa2235894b996d65c569a083f1
 +    // Purpur end
  }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 8b36ca5062f8e0e8bd58aa506e91704a747de81b..c94cd5a95f28190e88d31b522035fc7c74a2ac33 100644
+index 94910bf0c53c79588c55b89e4a023273d6c859ef..a57473fb8815545977ff08bf46d6463d2b7a9d78 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -207,6 +207,7 @@ public class ActivationRange

--- a/patches/server/0012-Configurable-server-mod-name.patch
+++ b/patches/server/0012-Configurable-server-mod-name.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable server mod name
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e816069db7574996073b932498232c5c6dd40f01..b4ddedf80aded5b8daebd0c62fb806658af368b2 100644
+index 42c24781d058cee94db8f0fa1a6849b41a0394ff..6121ef7fcbadb50d05fad4270556e825f636f4d8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1646,7 +1646,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0013-LivingEntity-safeFallDistance.patch
+++ b/patches/server/0013-LivingEntity-safeFallDistance.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] LivingEntity safeFallDistance
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 74f80b6af18c0b91d9613384ca6bafd9c89f23a4..2777bd3ea82b214fc15c5ce3ce47c90c1e5fe538 100644
+index 003e1f6dc8efbabcb2e0f7a6b379196f02203903..6d4f844c68ce48b942280fc5f3a54af89b31c093 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -228,6 +228,7 @@ public abstract class EntityLiving extends Entity {
@@ -27,7 +27,7 @@ index 74f80b6af18c0b91d9613384ca6bafd9c89f23a4..2777bd3ea82b214fc15c5ce3ce47c90c
  
              if (!iblockdata.isAir()) {
                  double d1 = Math.min((double) (0.2F + f / 15.0F), 2.5D);
-@@ -1790,7 +1791,7 @@ public abstract class EntityLiving extends Entity {
+@@ -1803,7 +1804,7 @@ public abstract class EntityLiving extends Entity {
          MobEffect mobeffect = this.getEffect(MobEffects.JUMP);
          float f2 = mobeffect == null ? 0.0F : (float) (mobeffect.getAmplifier() + 1);
  

--- a/patches/server/0014-Lagging-threshold.patch
+++ b/patches/server/0014-Lagging-threshold.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Lagging threshold
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b4ddedf80aded5b8daebd0c62fb806658af368b2..00f5a38f810bc9963b3ecf697dad2b4968bad33d 100644
+index 6121ef7fcbadb50d05fad4270556e825f636f4d8..c086f50613cc3b1061c9958eb2a8aba059a61e29 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -279,6 +279,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0027-Giants-AI-settings.patch
+++ b/patches/server/0027-Giants-AI-settings.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Giants AI settings
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5ac2811c88370a55f055c791baa3804fc9a107a8..c9ae1db4dc982f135e8b2174c59988273a271a77 100644
+index 99c93d48726b4b92a341ba98721173df8b4ff30a..b0cfd7e2be03222e3e34791e5bf6fb77a5d91c5a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -228,7 +228,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -18,10 +18,10 @@ index 5ac2811c88370a55f055c791baa3804fc9a107a8..c9ae1db4dc982f135e8b2174c5998827
      public float I;
      protected final Random random;
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index f4440a5c4aedb1d7d303517f86a07c856dd1309b..7443fe924486404931c11793acc67e2f03de4e41 100644
+index dc78bafeddf6b584181c818b90efa7ff531377a3..af04853ba114a80eb756c1700d27567fd8548e13 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-@@ -1020,6 +1020,7 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -1027,6 +1027,7 @@ public abstract class EntityInsentient extends EntityLiving {
          return f;
      }
  
@@ -29,7 +29,7 @@ index f4440a5c4aedb1d7d303517f86a07c856dd1309b..7443fe924486404931c11793acc67e2f
      protected void a(DifficultyDamageScaler difficultydamagescaler) {
          if (this.random.nextFloat() < 0.15F * difficultydamagescaler.d()) {
              int i = this.random.nextInt(2);
-@@ -1127,6 +1128,7 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -1134,6 +1135,7 @@ public abstract class EntityInsentient extends EntityLiving {
          }
      }
  
@@ -38,7 +38,7 @@ index f4440a5c4aedb1d7d303517f86a07c856dd1309b..7443fe924486404931c11793acc67e2f
          float f = difficultydamagescaler.d();
  
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 2777bd3ea82b214fc15c5ce3ce47c90c1e5fe538..f5bc04059c24f57530653c8845cfe4daa5fed843 100644
+index 6d4f844c68ce48b942280fc5f3a54af89b31c093..8feb1526a3cd5e9cdd2ce731a7701527180e157d 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -261,6 +261,7 @@ public abstract class EntityLiving extends Entity {
@@ -58,7 +58,7 @@ index 2777bd3ea82b214fc15c5ce3ce47c90c1e5fe538..f5bc04059c24f57530653c8845cfe4da
      public BehaviorController<?> getBehaviorController() {
          return this.bg;
      }
-@@ -2276,7 +2279,7 @@ public abstract class EntityLiving extends Entity {
+@@ -2289,7 +2292,7 @@ public abstract class EntityLiving extends Entity {
          this.enderTeleportTo(vec3d.x, vec3d.y, vec3d.z);
      }
  

--- a/patches/server/0029-Zombie-horse-naturally-spawn.patch
+++ b/patches/server/0029-Zombie-horse-naturally-spawn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Zombie horse naturally spawn
 
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 18ff28973cb543334946fb066ff77502f4582330..4df02479e3443becfa3ce91c00f51c2c19059e54 100644
+index 4f1b055dfe38f6a48763f75c1795dcd6dae9d378..06517693aacc22c7507a09c15739e0779dbb82b0 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -96,6 +96,7 @@ import net.minecraft.world.entity.ai.village.poi.VillagePlace;
@@ -16,7 +16,7 @@ index 18ff28973cb543334946fb066ff77502f4582330..4df02479e3443becfa3ce91c00f51c2c
  import net.minecraft.world.entity.animal.horse.EntityHorseSkeleton;
  import net.minecraft.world.entity.boss.EntityComplexPart;
  import net.minecraft.world.entity.boss.enderdragon.EntityEnderDragon;
-@@ -1253,12 +1254,18 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1242,12 +1243,18 @@ public class WorldServer extends World implements GeneratorAccessSeed {
                  boolean flag1 = this.getGameRules().getBoolean(GameRules.DO_MOB_SPAWNING) && this.random.nextDouble() < (double) difficultydamagescaler.b() * paperConfig.skeleHorseSpawnChance; // Paper
  
                  if (flag1) {

--- a/patches/server/0041-Cows-eat-mushrooms.patch
+++ b/patches/server/0041-Cows-eat-mushrooms.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cows eat mushrooms
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c9ae1db4dc982f135e8b2174c59988273a271a77..aeade4d52a98aac03c086ecb598326e55930d9d3 100644
+index b0cfd7e2be03222e3e34791e5bf6fb77a5d91c5a..690685ac224a8b63a022d0801e3e4adb9416cc39 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2919,6 +2919,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2917,6 +2917,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.invulnerable = flag;
      }
  
@@ -17,7 +17,7 @@ index c9ae1db4dc982f135e8b2174c59988273a271a77..aeade4d52a98aac03c086ecb598326e5
          this.setPositionRotation(entity.locX(), entity.locY(), entity.locZ(), entity.yaw, entity.pitch);
      }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index f5bc04059c24f57530653c8845cfe4daa5fed843..5cdefe2a1b4085e3aae7dbbb751cfd368593ebd7 100644
+index 8feb1526a3cd5e9cdd2ce731a7701527180e157d..d419d71af42c361d30aab12e4d245358667f857b 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -176,7 +176,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0049-Controllable-Minecarts.patch
+++ b/patches/server/0049-Controllable-Minecarts.patch
@@ -50,7 +50,7 @@ index c337b22a2f8ce5c76a1699956f6c06721046e814..e8f39bcf57e960be4a87acfa49910ab6
  
              if (!flag && isSpawnInvulnerable() && damagesource != DamageSource.OUT_OF_WORLD) { // Purpur
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 5cdefe2a1b4085e3aae7dbbb751cfd368593ebd7..f1781c2100bf3a8fa7123b66f9ab682177d6490e 100644
+index d419d71af42c361d30aab12e4d245358667f857b..bb227e7dfb1e91a7f5dcc4c7498387033b98df0f 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -194,9 +194,9 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0050-Disable-loot-drops-on-death-by-cramming.patch
+++ b/patches/server/0050-Disable-loot-drops-on-death-by-cramming.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Disable loot drops on death by cramming
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index f1781c2100bf3a8fa7123b66f9ab682177d6490e..906791fc6180e011ce029ac95a63c92553f0377e 100644
+index bb227e7dfb1e91a7f5dcc4c7498387033b98df0f..e31538338e02fdb6e859c37bed899e5f3a83d5ae 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -1598,8 +1598,10 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0054-Fix-the-dead-lagging-the-server.patch
+++ b/patches/server/0054-Fix-the-dead-lagging-the-server.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix the dead lagging the server
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index aeade4d52a98aac03c086ecb598326e55930d9d3..18e65d77a5e999ed60d32b91a1cd6a7b380d38d0 100644
+index 690685ac224a8b63a022d0801e3e4adb9416cc39..56d7662ccc2181df298f37a043f7af4036fe6125 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1664,6 +1664,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1662,6 +1662,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.pitch = MathHelper.a(f1, -90.0F, 90.0F) % 360.0F;
          this.lastYaw = this.yaw;
          this.lastPitch = this.pitch;
@@ -17,10 +17,10 @@ index aeade4d52a98aac03c086ecb598326e55930d9d3..18e65d77a5e999ed60d32b91a1cd6a7b
  
      public void f(double d0, double d1, double d2) {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 906791fc6180e011ce029ac95a63c92553f0377e..6fb4b06df010c3099a1af3b145749ea439a4aa39 100644
+index e31538338e02fdb6e859c37bed899e5f3a83d5ae..af08ec27f8c07653daa328d84bfc142bfc8a7f78 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-@@ -2597,7 +2597,7 @@ public abstract class EntityLiving extends Entity {
+@@ -2610,7 +2610,7 @@ public abstract class EntityLiving extends Entity {
              }
          }
  

--- a/patches/server/0058-Configurable-TPS-Catchup.patch
+++ b/patches/server/0058-Configurable-TPS-Catchup.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable TPS Catchup
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 00f5a38f810bc9963b3ecf697dad2b4968bad33d..07cc501a45669edbb27f1cd5336dcb91b91b877a 100644
+index c086f50613cc3b1061c9958eb2a8aba059a61e29..dccff89fcacdafe4961cd3121eb38ff8844e10da 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1132,7 +1132,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0061-Entities-pick-up-loot-bypass-mob-griefing-gamerule.patch
+++ b/patches/server/0061-Entities-pick-up-loot-bypass-mob-griefing-gamerule.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entities pick up loot bypass mob-griefing gamerule
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index 7443fe924486404931c11793acc67e2f03de4e41..d8a627ed1fad1fca37d8f8a3a344b80a60fc5e2f 100644
+index af04853ba114a80eb756c1700d27567fd8548e13..92d8c5e716678862deadd7755db8e9270daafeda 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 @@ -614,7 +614,7 @@ public abstract class EntityInsentient extends EntityLiving {

--- a/patches/server/0064-Allow-leashing-villagers.patch
+++ b/patches/server/0064-Allow-leashing-villagers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow leashing villagers
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index d8a627ed1fad1fca37d8f8a3a344b80a60fc5e2f..1a1561ab4276bd3654adc2cc2219f3bdb3924b88 100644
+index 92d8c5e716678862deadd7755db8e9270daafeda..4b4578e02fd4be72f20458c54a878892e3029d56 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 @@ -49,6 +49,7 @@ import net.minecraft.world.entity.item.EntityItem;
@@ -16,7 +16,7 @@ index d8a627ed1fad1fca37d8f8a3a344b80a60fc5e2f..1a1561ab4276bd3654adc2cc2219f3bd
  import net.minecraft.world.entity.player.EntityHuman;
  import net.minecraft.world.entity.vehicle.EntityBoat;
  import net.minecraft.world.item.Item;
-@@ -1217,6 +1218,7 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -1224,6 +1225,7 @@ public abstract class EntityInsentient extends EntityLiving {
          if (!this.isAlive()) {
              return EnumInteractionResult.PASS;
          } else if (this.getLeashHolder() == entityhuman) {

--- a/patches/server/0069-Add-canSaveToDisk-to-Entity.patch
+++ b/patches/server/0069-Add-canSaveToDisk-to-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add canSaveToDisk to Entity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 18e65d77a5e999ed60d32b91a1cd6a7b380d38d0..03b8b669ea8047ba1fa2b493b10fce2c37060c3b 100644
+index 56d7662ccc2181df298f37a043f7af4036fe6125..08f286a085cf36ce9a0ea420389f4ea33fb1cc1a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -449,6 +449,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -447,6 +447,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.headHeight = this.getHeadHeight(EntityPose.STANDING, this.size);
      }
  

--- a/patches/server/0070-Configurable-void-damage-height.patch
+++ b/patches/server/0070-Configurable-void-damage-height.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable void damage height
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 03b8b669ea8047ba1fa2b493b10fce2c37060c3b..21977036eb9e7eda408d0cd27b0a27adb9815c22 100644
+index 08f286a085cf36ce9a0ea420389f4ea33fb1cc1a..0950dcce2353504775813d9f60407361981c801d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -752,7 +752,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -750,7 +750,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      // Paper start
      protected void performVoidDamage() {

--- a/patches/server/0071-Dispenser-curse-of-binding-protection.patch
+++ b/patches/server/0071-Dispenser-curse-of-binding-protection.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Dispenser curse of binding protection
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index 1a1561ab4276bd3654adc2cc2219f3bdb3924b88..462bcb7cfe2daa27c10a7a0318bef9b739e586f4 100644
+index 4b4578e02fd4be72f20458c54a878892e3029d56..84995be65d033dd712211e1e479675815099c3b1 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 @@ -65,6 +65,7 @@ import net.minecraft.world.item.ItemSword;
@@ -16,7 +16,7 @@ index 1a1561ab4276bd3654adc2cc2219f3bdb3924b88..462bcb7cfe2daa27c10a7a0318bef9b7
  import net.minecraft.world.level.GameRules;
  import net.minecraft.world.level.GeneratorAccess;
  import net.minecraft.world.level.IBlockAccess;
-@@ -1067,6 +1068,13 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -1074,6 +1075,13 @@ public abstract class EntityInsentient extends EntityLiving {
  
      }
  

--- a/patches/server/0075-Add-5-second-tps-average-in-tps.patch
+++ b/patches/server/0075-Add-5-second-tps-average-in-tps.patch
@@ -27,7 +27,7 @@ index dc6bc1910ad0f9b27144d5750078c3ca607d03d3..e8be35f836ede2630d44902e99a21489
          setListData(vector);
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 07cc501a45669edbb27f1cd5336dcb91b91b877a..59dbc74f78eb8e065e815b6d4efc39350b2479ec 100644
+index dccff89fcacdafe4961cd3121eb38ff8844e10da..409c272629ca935dcbaa9e73e10ace4a0bd8f9b7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -278,7 +278,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0076-Implement-elytra-settings.patch
+++ b/patches/server/0076-Implement-elytra-settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement elytra settings
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 6fb4b06df010c3099a1af3b145749ea439a4aa39..e2124f60b37436d2514f92e180e914b4d4a8470c 100644
+index af08ec27f8c07653daa328d84bfc142bfc8a7f78..135e8b14d8b295797b87b2524a084f682bbf98ab 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-@@ -2955,7 +2955,16 @@ public abstract class EntityLiving extends Entity {
+@@ -2968,7 +2968,16 @@ public abstract class EntityLiving extends Entity {
              if (itemstack.getItem() == Items.ELYTRA && ItemElytra.d(itemstack)) {
                  flag = true;
                  if (!this.world.isClientSide && (this.be + 1) % 20 == 0) {

--- a/patches/server/0077-Item-entity-immunities.patch
+++ b/patches/server/0077-Item-entity-immunities.patch
@@ -55,10 +55,10 @@ index 737851cde7752e7cccf226f1868a38d6411bfb31..ae32fe66a70d583993fe81de4c95b7b2
          private final int trackingDistance;
          private SectionPosition e;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 21977036eb9e7eda408d0cd27b0a27adb9815c22..43ccdf9aabb2457308beac8e04222117b2740598 100644
+index 0950dcce2353504775813d9f60407361981c801d..6c0b1bc0c710d5795d559fe98af6319a644487cc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1613,6 +1613,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1611,6 +1611,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      }
  

--- a/patches/server/0080-Phantoms-attracted-to-crystals-and-crystals-shoot-ph.patch
+++ b/patches/server/0080-Phantoms-attracted-to-crystals-and-crystals-shoot-ph.patch
@@ -17,10 +17,10 @@ index 53ea8a6d90faf4f7f8fd0819be4499422bdd4cbe..6ba14f603b8ec69597c70677cc317f80
          return (new EntityDamageSourceIndirect("indirectMagic", entity, entity1)).setIgnoreArmor().setMagic();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 43ccdf9aabb2457308beac8e04222117b2740598..0336946172c2a9b08d5b0b7c3f155d3eae0385db 100644
+index 6c0b1bc0c710d5795d559fe98af6319a644487cc..31835e73c2704aa56ab8b14c79dd3a337ab05dff 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2279,8 +2279,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2277,8 +2277,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.a(new ItemStack(imaterial), (float) i);
      }
  

--- a/patches/server/0086-Entity-lifespan.patch
+++ b/patches/server/0086-Entity-lifespan.patch
@@ -17,7 +17,7 @@ index c4ef3fef4db2326a531694e6798bab6103c7061c..92437cf4413ea76ef139b007adf2b76c
                          event = new PlayerInteractEntityEvent((Player) this.getPlayer(), entity.getBukkitEntity(), (packetplayinuseentity.c() == EnumHand.OFF_HAND) ? EquipmentSlot.OFF_HAND : EquipmentSlot.HAND);
                      } else {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index 462bcb7cfe2daa27c10a7a0318bef9b739e586f4..c9136f1b54ff0620a621b703b4e7487f4a63b01d 100644
+index 84995be65d033dd712211e1e479675815099c3b1..e10377b379079bc467a60abe719075c5ef73e858 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 @@ -124,7 +124,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -94,7 +94,7 @@ index 462bcb7cfe2daa27c10a7a0318bef9b739e586f4..c9136f1b54ff0620a621b703b4e7487f
      }
  
      @Override
-@@ -1625,7 +1657,7 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -1632,7 +1664,7 @@ public abstract class EntityInsentient extends EntityLiving {
              this.a((EntityLiving) this, entity);
              this.z(entity);
          }

--- a/patches/server/0087-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
+++ b/patches/server/0087-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
@@ -36,7 +36,7 @@ index 1878d09553e2c9013e1c135b5449ce9fe88ecfd5..77a49f76927e65874ae35f7709bef1b0
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index e2124f60b37436d2514f92e180e914b4d4a8470c..f4407cd0865b0e4861930645615c057d11079034 100644
+index 135e8b14d8b295797b87b2524a084f682bbf98ab..9c4bcc691ad2f6896b28d83f386fc8daa2777a3a 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -45,6 +45,7 @@ import net.minecraft.network.syncher.DataWatcher;

--- a/patches/server/0088-Squid-EAR-immunity.patch
+++ b/patches/server/0088-Squid-EAR-immunity.patch
@@ -21,7 +21,7 @@ index b9e252c3db715c288493d5b98fc20d84de46c4e4..cdb7a97ecececa78a200acc898535d33
      public boolean villagerUseBrainTicksOnlyWhenLagging = true;
      public boolean villagerCanBeLeashed = false;
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index c94cd5a95f28190e88d31b522035fc7c74a2ac33..d04a21b93374c287b271deb6618b984abc8831bb 100644
+index a57473fb8815545977ff08bf46d6463d2b7a9d78..2d06392c8d33dd200e101079c2dbf5c488ade982 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -11,6 +11,7 @@ import net.minecraft.world.entity.EntityLiving;

--- a/patches/server/0094-Totems-work-in-inventory.patch
+++ b/patches/server/0094-Totems-work-in-inventory.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Totems work in inventory
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index f4407cd0865b0e4861930645615c057d11079034..8930ab8a39c50eaa84372f0e8caf8b92789bb0c4 100644
+index 9c4bcc691ad2f6896b28d83f386fc8daa2777a3a..69101211dc01e5fbd1f156cbd612b4231098da5a 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -1426,6 +1426,19 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0100-Add-no-random-tick-block-list.patch
+++ b/patches/server/0100-Add-no-random-tick-block-list.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add no-random-tick block list
 
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 4df02479e3443becfa3ce91c00f51c2c19059e54..5e5645865a7be673995d395db20077ee2ea6660e 100644
+index 06517693aacc22c7507a09c15739e0779dbb82b0..9fce5ff2a7980a02510fdc5d1e45d39336d1542a 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -532,14 +532,14 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0103-Stop-squids-floating-on-top-of-water.patch
+++ b/patches/server/0103-Stop-squids-floating-on-top-of-water.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Stop squids floating on top of water
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0336946172c2a9b08d5b0b7c3f155d3eae0385db..15daeadc81bfbbef09755d0117b5939163f3ee4a 100644
+index 31835e73c2704aa56ab8b14c79dd3a337ab05dff..4e084e26e0430422b0348a0a91f0e412ff3a9eff 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3589,8 +3589,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3587,8 +3587,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.lastYaw = this.yaw;
      }
  

--- a/patches/server/0104-Ridables.patch
+++ b/patches/server/0104-Ridables.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ridables
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 59dbc74f78eb8e065e815b6d4efc39350b2479ec..9dfcfffeaab976d00d27e75857715c2113661b9c 100644
+index 409c272629ca935dcbaa9e73e10ace4a0bd8f9b7..4ceaa8e905c9ba7277ee00cea020d01d14ae2178 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1540,6 +1540,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -88,7 +88,7 @@ index 77a49f76927e65874ae35f7709bef1b041bf77a6..4f641d43c3d26c50b58caf8d6c2f05a9
  
      public void playerTick() {
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 5e5645865a7be673995d395db20077ee2ea6660e..36b374187fcdec619c0a8f5511ddcff1f76f7e30 100644
+index 9fce5ff2a7980a02510fdc5d1e45d39336d1542a..535cd9faeeb8072b395bff7a3f7ca095afb02df4 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -216,6 +216,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -133,7 +133,7 @@ index 6ba14f603b8ec69597c70677cc317f802d6afae9..24fd920394774bf38d2818a4cd013670
          this.B = true;
          return this;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff367786e697859 100644
+index 4e084e26e0430422b0348a0a91f0e412ff3a9eff..4e1363050bef7fff9117250b79cbf35bf6bfc537 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -22,6 +22,7 @@ import net.minecraft.BlockUtil;
@@ -171,7 +171,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
      private float headHeight;
      // CraftBukkit start
      public boolean persist = true;
-@@ -1623,6 +1624,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1621,6 +1622,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return !this.justCreated && this.M.getDouble(TagsFluid.LAVA) > 0.0D;
      }
  
@@ -179,7 +179,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
      public void a(float f, Vec3D vec3d) {
          Vec3D vec3d1 = a(vec3d, f, this.yaw);
  
-@@ -2379,6 +2381,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2377,6 +2379,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.a(entity, false);
      }
  
@@ -187,7 +187,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
      public boolean a(Entity entity, boolean flag) {
          for (Entity entity1 = entity; entity1.vehicle != null; entity1 = entity1.vehicle) {
              if (entity1.vehicle == this) {
-@@ -2474,6 +2477,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2472,6 +2475,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  this.passengers.add(entity);
              }
  
@@ -201,7 +201,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
          }
          return true; // CraftBukkit
      }
-@@ -2514,6 +2524,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2512,6 +2522,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  return false;
              }
              // Spigot end
@@ -214,7 +214,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
              this.passengers.remove(entity);
              entity.j = 60;
          }
-@@ -2679,6 +2695,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2677,6 +2693,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.setFlag(4, flag);
      }
  
@@ -222,7 +222,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
      public boolean bE() {
          return this.glowing || this.world.isClientSide && this.getFlag(6);
      }
-@@ -2901,6 +2918,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2899,6 +2916,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      public void setHeadRotation(float f) {}
  
@@ -230,7 +230,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
      public void n(float f) {}
  
      public boolean bL() {
-@@ -3342,6 +3360,18 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3340,6 +3358,18 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return false;
      }
  
@@ -249,7 +249,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
      @Override
      public void sendMessage(IChatBaseComponent ichatbasecomponent, UUID uuid) {}
  
-@@ -3794,4 +3824,47 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3792,4 +3822,47 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return ((ChunkProviderServer) world.getChunkProvider()).isInEntityTickingChunk(this);
      }
      // Paper end
@@ -298,7 +298,7 @@ index 15daeadc81bfbbef09755d0117b5939163f3ee4a..586c65f026d3b4f5b6e1ebcd1ff36778
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index c9136f1b54ff0620a621b703b4e7487f4a63b01d..8b7f840bb1b24996b40c9bef85f4c1e98e39caec 100644
+index e10377b379079bc467a60abe719075c5ef73e858..df33b46ff1267f0f2692a8956438f3bd1e2a3086 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 @@ -100,7 +100,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -354,7 +354,7 @@ index c9136f1b54ff0620a621b703b4e7487f4a63b01d..8b7f840bb1b24996b40c9bef85f4c1e9
      public void v(float f) {
          this.aR = f;
      }
-@@ -1325,7 +1328,7 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -1332,7 +1335,7 @@ public abstract class EntityInsentient extends EntityLiving {
      protected void a(EntityHuman entityhuman, EntityInsentient entityinsentient) {}
  
      protected EnumInteractionResult b(EntityHuman entityhuman, EnumHand enumhand) {
@@ -363,7 +363,7 @@ index c9136f1b54ff0620a621b703b4e7487f4a63b01d..8b7f840bb1b24996b40c9bef85f4c1e9
      }
  
      public boolean ev() {
-@@ -1706,4 +1709,54 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -1713,4 +1716,54 @@ public abstract class EntityInsentient extends EntityLiving {
          this.unleash(true, event.isDropLeash());
          // Paper end
      }
@@ -419,7 +419,7 @@ index c9136f1b54ff0620a621b703b4e7487f4a63b01d..8b7f840bb1b24996b40c9bef85f4c1e9
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 8930ab8a39c50eaa84372f0e8caf8b92789bb0c4..bcf1d77f627e800b9dbbfd7f9ed99887e2aca714 100644
+index 69101211dc01e5fbd1f156cbd612b4231098da5a..2d3ec6505b91a2cb43a1e2285a7d4e57a54e243c 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -559,7 +559,7 @@ public abstract class EntityLiving extends Entity {
@@ -431,7 +431,7 @@ index 8930ab8a39c50eaa84372f0e8caf8b92789bb0c4..bcf1d77f627e800b9dbbfd7f9ed99887
      }
  
      protected void cU() {
-@@ -2300,7 +2300,7 @@ public abstract class EntityLiving extends Entity {
+@@ -2313,7 +2313,7 @@ public abstract class EntityLiving extends Entity {
          return 0.42F * this.getBlockJumpFactor();
      }
  
@@ -440,7 +440,7 @@ index 8930ab8a39c50eaa84372f0e8caf8b92789bb0c4..bcf1d77f627e800b9dbbfd7f9ed99887
          float f = this.dJ();
  
          if (this.hasEffect(MobEffects.JUMP)) {
-@@ -2549,10 +2549,12 @@ public abstract class EntityLiving extends Entity {
+@@ -2562,10 +2562,12 @@ public abstract class EntityLiving extends Entity {
          return this.onGround ? this.dN() * (0.21600002F / (f * f * f)) : this.aE;
      }
  
@@ -453,7 +453,7 @@ index 8930ab8a39c50eaa84372f0e8caf8b92789bb0c4..bcf1d77f627e800b9dbbfd7f9ed99887
      public void q(float f) {
          this.bu = f;
      }
-@@ -2938,8 +2940,10 @@ public abstract class EntityLiving extends Entity {
+@@ -2951,8 +2953,10 @@ public abstract class EntityLiving extends Entity {
          this.collideNearby();
          this.world.getMethodProfiler().exit();
          // Paper start
@@ -466,7 +466,7 @@ index 8930ab8a39c50eaa84372f0e8caf8b92789bb0c4..bcf1d77f627e800b9dbbfd7f9ed99887
                  Location from = new Location(world.getWorld(), lastX, lastY, lastZ, lastYaw, lastPitch);
                  Location to = new Location (world.getWorld(), locX(), locY(), locZ(), yaw, pitch);
                  EntityMoveEvent event = new EntityMoveEvent(getBukkitLivingEntity(), from, to.clone());
-@@ -2949,6 +2953,21 @@ public abstract class EntityLiving extends Entity {
+@@ -2962,6 +2966,21 @@ public abstract class EntityLiving extends Entity {
                      setLocation(event.getTo().getX(), event.getTo().getY(), event.getTo().getZ(), event.getTo().getYaw(), event.getTo().getPitch());
                  }
              }

--- a/patches/server/0107-Entities-can-use-portals-configuration.patch
+++ b/patches/server/0107-Entities-can-use-portals-configuration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entities can use portals configuration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 586c65f026d3b4f5b6e1ebcd1ff367786e697859..543a2d209726ef57e7ba542f11b1087611b3ae8e 100644
+index 4e1363050bef7fff9117250b79cbf35bf6bfc537..918edab475a8d33a253e3d6cd3c5655748d10dc0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2556,7 +2556,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2554,7 +2554,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public void d(BlockPosition blockposition) {
          if (this.ai()) {
              this.resetPortalCooldown();
@@ -17,7 +17,7 @@ index 586c65f026d3b4f5b6e1ebcd1ff367786e697859..543a2d209726ef57e7ba542f11b10876
              if (!this.world.isClientSide && !blockposition.equals(this.ac)) {
                  this.ac = blockposition.immutableCopy();
              }
-@@ -3136,7 +3136,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3134,7 +3134,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean canPortal() {

--- a/patches/server/0110-Allow-toggling-special-MobSpawners-per-world.patch
+++ b/patches/server/0110-Allow-toggling-special-MobSpawners-per-world.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow toggling special MobSpawners per world
 In vanilla, these are all hardcoded on for world type 0 (overworld) and hardcoded off for every other world type. Default config behaviour matches this.
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 36b374187fcdec619c0a8f5511ddcff1f76f7e30..29b7c8ee5158e4c5aec1809ef083916a1914d5fb 100644
+index 535cd9faeeb8072b395bff7a3f7ca095afb02df4..64feabfb860ac29a7f7692bcc9972369dbdc2e02 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -92,6 +92,7 @@ import net.minecraft.world.entity.EnumCreatureType;

--- a/patches/server/0119-Configurable-daylight-cycle.patch
+++ b/patches/server/0119-Configurable-daylight-cycle.patch
@@ -18,7 +18,7 @@ index 3086ee023685781d94e2fb99fc8dff5264f01165..74c1047305cac5673e274096709c757e
      public PacketPlayOutUpdateTime() {}
  
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 29b7c8ee5158e4c5aec1809ef083916a1914d5fb..b2eba3d8d973285fec51a12ba0151406750d3ac6 100644
+index 64feabfb860ac29a7f7692bcc9972369dbdc2e02..028911ebe843751080564d90e96306524e5a2e21 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -64,6 +64,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutExplosion;
@@ -45,7 +45,7 @@ index 29b7c8ee5158e4c5aec1809ef083916a1914d5fb..b2eba3d8d973285fec51a12ba0151406
      }
  
      // Tuinity start - optimise collision
-@@ -1222,7 +1225,21 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1211,7 +1214,21 @@ public class WorldServer extends World implements GeneratorAccessSeed {
              this.nextTickListBlock.nextTick(); // Paper
              this.nextTickListFluid.nextTick(); // Paper
              this.worldDataServer.u().a(this.server, i);
@@ -68,7 +68,7 @@ index 29b7c8ee5158e4c5aec1809ef083916a1914d5fb..b2eba3d8d973285fec51a12ba0151406
                  this.setDayTime(this.worldData.getDayTime() + 1L);
              }
  
-@@ -1231,6 +1248,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+@@ -1220,6 +1237,12 @@ public class WorldServer extends World implements GeneratorAccessSeed {
  
      public void setDayTime(long i) {
          this.worldDataServer.setDayTime(i);

--- a/patches/server/0138-Changeable-Mob-Left-Handed-Chance.patch
+++ b/patches/server/0138-Changeable-Mob-Left-Handed-Chance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Changeable Mob Left Handed Chance
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index 8b7f840bb1b24996b40c9bef85f4c1e98e39caec..63d93060b350069040876aaacb91c853d674ea7b 100644
+index df33b46ff1267f0f2692a8956438f3bd1e2a3086..a6ea96683b0f4d35015dff6168f3bf458346fb6f 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-@@ -1209,7 +1209,7 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -1216,7 +1216,7 @@ public abstract class EntityInsentient extends EntityLiving {
      @Nullable
      public GroupDataEntity prepare(WorldAccess worldaccess, DifficultyDamageScaler difficultydamagescaler, EnumMobSpawn enummobspawn, @Nullable GroupDataEntity groupdataentity, @Nullable NBTTagCompound nbttagcompound) {
          this.getAttributeInstance(GenericAttributes.FOLLOW_RANGE).addModifier(new AttributeModifier("Random spawn bonus", this.random.nextGaussian() * 0.05D, AttributeModifier.Operation.MULTIPLY_BASE));

--- a/patches/server/0145-Lobotomize-stuck-villagers.patch
+++ b/patches/server/0145-Lobotomize-stuck-villagers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Lobotomize stuck villagers
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 543a2d209726ef57e7ba542f11b1087611b3ae8e..ac6f63e22c3c5312855d0263a627a8db7eb33cdd 100644
+index 918edab475a8d33a253e3d6cd3c5655748d10dc0..4d64fb19c3c9cce41e89ba4d702e687b34620b7e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -207,7 +207,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne

--- a/patches/server/0149-Configurable-chance-for-wolves-to-spawn-rabid.patch
+++ b/patches/server/0149-Configurable-chance-for-wolves-to-spawn-rabid.patch
@@ -7,10 +7,10 @@ Configurable chance to spawn a wolf that is rabid.
 Rabid wolves attack all players, mobs, and animals.
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index bcf1d77f627e800b9dbbfd7f9ed99887e2aca714..c957122f8463fc1eae632730a64bec7f8b0d1055 100644
+index 2d3ec6505b91a2cb43a1e2285a7d4e57a54e243c..f0a485056f3ad94e7375fbdfd512026b969a0eed 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-@@ -2200,6 +2200,7 @@ public abstract class EntityLiving extends Entity {
+@@ -2213,6 +2213,7 @@ public abstract class EntityLiving extends Entity {
          }
      }
  

--- a/patches/server/0154-Implement-TPSBar.patch
+++ b/patches/server/0154-Implement-TPSBar.patch
@@ -17,7 +17,7 @@ index 0982b14a4b39c40a68ee900d506b4e44f840299d..324f475513eecab4242b8900084d7f08
  
          if (commanddispatcher_servertype.d) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9dfcfffeaab976d00d27e75857715c2113661b9c..5f8960754f7a04fba66184df47f3f6b49646d302 100644
+index 4ceaa8e905c9ba7277ee00cea020d01d14ae2178..137c52999666ea331ac52c230f0674d489a95524 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -989,6 +989,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/patches/server/0160-Add-mobGriefing-bypass-to-everything-affected.patch
+++ b/patches/server/0160-Add-mobGriefing-bypass-to-everything-affected.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add mobGriefing bypass to everything affected
 This adds the "bypass-mob-griefing" world config option to everything that is affected by the gamerule.
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index c957122f8463fc1eae632730a64bec7f8b0d1055..52bd6b4a3bcd44166bd4c897756fe06b19120907 100644
+index f0a485056f3ad94e7375fbdfd512026b969a0eed..e866531958c9d0171d39ba7f6963fe92eb2d42cc 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -1571,7 +1571,7 @@ public abstract class EntityLiving extends Entity {

--- a/patches/server/0165-Movement-options-for-armor-stands.patch
+++ b/patches/server/0165-Movement-options-for-armor-stands.patch
@@ -17,10 +17,10 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ac6f63e22c3c5312855d0263a627a8db7eb33cdd..9053a36e9397a6cfa49edd5100c0cc77fa1a1e4b 100644
+index 4d64fb19c3c9cce41e89ba4d702e687b34620b7e..2545b0891a299301a8d9e194e795b0f3856f2178 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1502,7 +1502,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1500,7 +1500,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.isInWater() || flag;
      }
  

--- a/patches/server/0166-Fix-stuck-in-portals.patch
+++ b/patches/server/0166-Fix-stuck-in-portals.patch
@@ -17,10 +17,10 @@ index e0694ff71102313634c9d3836ea9f48e7f41c23a..79b65c1fa9c5ab7b840172da5d0c2ec2
                  // CraftBukkit end
                  this.spawnIn(worldserver);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9053a36e9397a6cfa49edd5100c0cc77fa1a1e4b..d0537b9deb71b9f064e63caf33dce98d8d0ba205 100644
+index 2545b0891a299301a8d9e194e795b0f3856f2178..fdd374232ced8f4da675afaee3f5278c036ef112 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2553,12 +2553,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2551,12 +2551,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return new Vec2F(this.pitch, this.yaw);
      }
  

--- a/patches/server/0168-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0168-Toggle-for-water-sensitive-mob-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggle for water sensitive mob damage
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index 63d93060b350069040876aaacb91c853d674ea7b..e9793954c872baacfe7be80ecf3888e848dc924f 100644
+index a6ea96683b0f4d35015dff6168f3bf458346fb6f..95c08c31cb4d9df73f0af8f0e3b61236e1b46faa 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-@@ -856,7 +856,8 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -863,7 +863,8 @@ public abstract class EntityInsentient extends EntityLiving {
                  if (goalFloat.validConditions()) goalFloat.update();
                  this.getControllerJump().jumpIfSet();
              }
@@ -19,10 +19,10 @@ index 63d93060b350069040876aaacb91c853d674ea7b..e9793954c872baacfe7be80ecf3888e8
              }
              return;
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 52bd6b4a3bcd44166bd4c897756fe06b19120907..f59d18195bf40f5589d50cee8d074005e98416a6 100644
+index e866531958c9d0171d39ba7f6963fe92eb2d42cc..d0adfc802371f562fe87c3f8ebe2368ff133776a 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-@@ -2977,6 +2977,7 @@ public abstract class EntityLiving extends Entity {
+@@ -2990,6 +2990,7 @@ public abstract class EntityLiving extends Entity {
  
      }
  

--- a/patches/server/0173-Configs-for-if-Wither-Ender-Dragon-can-ride-vehicles.patch
+++ b/patches/server/0173-Configs-for-if-Wither-Ender-Dragon-can-ride-vehicles.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configs for if Wither/Ender Dragon can ride vehicles
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d0537b9deb71b9f064e63caf33dce98d8d0ba205..c9001c88a3101c3cbdedcf9bcb61e051adc5bd85 100644
+index fdd374232ced8f4da675afaee3f5278c036ef112..f3151969e5841861d31ac50abdfef3c65e5198a3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2403,7 +2403,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2401,7 +2401,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          }
      }
  

--- a/patches/server/0175-One-Punch-Man.patch
+++ b/patches/server/0175-One-Punch-Man.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] One Punch Man!
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index f59d18195bf40f5589d50cee8d074005e98416a6..cbfaa40c327fefe416c4c751846bcf278a36144a 100644
+index d0adfc802371f562fe87c3f8ebe2368ff133776a..93f8aa6d40b1eba6535f170bf0a79417d7d21069 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-@@ -2019,6 +2019,23 @@ public abstract class EntityLiving extends Entity {
+@@ -2032,6 +2032,23 @@ public abstract class EntityLiving extends Entity {
                  ((EntityPlayer) damagesource.getEntity()).a(StatisticList.DAMAGE_DEALT_ABSORBED, Math.round(f2 * 10.0F));
              }
  

--- a/patches/server/0187-Config-for-skipping-night.patch
+++ b/patches/server/0187-Config-for-skipping-night.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config for skipping night
 
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index b2eba3d8d973285fec51a12ba0151406750d3ac6..dfcd55d88d5262a2a64d3f79bb0518a93af8b601 100644
+index 028911ebe843751080564d90e96306524e5a2e21..f84066233f551be145a7db2694b3c7cb0c918128 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -1028,7 +1028,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/patches/server/0190-Drowning-Settings.patch
+++ b/patches/server/0190-Drowning-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Drowning Settings
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c9001c88a3101c3cbdedcf9bcb61e051adc5bd85..7e22d24ce23befd9b992fb4bb528a70b0ec50fe4 100644
+index f3151969e5841861d31ac50abdfef3c65e5198a3..706a1e2fadb0880277093be5de63f4dc0792fb72 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2608,7 +2608,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2606,7 +2606,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public int getDefaultPortalCooldown() {
@@ -18,7 +18,7 @@ index c9001c88a3101c3cbdedcf9bcb61e051adc5bd85..7e22d24ce23befd9b992fb4bb528a70b
  
      public Iterable<ItemStack> bn() {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index cbfaa40c327fefe416c4c751846bcf278a36144a..be709c961cd85c1db32fb49c71c63814cbe6bd23 100644
+index 93f8aa6d40b1eba6535f170bf0a79417d7d21069..8db61c8b392c8e95f6896b6e48e4d74ddd6b8708 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -394,7 +394,7 @@ public abstract class EntityLiving extends Entity {


### PR DESCRIPTION
The last upstream introduced an issue where the server would have entity lag at high player counts... *sorry*

Upstream has released updates that appear to apply and compile correctly

Paper Changes:
b8020379c Extract Adventure Version into a variable, add reminder to update the linked JD on the homepage (#5422)

Airplane Changes:
f5fb02447 Temporarily revert patch
3c728a7a9 Oops, these 2 too
37a93e561 Your daily dose of 1-3% optimization patches
bbd689a77 Remove useless check