### PR TITLE
Toggle for kinetic damage

### DIFF
--- a/patches/server/0240-Toggle-for-kinetic-damage.patch
+++ b/patches/server/0240-Toggle-for-kinetic-damage.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: 12emin34 <macanovic.emin@gmail.com>
+Date: Wed, 4 Aug 2021 11:44:26 +0200
+Subject: [PATCH] Toggle for kinetic damage
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 04e32a71cd97710b8193711fb691cc08e5460daf..5d10acb75a6d92694055ade8de5b9e11db566533 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -2779,7 +2779,11 @@ public abstract class LivingEntity extends Entity {
+ 
+                     if (f4 > 0.0F) {
+                         this.playSound(this.getFallDamageSound((int) f4), 1.0F, 1.0F);
+-                        this.hurt(DamageSource.FLY_INTO_WALL, f4);
++                        // Purpur start
++                        if (level.purpurConfig.elytraKineticDamage) {
++                            this.hurt(DamageSource.FLY_INTO_WALL, f4);
++                        }
++                        // Purpur end
+                     }
+                 }
+ 
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index 5d9f610c649e4f34dfc3b3b151ab5cefd1fc4f03..64f671cb809d22e35f01939b91d5bc1fee09629b 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -137,12 +137,14 @@ public class PurpurWorldConfig {
+     public boolean elytraIgnoreUnbreaking = false;
+     public int elytraDamagePerFireworkBoost = 0;
+     public int elytraDamagePerTridentBoost = 0;
++    public boolean elytraKineticDamage = true;
+     private void elytraSettings() {
+         elytraDamagePerSecond = getInt("gameplay-mechanics.elytra.damage-per-second", elytraDamagePerSecond);
+         elytraDamageMultiplyBySpeed = getDouble("gameplay-mechanics.elytra.damage-multiplied-by-speed", elytraDamageMultiplyBySpeed);
+         elytraIgnoreUnbreaking = getBoolean("gameplay-mechanics.elytra.ignore-unbreaking", elytraIgnoreUnbreaking);
+         elytraDamagePerFireworkBoost = getInt("gameplay-mechanics.elytra.damage-per-boost.firework", elytraDamagePerFireworkBoost);
+         elytraDamagePerTridentBoost = getInt("gameplay-mechanics.elytra.damage-per-boost.trident", elytraDamagePerTridentBoost);
++        elytraKineticDamage = getBoolean("gameplay-mechanics.elytra.kinetic-damage", elytraKineticDamage);
+     }
+ 
+     public int entityLifeSpan = 0;


### PR DESCRIPTION
This patch adds in a config option that controls whether players will get damaged when flying into the wall with an elytra (kinetic damage).