### PR TITLE
Configurable powered rail boost modifier

### DIFF
--- a/patches/server/0215-Configurable-powered-rail-boost-modifier.patch
+++ b/patches/server/0215-Configurable-powered-rail-boost-modifier.patch
@@ -18,7 +18,7 @@ index 7b49544210d087f5006a83c2a0d5c47c785c567f..9e91fc85e8f7ebadde239941700282fd
                  Vec3D vec3d5 = this.getMot();
                  double d21 = vec3d5.x;
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index db8b31972b38f907a53b4f63465c83d1f47f4dc3..86af0800d86c486bf05d151d80286e1e2c34e90c 100644
+index db8b31972b38f907a53b4f63465c83d1f47f4dc3..99c196f1262660b901f84c0ac66d10c9d1e6bcf7 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 @@ -133,6 +133,7 @@ public class PurpurWorldConfig {
@@ -33,7 +33,7 @@ index db8b31972b38f907a53b4f63465c83d1f47f4dc3..86af0800d86c486bf05d151d80286e1e
              set("gameplay-mechanics.minecart.controllable.block-speed.grass_block", 0.3D);
              set("gameplay-mechanics.minecart.controllable.block-speed.stone", 0.5D);
          }
-+        poweredRailBoostModifier = getDouble("gameplay-mechanics.minecart.powered-rail-boost-modifier", poweredRailBoostModifier);
++        poweredRailBoostModifier = getDouble("gameplay-mechanics.minecart.powered-rail.boost-modifier", poweredRailBoostModifier);
      }
  
      public int daytimeTicks = 12000;

--- a/patches/server/0215-Configurable-powered-rail-boost-modifier.patch
+++ b/patches/server/0215-Configurable-powered-rail-boost-modifier.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Callum Seabrook <callum.seabrook@prevarinite.com>
+Date: Fri, 14 May 2021 21:22:57 +0100
+Subject: [PATCH] Configurable powered rail boost modifier
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/EntityMinecartAbstract.java b/src/main/java/net/minecraft/world/entity/vehicle/EntityMinecartAbstract.java
+index 7b49544210d087f5006a83c2a0d5c47c785c567f..9e91fc85e8f7ebadde239941700282fd820588e4 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/EntityMinecartAbstract.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/EntityMinecartAbstract.java
+@@ -705,7 +705,7 @@ public abstract class EntityMinecartAbstract extends Entity {
+             if (d18 > 0.01D) {
+                 double d20 = 0.06D;
+ 
+-                this.setMot(vec3d4.add(vec3d4.x / d18 * 0.06D, 0.0D, vec3d4.z / d18 * 0.06D));
++                this.setMot(vec3d4.add(vec3d4.x / d18 * world.purpurConfig.poweredRailBoostModifier, 0.0D, vec3d4.z / d18 * world.purpurConfig.poweredRailBoostModifier)); // Purpur
+             } else {
+                 Vec3D vec3d5 = this.getMot();
+                 double d21 = vec3d5.x;
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index db8b31972b38f907a53b4f63465c83d1f47f4dc3..86af0800d86c486bf05d151d80286e1e2c34e90c 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -133,6 +133,7 @@ public class PurpurWorldConfig {
+     public boolean minecartControllableFallDamage = true;
+     public double minecartControllableBaseSpeed = 0.1D;
+     public Map<Block, Double> minecartControllableBlockSpeeds = new HashMap<>();
++    public double poweredRailBoostModifier = 0.06;
+     private void minecartSettings() {
+         if (PurpurConfig.version < 12) {
+             boolean oldBool = getBoolean("gameplay-mechanics.controllable-minecarts.place-anywhere", minecartPlaceAnywhere);
+@@ -185,6 +186,7 @@ public class PurpurWorldConfig {
+             set("gameplay-mechanics.minecart.controllable.block-speed.grass_block", 0.3D);
+             set("gameplay-mechanics.minecart.controllable.block-speed.stone", 0.5D);
+         }
++        poweredRailBoostModifier = getDouble("gameplay-mechanics.minecart.powered-rail-boost-modifier", poweredRailBoostModifier);
+     }
+ 
+     public int daytimeTicks = 12000;


### PR DESCRIPTION
Closes #329 

This adds an option to change the speed boost that minecarts gain from hitting a powered rail.

(Note: This doesn't work with furnace minecarts because they're weird :))