### PR TITLE
Config for health to impact Creeper explosion radius

### DIFF
--- a/patches/server/0203-Config-for-health-to-impact-Creeper-explosion-radius.patch
+++ b/patches/server/0203-Config-for-health-to-impact-Creeper-explosion-radius.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Thu, 29 Apr 2021 20:28:18 -0400
+Subject: [PATCH] Config for health to impact Creeper explosion radius
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityCreeper.java b/src/main/java/net/minecraft/world/entity/monster/EntityCreeper.java
+index 014091f35ee5aac0ee2f155ccec2daf586e4d3d3..79b61879e0b05d3ac50b92128ad35d10b7804f6b 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/EntityCreeper.java
++++ b/src/main/java/net/minecraft/world/entity/monster/EntityCreeper.java
+@@ -341,9 +341,10 @@ public class EntityCreeper extends EntityMonster {
+         if (!this.world.isClientSide) {
+             Explosion.Effect explosion_effect = this.world.getGameRules().getBoolean(GameRules.MOB_GRIEFING) && world.purpurConfig.creeperAllowGriefing ? Explosion.Effect.DESTROY : Explosion.Effect.NONE; // Purpur
+             float f = this.isPowered() ? 2.0F : 1.0F;
++            float multiplier = this.world.purpurConfig.creeperHealthRadius ? this.getHealth() / this.getMaxHealth() : 1; // Purpur
+ 
+             // CraftBukkit start
+-            ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), this.explosionRadius * f, false);
++            ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), multiplier * (this.explosionRadius * f), false); // Purpur
+             this.world.getServer().getPluginManager().callEvent(event);
+             if (!event.isCancelled()) {
+                 this.killed = true;
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 69d6ced8e583a3a0625ced9d444caca21fa80723..280a01f184c9c8b55a257d38b47e73e8cbd0cb6c 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -803,6 +803,7 @@ public class PurpurWorldConfig {
+     public boolean creeperRidable = false;
+     public boolean creeperRidableInWater = false;
+     public boolean creeperExplodeWhenKilled = false;
++    public boolean creeperHealthRadius = false;
+     public boolean creeperAllowGriefing = true;
+     public double creeperChargedChance = 0.0D;
+     public double creeperMaxHealth = 20.0D;
+@@ -810,6 +811,7 @@ public class PurpurWorldConfig {
+         creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
+         creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
+         creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
++        creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
+         creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
+         creeperChargedChance = getDouble("mobs.creeper.naturally-charged-chance", creeperChargedChance);
+         if (PurpurConfig.version < 10) {

--- a/patches/server/0210-Config-for-health-to-impact-Creeper-explosion-radius.patch
+++ b/patches/server/0210-Config-for-health-to-impact-Creeper-explosion-radius.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config for health to impact Creeper explosion radius
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityCreeper.java b/src/main/java/net/minecraft/world/entity/monster/EntityCreeper.java
-index 014091f35ee5aac0ee2f155ccec2daf586e4d3d3..79b61879e0b05d3ac50b92128ad35d10b7804f6b 100644
+index 27d5e9fc5ec1396e95180fc14e8a61b030cfd1e6..d2ae28bb1a2db6dde2aa7c95589656b6eaf3072d 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EntityCreeper.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EntityCreeper.java
 @@ -341,9 +341,10 @@ public class EntityCreeper extends EntityMonster {
@@ -21,10 +21,10 @@ index 014091f35ee5aac0ee2f155ccec2daf586e4d3d3..79b61879e0b05d3ac50b92128ad35d10
              if (!event.isCancelled()) {
                  this.killed = true;
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index 69d6ced8e583a3a0625ced9d444caca21fa80723..280a01f184c9c8b55a257d38b47e73e8cbd0cb6c 100644
+index b8622f687b4fd70aaee5fa44cc50b8ee38582582..5659e75177f3c5acb935b0f6dc0b720853602108 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-@@ -803,6 +803,7 @@ public class PurpurWorldConfig {
+@@ -830,6 +830,7 @@ public class PurpurWorldConfig {
      public boolean creeperRidable = false;
      public boolean creeperRidableInWater = false;
      public boolean creeperExplodeWhenKilled = false;
@@ -32,7 +32,7 @@ index 69d6ced8e583a3a0625ced9d444caca21fa80723..280a01f184c9c8b55a257d38b47e73e8
      public boolean creeperAllowGriefing = true;
      public double creeperChargedChance = 0.0D;
      public double creeperMaxHealth = 20.0D;
-@@ -810,6 +811,7 @@ public class PurpurWorldConfig {
+@@ -837,6 +838,7 @@ public class PurpurWorldConfig {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);


### PR DESCRIPTION
This allows for a Creeper's explosion to be affected by its health value.
This should scale with any custom explosion radius or max health set.
Equation: Creeper's explosion radius multiplied by percentage of max health `(health / max health) * (explosion radius * charged multiplier)`

Update for those wondering why this hasn't been merged yet: We're currently making sure the JavaScript engine Purpur integrates is functioning correctly, then this PR will change to allow for the equation to be customized by the user.

**Explosion radius with feature disabled:**
![](https://media.discordapp.net/attachments/365455566329348097/837490632775172116/2021-04-29_20.48.14.png)

**Explosion radius at full health:**
![](https://media.discordapp.net/attachments/365455566329348097/837489686607036436/2021-04-29_20.44.52.png)

**Explosion radius at half health:**
![](https://media.discordapp.net/attachments/365455566329348097/837489686272278528/2021-04-29_20.44.08.png)