### PR TITLE
Option for beds to explode on villager sleep

### DIFF
--- a/patches/server/0255-Option-for-beds-to-explode-on-villager-sleep.patch
+++ b/patches/server/0255-Option-for-beds-to-explode-on-villager-sleep.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for beds to explode on villager sleep
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index 597d21bd2d7dde000e02986557be205380e2aa0a..a3a284c0e17a8fcdb3397dafdb3573dcfd9f7cc3 100644
+index 597d21bd2d7dde000e02986557be205380e2aa0a..e5adfd16d132828727040b56a90c1173c9b71a44 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-@@ -1175,10 +1175,19 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+@@ -1175,10 +1175,16 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
  
      @Override
      public void startSleeping(BlockPos pos) {
@@ -17,11 +17,8 @@ index 597d21bd2d7dde000e02986557be205380e2aa0a..a3a284c0e17a8fcdb3397dafdb3573dc
 -        this.brain.eraseMemory(MemoryModuleType.WALK_TARGET);
 -        this.brain.eraseMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);
 +        // Purpur start
-+        if (level.purpurConfig.bedExplodeOnVillagerSleep) {
-+            BlockState blockState = this.level.getBlockState(pos);
-+            if (blockState.getBlock() instanceof net.minecraft.world.level.block.BedBlock) {
-+                this.level.explode(null, DamageSource.explosion((net.minecraft.world.level.Explosion) null), null, (double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (float) this.level.purpurConfig.bedExplosionPower, this.level.purpurConfig.bedExplosionFire, this.level.purpurConfig.bedExplosionEffect);
-+            }
++        if (level.purpurConfig.bedExplodeOnVillagerSleep && this.level.getBlockState(pos).getBlock() instanceof net.minecraft.world.level.block.BedBlock) {
++            this.level.explode(null, DamageSource.explosion((net.minecraft.world.level.Explosion) null), null, (double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (float) this.level.purpurConfig.bedExplosionPower, this.level.purpurConfig.bedExplosionFire, this.level.purpurConfig.bedExplosionEffect);
 +        } else {
 +            super.startSleeping(pos);
 +            this.brain.setMemory(MemoryModuleType.LAST_SLEPT, this.level.getGameTime()); // CraftBukkit - decompile error
@@ -33,10 +30,10 @@ index 597d21bd2d7dde000e02986557be205380e2aa0a..a3a284c0e17a8fcdb3397dafdb3573dc
  
      @Override
 diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-index bbfbe72f3b5e06c50d074dbbb2d9f459bb15c04b..2187207ecd4a040a9d8fdaf625cfe9f96db1eb29 100644
+index 467cc1e7166875c929b4d39f7ed3d7c2f12991e6..702ed3dd224982989060295f3ca07a6459072c65 100644
 --- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
-@@ -723,11 +723,13 @@ public class PurpurWorldConfig {
+@@ -731,11 +731,13 @@ public class PurpurWorldConfig {
      }
  
      public boolean bedExplode = true;

--- a/patches/server/0257-Option-for-beds-to-explode-on-villager-sleep.patch
+++ b/patches/server/0257-Option-for-beds-to-explode-on-villager-sleep.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Option for beds to explode on villager sleep
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index 597d21bd2d7dde000e02986557be205380e2aa0a..eac25fbfa1030be5792ba6a9066db12c045de311 100644
+index 597d21bd2d7dde000e02986557be205380e2aa0a..a3a284c0e17a8fcdb3397dafdb3573dcfd9f7cc3 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
 @@ -1175,10 +1175,19 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
@@ -19,7 +19,7 @@ index 597d21bd2d7dde000e02986557be205380e2aa0a..eac25fbfa1030be5792ba6a9066db12c
 +        // Purpur start
 +        if (level.purpurConfig.bedExplodeOnVillagerSleep) {
 +            BlockState blockState = this.level.getBlockState(pos);
-+            if (blockState.getBlock() instanceof net.minecraft.world.level.block.BedBlock && (this.level.isNether() || this.level.isTheEnd())) {
++            if (blockState.getBlock() instanceof net.minecraft.world.level.block.BedBlock) {
 +                this.level.explode(null, DamageSource.explosion((net.minecraft.world.level.Explosion) null), null, (double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (float) this.level.purpurConfig.bedExplosionPower, this.level.purpurConfig.bedExplosionFire, this.level.purpurConfig.bedExplosionEffect);
 +            }
 +        } else {

--- a/patches/server/0257-Option-for-beds-to-explode-on-villager-sleep.patch
+++ b/patches/server/0257-Option-for-beds-to-explode-on-villager-sleep.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: 12emin34 <macanovic.emin@gmail.com>
+Date: Tue, 31 Aug 2021 16:48:29 +0200
+Subject: [PATCH] Option for beds to explode on villager sleep
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+index 597d21bd2d7dde000e02986557be205380e2aa0a..eac25fbfa1030be5792ba6a9066db12c045de311 100644
+--- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
++++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+@@ -1175,10 +1175,19 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+ 
+     @Override
+     public void startSleeping(BlockPos pos) {
+-        super.startSleeping(pos);
+-        this.brain.setMemory(MemoryModuleType.LAST_SLEPT, this.level.getGameTime()); // CraftBukkit - decompile error
+-        this.brain.eraseMemory(MemoryModuleType.WALK_TARGET);
+-        this.brain.eraseMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);
++        // Purpur start
++        if (level.purpurConfig.bedExplodeOnVillagerSleep) {
++            BlockState blockState = this.level.getBlockState(pos);
++            if (blockState.getBlock() instanceof net.minecraft.world.level.block.BedBlock && (this.level.isNether() || this.level.isTheEnd())) {
++                this.level.explode(null, DamageSource.explosion((net.minecraft.world.level.Explosion) null), null, (double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (float) this.level.purpurConfig.bedExplosionPower, this.level.purpurConfig.bedExplosionFire, this.level.purpurConfig.bedExplosionEffect);
++            }
++        } else {
++            super.startSleeping(pos);
++            this.brain.setMemory(MemoryModuleType.LAST_SLEPT, this.level.getGameTime()); // CraftBukkit - decompile error
++            this.brain.eraseMemory(MemoryModuleType.WALK_TARGET);
++            this.brain.eraseMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);
++        }
++        // Purpur end
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index bbfbe72f3b5e06c50d074dbbb2d9f459bb15c04b..2187207ecd4a040a9d8fdaf625cfe9f96db1eb29 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -723,11 +723,13 @@ public class PurpurWorldConfig {
+     }
+ 
+     public boolean bedExplode = true;
++    public boolean bedExplodeOnVillagerSleep = false;
+     public double bedExplosionPower = 5.0D;
+     public boolean bedExplosionFire = true;
+     public Explosion.BlockInteraction bedExplosionEffect = Explosion.BlockInteraction.DESTROY;
+     private void bedSettings() {
+         bedExplode = getBoolean("blocks.bed.explode", bedExplode);
++        bedExplodeOnVillagerSleep = getBoolean("blocks.bed.explode-on-villager-sleep", bedExplodeOnVillagerSleep);
+         bedExplosionPower = getDouble("blocks.bed.explosion-power", bedExplosionPower);
+         bedExplosionFire = getBoolean("blocks.bed.explosion-fire", bedExplosionFire);
+         try {


### PR DESCRIPTION
This patch allows beds to explode when villagers try to sleep (~~only in nether and end, of course~~ per world now).