### PR TITLE
Make anvil cumulative cost configurable

### DIFF
--- a/patches/server/0219-Make-anvil-cumulative-cost-configurable.patch
+++ b/patches/server/0219-Make-anvil-cumulative-cost-configurable.patch
@@ -26,7 +26,7 @@ index 77810fbb70bf2e1ad03c28c0d69ceaa63221d94c..20b2f41d98058c1ecc2529ca61accdf9
  
      public void a(String s) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 5a228c14a6e6335399f3436419deb51420082ad2..7f280449190e0ff564f441d59e33e52418e00d9d 100644
+index 5a228c14a6e6335399f3436419deb51420082ad2..c828b37647880be200fe9132d2dd624822ef4a8b 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
 @@ -3,7 +3,6 @@ package net.pl3x.purpur;
@@ -41,7 +41,7 @@ index 5a228c14a6e6335399f3436419deb51420082ad2..7f280449190e0ff564f441d59e33e524
      public static boolean enderChestPermissionRows = false;
      public static boolean cryingObsidianValidForPortalFrame = false;
      public static int beeInsideBeeHive = 3;
-+    public static boolean anvilCumulativeCost = false;
++    public static boolean anvilCumulativeCost = true;
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);

--- a/patches/server/0219-Make-anvil-cumulative-cost-configurable.patch
+++ b/patches/server/0219-Make-anvil-cumulative-cost-configurable.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: 12emin34 <macanovic.emin@gmail.com>
+Date: Fri, 21 May 2021 16:58:45 +0200
+Subject: [PATCH] Make anvil cumulative cost configurable
+
+
+diff --git a/src/main/java/net/minecraft/world/inventory/ContainerAnvil.java b/src/main/java/net/minecraft/world/inventory/ContainerAnvil.java
+index 77810fbb70bf2e1ad03c28c0d69ceaa63221d94c..20b2f41d98058c1ecc2529ca61accdf985a4f237 100644
+--- a/src/main/java/net/minecraft/world/inventory/ContainerAnvil.java
++++ b/src/main/java/net/minecraft/world/inventory/ContainerAnvil.java
+@@ -20,6 +20,7 @@ import net.minecraft.world.item.enchantment.Enchantment;
+ import net.minecraft.world.item.enchantment.EnchantmentManager;
+ import net.minecraft.world.level.block.BlockAnvil;
+ import net.minecraft.world.level.block.state.IBlockData;
++import net.pl3x.purpur.PurpurConfig;
+ import org.apache.commons.lang3.StringUtils;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+@@ -337,7 +338,7 @@ public class ContainerAnvil extends ContainerAnvilAbstract {
+     }
+ 
+     public static int d(int i) {
+-        return i * 2 + 1;
++        return PurpurConfig.anvilCumulativeCost ? i * 2 + 1 : 0;
+     }
+ 
+     public void a(String s) {
+diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+index 5a228c14a6e6335399f3436419deb51420082ad2..7f280449190e0ff564f441d59e33e52418e00d9d 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
+@@ -3,7 +3,6 @@ package net.pl3x.purpur;
+ import co.aikar.timings.TimingsManager;
+ import com.destroystokyo.paper.PaperConfig;
+ import com.google.common.base.Throwables;
+-import net.minecraft.locale.LocaleLanguage;
+ import net.minecraft.server.MinecraftServer;
+ import net.minecraft.world.entity.EntitySize;
+ import net.minecraft.world.entity.EntityTypes;
+@@ -225,6 +224,7 @@ public class PurpurConfig {
+     public static boolean enderChestPermissionRows = false;
+     public static boolean cryingObsidianValidForPortalFrame = false;
+     public static int beeInsideBeeHive = 3;
++    public static boolean anvilCumulativeCost = false;
+     private static void blockSettings() {
+         if (version < 3) {
+             boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
+@@ -234,6 +234,7 @@ public class PurpurConfig {
+             set("settings.blocks.ender_chest.six-rows", oldValue);
+             set("settings.large-ender-chests", null);
+         }
++        anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);
+         barrelSixRows = getBoolean("settings.blocks.barrel.six-rows", barrelSixRows);
+         InventoryType.BARREL.setDefaultSize(barrelSixRows ? 54 : 27);
+         enderChestSixRows = getBoolean("settings.blocks.ender_chest.six-rows", enderChestSixRows);

--- a/patches/server/0219-Make-anvil-cumulative-cost-configurable.patch
+++ b/patches/server/0219-Make-anvil-cumulative-cost-configurable.patch
@@ -5,39 +5,23 @@ Subject: [PATCH] Make anvil cumulative cost configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/ContainerAnvil.java b/src/main/java/net/minecraft/world/inventory/ContainerAnvil.java
-index 77810fbb70bf2e1ad03c28c0d69ceaa63221d94c..20b2f41d98058c1ecc2529ca61accdf985a4f237 100644
+index 77810fbb70bf2e1ad03c28c0d69ceaa63221d94c..e1cc66e382b2251e0fa60f777515d5a110f1684e 100644
 --- a/src/main/java/net/minecraft/world/inventory/ContainerAnvil.java
 +++ b/src/main/java/net/minecraft/world/inventory/ContainerAnvil.java
-@@ -20,6 +20,7 @@ import net.minecraft.world.item.enchantment.Enchantment;
- import net.minecraft.world.item.enchantment.EnchantmentManager;
- import net.minecraft.world.level.block.BlockAnvil;
- import net.minecraft.world.level.block.state.IBlockData;
-+import net.pl3x.purpur.PurpurConfig;
- import org.apache.commons.lang3.StringUtils;
- import org.apache.logging.log4j.LogManager;
- import org.apache.logging.log4j.Logger;
-@@ -337,7 +338,7 @@ public class ContainerAnvil extends ContainerAnvilAbstract {
+@@ -337,7 +337,7 @@ public class ContainerAnvil extends ContainerAnvilAbstract {
      }
  
      public static int d(int i) {
 -        return i * 2 + 1;
-+        return PurpurConfig.anvilCumulativeCost ? i * 2 + 1 : 0;
++        return net.pl3x.purpur.PurpurConfig.anvilCumulativeCost ? i * 2 + 1 : 0;
      }
  
      public void a(String s) {
 diff --git a/src/main/java/net/pl3x/purpur/PurpurConfig.java b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-index 5a228c14a6e6335399f3436419deb51420082ad2..c828b37647880be200fe9132d2dd624822ef4a8b 100644
+index 5a228c14a6e6335399f3436419deb51420082ad2..ce9cbc3964ef626e7fe3baf59225114ca93b0b53 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurConfig.java
-@@ -3,7 +3,6 @@ package net.pl3x.purpur;
- import co.aikar.timings.TimingsManager;
- import com.destroystokyo.paper.PaperConfig;
- import com.google.common.base.Throwables;
--import net.minecraft.locale.LocaleLanguage;
- import net.minecraft.server.MinecraftServer;
- import net.minecraft.world.entity.EntitySize;
- import net.minecraft.world.entity.EntityTypes;
-@@ -225,6 +224,7 @@ public class PurpurConfig {
+@@ -225,6 +225,7 @@ public class PurpurConfig {
      public static boolean enderChestPermissionRows = false;
      public static boolean cryingObsidianValidForPortalFrame = false;
      public static int beeInsideBeeHive = 3;
@@ -45,7 +29,7 @@ index 5a228c14a6e6335399f3436419deb51420082ad2..c828b37647880be200fe9132d2dd6248
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -234,6 +234,7 @@ public class PurpurConfig {
+@@ -234,6 +235,7 @@ public class PurpurConfig {
              set("settings.blocks.ender_chest.six-rows", oldValue);
              set("settings.large-ender-chests", null);
          }


### PR DESCRIPTION
XP cost of the anvil gets higher each time an item is used in the anvil
https://minecraft.fandom.com/wiki/Anvil_mechanics#Costs_for_combining_enchantments
This patch adds an option to toggle the cumulative cost increase