### PR TITLE
Updated Upstream (Paper) 

### DIFF
--- a/patches/api/0022-Ridables.patch
+++ b/patches/api/0022-Ridables.patch
@@ -169,7 +169,7 @@ index 0000000000000000000000000000000000000000..c0ec5a130985e8da4cc9e596a6b70503
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 428daeb04d0a35a443467e2f657d2356bcfdd7d7..7dc06b28af9fa45b2b49a6d37c1ed829257f812a 100644
+index 46985eaea3d3b00d1dd88c2dd5a2bc53d518c64f..38c6ecba4a6090ee42180ff52db42bac8e7f95d7 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -704,4 +704,35 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent

--- a/patches/api/0028-Add-predicate-to-recipe-s-ExactChoice-ingredient.patch
+++ b/patches/api/0028-Add-predicate-to-recipe-s-ExactChoice-ingredient.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add predicate to recipe's ExactChoice ingredient
 
 
 diff --git a/src/main/java/org/bukkit/inventory/RecipeChoice.java b/src/main/java/org/bukkit/inventory/RecipeChoice.java
-index 3d325cab6b106ce8617e321d7a733eca91ba93e5..4dedbdc1cc8b34b73a1a32b35d1985284da6fc08 100644
+index 90208bc96085f05a3b657b9467b1670d00b03104..c59d5e4ef9641fd73463b177239226866272745b 100644
 --- a/src/main/java/org/bukkit/inventory/RecipeChoice.java
 +++ b/src/main/java/org/bukkit/inventory/RecipeChoice.java
 @@ -10,6 +10,7 @@ import java.util.function.Predicate;
@@ -16,7 +16,7 @@ index 3d325cab6b106ce8617e321d7a733eca91ba93e5..4dedbdc1cc8b34b73a1a32b35d198528
  
  /**
   * Represents a potential item match within a recipe. All choices within a
-@@ -155,6 +156,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -152,6 +153,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
      public static class ExactChoice implements RecipeChoice {
  
          private List<ItemStack> choices;
@@ -24,7 +24,7 @@ index 3d325cab6b106ce8617e321d7a733eca91ba93e5..4dedbdc1cc8b34b73a1a32b35d198528
  
          public ExactChoice(@NotNull ItemStack stack) {
              this(Arrays.asList(stack));
-@@ -199,6 +201,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -196,6 +198,7 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
  
          @Override
          public boolean test(@NotNull ItemStack t) {
@@ -32,7 +32,7 @@ index 3d325cab6b106ce8617e321d7a733eca91ba93e5..4dedbdc1cc8b34b73a1a32b35d198528
              for (ItemStack match : choices) {
                  if (t.isSimilar(match)) {
                      return true;
-@@ -208,6 +211,17 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
+@@ -205,6 +208,17 @@ public interface RecipeChoice extends Predicate<ItemStack>, Cloneable {
              return false;
          }
  

--- a/patches/api/0033-Fix-javadoc-warnings-missing-param-and-return.patch
+++ b/patches/api/0033-Fix-javadoc-warnings-missing-param-and-return.patch
@@ -860,7 +860,7 @@ index d9be83961b28b927a587f6dbb339b531520e4865..1ff4c5e283ac05c405c09bd4b8530664
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 7dc06b28af9fa45b2b49a6d37c1ed829257f812a..c51d545e137eec2017c9f2ff944db70f2fdffdfc 100644
+index 38c6ecba4a6090ee42180ff52db42bac8e7f95d7..b47e31d2b9b41b39b46892fe10bf36d82c5d8e1b 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -622,6 +622,9 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
@@ -1045,12 +1045,12 @@ index 9a99b8ca1ec9c3c88b29275c88b1221e1b22bcef..f1763f75d5f223ef70b968e463361673
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Shulker.java b/src/main/java/org/bukkit/entity/Shulker.java
-index 274d6131c893630dbc5e22aa2684d89e5a2c6c72..4507fa13689cd393f41c9f0c4a73362491f34c76 100644
+index 010e1f9c3567a2fe8297fe04fcf7b75df0279eca..bd40fdfbcd9a34c7cde5f4dc34cba53aec53c485 100644
 --- a/src/main/java/org/bukkit/entity/Shulker.java
 +++ b/src/main/java/org/bukkit/entity/Shulker.java
-@@ -2,6 +2,9 @@ package org.bukkit.entity;
- 
+@@ -4,6 +4,9 @@ import org.bukkit.block.BlockFace;
  import org.bukkit.material.Colorable;
+ import org.jetbrains.annotations.NotNull;
  
 +/**
 + * Represents a shulker

--- a/patches/api/0038-Add-unsafe-Entity-serialization-API.patch
+++ b/patches/api/0038-Add-unsafe-Entity-serialization-API.patch
@@ -50,7 +50,7 @@ index 5f2d5e12f11b471662943680b2012c99a8466306..7395fe0261da696d1b16c845d244ad5d
 +    // Purpur end
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index c51d545e137eec2017c9f2ff944db70f2fdffdfc..1e25f387e053b648477a3e9dace1a6c95e7f8cba 100644
+index b47e31d2b9b41b39b46892fe10bf36d82c5d8e1b..7fa5242bd44c9b19648d79fa8fecbb7ee125288e 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -751,5 +751,24 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
ef60c01c4 [Auto] Updated Upstream (CraftBukkit)
0256dbea3 [Auto] Updated Upstream (Bukkit/CraftBukkit)
91ef74029 Updated Upstream (Spigot) (#5550)
fdf2a59d5 Updated Upstream (Bukkit/CraftBukkit) (#5549)