### PR TITLE
Allows to display progress messages by player instead to everyone on the server.

### DIFF
--- a/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
+++ b/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
@@ -23,7 +23,7 @@ index 59d781b5e61c5d2c004bc92300d8d42e81821308..f37a4a6dccd808e5681cd6e415a0b0e1
                  if (advancement.c() != null && advancement.c().i() && this.player.world.getGameRules().getBoolean(GameRules.ANNOUNCE_ADVANCEMENTS)) {
 -                    this.e.sendMessage(new ChatMessage("chat.type.advancement." + advancement.c().e().a(), new Object[]{this.player.getScoreboardDisplayName(), advancement.j()}), ChatMessageType.SYSTEM, SystemUtils.b);
 +                    // Purpur Start - AdvancementMessage By Player
-+                    if (net.pl3x.purpur.PurpurConfig.advancementMessageByPlayer) {
++                    if (net.pl3x.purpur.PurpurConfig.advancementOnlyBroadcastToAffectedPlayer) {
 +                        this.player.sendMessage(getMessagePlayerAdvancement(advancement), SystemUtils.b);
 +                    } else {
 +                        this.e.sendMessage(getMessagePlayerAdvancement(advancement), ChatMessageType.SYSTEM, SystemUtils.b);

--- a/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
+++ b/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
@@ -5,28 +5,54 @@ Subject: [PATCH] Allows to display progress messages by player instead to
  everyone on the server.
 
 
-diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
-index 59d781b5e61c5d2c004bc92300d8d42e81821308..f37a4a6dccd808e5681cd6e415a0b0e1b6fecb29 100644
---- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
-+++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
-@@ -298,6 +298,7 @@ public class AdvancementDataPlayer {
- 
+diff --git a/src/main/java/net/minecraft/advancements/Advancement.java b/src/main/java/net/minecraft/advancements/Advancement.java
+index 8bfd20ff9a3c96fa9ff5cc618ca7e858e62943a0..ced98a97258bc2f3c2ee3eaecbf4d8419c0f4b19 100644
+--- a/src/main/java/net/minecraft/advancements/Advancement.java
++++ b/src/main/java/net/minecraft/advancements/Advancement.java
+@@ -125,6 +125,7 @@ public class Advancement {
+         return this.requirements;
      }
  
-+    public ChatMessage getMessagePlayerAdvancement(Advancement advancement) { return new ChatMessage("chat.type.advancement." + advancement.c().e().a(), this.player.getScoreboardDisplayName(), advancement.j()); } // Purpur - OBFHELPER
-     public boolean grantCriteria(Advancement advancement, String s) {
-         boolean flag = false;
-         AdvancementProgress advancementprogress = this.getProgress(advancement);
-@@ -317,7 +318,13 @@ public class AdvancementDataPlayer {
++    public IChatBaseComponent getJ() { return j(); } // Purpur - OBFHELPER
+     public IChatBaseComponent j() {
+         return this.chatComponent;
+     }
+diff --git a/src/main/java/net/minecraft/advancements/AdvancementFrameType.java b/src/main/java/net/minecraft/advancements/AdvancementFrameType.java
+index f096ecf8d77b085e6c2ef4c3b64f0b65409bb287..a9157e2bbbb5041658b0ea89fbfd5fd1bee0fd66 100644
+--- a/src/main/java/net/minecraft/advancements/AdvancementFrameType.java
++++ b/src/main/java/net/minecraft/advancements/AdvancementFrameType.java
+@@ -31,6 +31,7 @@ public enum AdvancementFrameType {
+         this.g = new ChatMessage("advancements.toast." + s);
+     }
+ 
++    public String advancementType() { return  a(); } // Purpur - OBFHELPER
+     public String a() {
+         return this.d;
+     }
+diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+index 59d781b5e61c5d2c004bc92300d8d42e81821308..e43c96c493b91ec62c75f75f9ca3022cb49de279 100644
+--- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
++++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+@@ -59,7 +59,7 @@ public class AdvancementDataPlayer {
+     private static final TypeToken<Map<MinecraftKey, AdvancementProgress>> c = new TypeToken<Map<MinecraftKey, AdvancementProgress>>() {
+     };
+     private final DataFixer d;
+-    private final PlayerList e;
++    private final PlayerList e; public PlayerList getPlayerList() { return e; } // Purpur - OBFHELPER
+     private final File f;
+     public final Map<Advancement, AdvancementProgress> data = Maps.newLinkedHashMap();
+     private final Set<Advancement> h = Sets.newLinkedHashSet();
+@@ -317,7 +317,14 @@ public class AdvancementDataPlayer {
                  this.player.world.getServer().getPluginManager().callEvent(new org.bukkit.event.player.PlayerAdvancementDoneEvent(this.player.getBukkitEntity(), advancement.bukkit)); // CraftBukkit
                  advancement.d().a(this.player);
                  if (advancement.c() != null && advancement.c().i() && this.player.world.getGameRules().getBoolean(GameRules.ANNOUNCE_ADVANCEMENTS)) {
 -                    this.e.sendMessage(new ChatMessage("chat.type.advancement." + advancement.c().e().a(), new Object[]{this.player.getScoreboardDisplayName(), advancement.j()}), ChatMessageType.SYSTEM, SystemUtils.b);
 +                    // Purpur Start - AdvancementMessage By Player
++                    ChatMessage advancementMessage = new ChatMessage("chat.type.advancement." + advancement.getDisplay().getFrameType().advancementType(), this.player.getScoreboardDisplayName(), advancement.getJ());
 +                    if (net.pl3x.purpur.PurpurConfig.advancementOnlyBroadcastToAffectedPlayer) {
-+                        this.player.sendMessage(getMessagePlayerAdvancement(advancement), SystemUtils.b);
++                        this.player.sendMessage(advancementMessage, SystemUtils.getNullUUID());
 +                    } else {
-+                        this.e.sendMessage(getMessagePlayerAdvancement(advancement), ChatMessageType.SYSTEM, SystemUtils.b);
++                        getPlayerList().sendMessage(advancementMessage, ChatMessageType.SYSTEM, SystemUtils.getNullUUID());
 +                    }
 +                    // Purpur End
                  }

--- a/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
+++ b/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
@@ -67,7 +67,7 @@ index 56424e45c04e7165c0671f74cdcd0147d1069af7..b510ec6fc0c915f3018e039cf1ac19bb
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }
 +
-+    public static boolean advancementOnlyBroadcastToAffectedPlayer  = false;
++    public static boolean advancementOnlyBroadcastToAffectedPlayer = false;
 +    private static void advancementSettings() {
 +        advancementOnlyBroadcastToAffectedPlayer  = getBoolean("settings.advancement.only-broadcast-to-affected-player", advancementOnlyBroadcastToAffectedPlayer );
 +    }

--- a/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
+++ b/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
@@ -48,7 +48,7 @@ index 59d781b5e61c5d2c004bc92300d8d42e81821308..e43c96c493b91ec62c75f75f9ca3022c
                  if (advancement.c() != null && advancement.c().i() && this.player.world.getGameRules().getBoolean(GameRules.ANNOUNCE_ADVANCEMENTS)) {
 -                    this.e.sendMessage(new ChatMessage("chat.type.advancement." + advancement.c().e().a(), new Object[]{this.player.getScoreboardDisplayName(), advancement.j()}), ChatMessageType.SYSTEM, SystemUtils.b);
 +                    // Purpur Start - AdvancementMessage By Player
-+                    ChatMessage advancementMessage = new ChatMessage("chat.type.advancement." + advancement.getDisplay().getFrameType().advancementType(), this.player.getScoreboardDisplayName(), advancement.getJ());
++                    ChatMessage advancementMessage = new ChatMessage("chat.type.advancement." + advancement.getDisplay().getFrameType().getName(), this.player.getScoreboardDisplayName(), advancement.getChatComponent());
 +                    if (net.pl3x.purpur.PurpurConfig.advancementOnlyBroadcastToAffectedPlayer) {
 +                        this.player.sendMessage(advancementMessage, SystemUtils.getNullUUID());
 +                    } else {

--- a/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
+++ b/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: DoctaEnkoda <bierquejason@gmail.com>
+Date: Mon, 3 May 2021 01:33:14 +0200
+Subject: [PATCH] Allows to display progress messages by player instead to
+ everyone on the server.
+
+
+diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+index 59d781b5e61c5d2c004bc92300d8d42e81821308..ecb4313701281faf53b2b913930bb5f5dbf81411 100644
+--- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
++++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+@@ -317,7 +317,14 @@ public class AdvancementDataPlayer {
+                 this.player.world.getServer().getPluginManager().callEvent(new org.bukkit.event.player.PlayerAdvancementDoneEvent(this.player.getBukkitEntity(), advancement.bukkit)); // CraftBukkit
+                 advancement.d().a(this.player);
+                 if (advancement.c() != null && advancement.c().i() && this.player.world.getGameRules().getBoolean(GameRules.ANNOUNCE_ADVANCEMENTS)) {
+-                    this.e.sendMessage(new ChatMessage("chat.type.advancement." + advancement.c().e().a(), new Object[]{this.player.getScoreboardDisplayName(), advancement.j()}), ChatMessageType.SYSTEM, SystemUtils.b);
++                    // Purpur Start - AdvancementMessage By Player
++                    ChatMessage advancementMessage = new ChatMessage("chat.type.advancement." + advancement.c().e().a(), this.player.getScoreboardDisplayName(), advancement.j());
++                    if (net.pl3x.purpur.PurpurConfig.advancementMessageByPlayer) {
++                        this.player.sendMessage(advancementMessage, SystemUtils.b);
++                    } else {
++                        this.e.sendMessage(advancementMessage, ChatMessageType.SYSTEM, SystemUtils.b);
++                    }
++                    // Purpur End
+                 }
+             }
+         }
+diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+index 56424e45c04e7165c0671f74cdcd0147d1069af7..00b291d8c181d0afe3209e4a3ffd3cf050598b88 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+@@ -287,4 +287,9 @@ public class PurpurConfig {
+     private static void tpsCatchup() {
+         tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
+     }
++
++    public static boolean advancementMessageByPlayer = false;
++    private static void advancementSettings() {
++        advancementMessageByPlayer = getBoolean("settings.advancement.message-by-player", advancementMessageByPlayer);
++    }
+ }

--- a/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
+++ b/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
@@ -33,7 +33,7 @@ index 59d781b5e61c5d2c004bc92300d8d42e81821308..f37a4a6dccd808e5681cd6e415a0b0e1
              }
          }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 56424e45c04e7165c0671f74cdcd0147d1069af7..00b291d8c181d0afe3209e4a3ffd3cf050598b88 100644
+index 56424e45c04e7165c0671f74cdcd0147d1069af7..b510ec6fc0c915f3018e039cf1ac19bb773eb53a 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -287,4 +287,9 @@ public class PurpurConfig {
@@ -41,8 +41,8 @@ index 56424e45c04e7165c0671f74cdcd0147d1069af7..00b291d8c181d0afe3209e4a3ffd3cf0
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }
 +
-+    public static boolean advancementMessageByPlayer = false;
++    public static boolean advancementOnlyBroadcastToAffectedPlayer  = false;
 +    private static void advancementSettings() {
-+        advancementMessageByPlayer = getBoolean("settings.advancement.message-by-player", advancementMessageByPlayer);
++        advancementOnlyBroadcastToAffectedPlayer  = getBoolean("settings.advancement.only-broadcast-to-affected-player", advancementOnlyBroadcastToAffectedPlayer );
 +    }
  }

--- a/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
+++ b/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
@@ -6,20 +6,27 @@ Subject: [PATCH] Allows to display progress messages by player instead to
 
 
 diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
-index 59d781b5e61c5d2c004bc92300d8d42e81821308..ecb4313701281faf53b2b913930bb5f5dbf81411 100644
+index 59d781b5e61c5d2c004bc92300d8d42e81821308..f37a4a6dccd808e5681cd6e415a0b0e1b6fecb29 100644
 --- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
 +++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
-@@ -317,7 +317,14 @@ public class AdvancementDataPlayer {
+@@ -298,6 +298,7 @@ public class AdvancementDataPlayer {
+ 
+     }
+ 
++    public ChatMessage getMessagePlayerAdvancement(Advancement advancement) { return new ChatMessage("chat.type.advancement." + advancement.c().e().a(), this.player.getScoreboardDisplayName(), advancement.j()); } // Purpur - OBFHELPER
+     public boolean grantCriteria(Advancement advancement, String s) {
+         boolean flag = false;
+         AdvancementProgress advancementprogress = this.getProgress(advancement);
+@@ -317,7 +318,13 @@ public class AdvancementDataPlayer {
                  this.player.world.getServer().getPluginManager().callEvent(new org.bukkit.event.player.PlayerAdvancementDoneEvent(this.player.getBukkitEntity(), advancement.bukkit)); // CraftBukkit
                  advancement.d().a(this.player);
                  if (advancement.c() != null && advancement.c().i() && this.player.world.getGameRules().getBoolean(GameRules.ANNOUNCE_ADVANCEMENTS)) {
 -                    this.e.sendMessage(new ChatMessage("chat.type.advancement." + advancement.c().e().a(), new Object[]{this.player.getScoreboardDisplayName(), advancement.j()}), ChatMessageType.SYSTEM, SystemUtils.b);
 +                    // Purpur Start - AdvancementMessage By Player
-+                    ChatMessage advancementMessage = new ChatMessage("chat.type.advancement." + advancement.c().e().a(), this.player.getScoreboardDisplayName(), advancement.j());
 +                    if (net.pl3x.purpur.PurpurConfig.advancementMessageByPlayer) {
-+                        this.player.sendMessage(advancementMessage, SystemUtils.b);
++                        this.player.sendMessage(getMessagePlayerAdvancement(advancement), SystemUtils.b);
 +                    } else {
-+                        this.e.sendMessage(advancementMessage, ChatMessageType.SYSTEM, SystemUtils.b);
++                        this.e.sendMessage(getMessagePlayerAdvancement(advancement), ChatMessageType.SYSTEM, SystemUtils.b);
 +                    }
 +                    // Purpur End
                  }

--- a/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
+++ b/patches/server/0206-Allows-to-display-progress-messages-by-player-instea.patch
@@ -6,26 +6,26 @@ Subject: [PATCH] Allows to display progress messages by player instead to
 
 
 diff --git a/src/main/java/net/minecraft/advancements/Advancement.java b/src/main/java/net/minecraft/advancements/Advancement.java
-index 8bfd20ff9a3c96fa9ff5cc618ca7e858e62943a0..ced98a97258bc2f3c2ee3eaecbf4d8419c0f4b19 100644
+index 8bfd20ff9a3c96fa9ff5cc618ca7e858e62943a0..97479cacc2a3f7850df8647f78d7dbb5710ae27b 100644
 --- a/src/main/java/net/minecraft/advancements/Advancement.java
 +++ b/src/main/java/net/minecraft/advancements/Advancement.java
 @@ -125,6 +125,7 @@ public class Advancement {
          return this.requirements;
      }
  
-+    public IChatBaseComponent getJ() { return j(); } // Purpur - OBFHELPER
++    public IChatBaseComponent getChatComponent() { return j(); } // Purpur - OBFHELPER
      public IChatBaseComponent j() {
          return this.chatComponent;
      }
 diff --git a/src/main/java/net/minecraft/advancements/AdvancementFrameType.java b/src/main/java/net/minecraft/advancements/AdvancementFrameType.java
-index f096ecf8d77b085e6c2ef4c3b64f0b65409bb287..a9157e2bbbb5041658b0ea89fbfd5fd1bee0fd66 100644
+index f096ecf8d77b085e6c2ef4c3b64f0b65409bb287..bfa86826b93a2eee7f22203ca09250e15f12d217 100644
 --- a/src/main/java/net/minecraft/advancements/AdvancementFrameType.java
 +++ b/src/main/java/net/minecraft/advancements/AdvancementFrameType.java
 @@ -31,6 +31,7 @@ public enum AdvancementFrameType {
          this.g = new ChatMessage("advancements.toast." + s);
      }
  
-+    public String advancementType() { return  a(); } // Purpur - OBFHELPER
++    public String getName() { return  a(); } // Purpur - OBFHELPER
      public String a() {
          return this.d;
      }
@@ -59,7 +59,7 @@ index 59d781b5e61c5d2c004bc92300d8d42e81821308..e43c96c493b91ec62c75f75f9ca3022c
              }
          }
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 56424e45c04e7165c0671f74cdcd0147d1069af7..b510ec6fc0c915f3018e039cf1ac19bb773eb53a 100644
+index 56424e45c04e7165c0671f74cdcd0147d1069af7..7e8654e4df61527f33d4fce2afdb14e29b90a4c2 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -287,4 +287,9 @@ public class PurpurConfig {


### PR DESCRIPTION
When a server has a lot of people, player advancements spam the chat, a lot of servers turn it off to make the chat clean.
My patch allows to keep it on the server but by sending it only to the player concerned and not to the whole server.