### PR TITLE
fix empty messages still sending when empty

### DIFF
--- a/patches/server/0006-Component-related-conveniences.patch
+++ b/patches/server/0006-Component-related-conveniences.patch
@@ -103,7 +103,7 @@ index ad9fb50791779a5fe7d22268b71bd10d9c9ff3f0..1c1602f839828252748e1acacfe42c7c
          this.server.sendMessage(message, sender);
          Iterator iterator = this.players.iterator();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 732eb171f6a8fe1b02044a00fcf85217c41116ac..3b7d72f035d7fd74971af043294047ff1ed4c95c 100644
+index 5d455a662107182659abcbe83195ac5d6cf25813..22a730d1b2f8ede06ae3366344af5120134d1af7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3596,6 +3596,34 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -116,7 +116,7 @@ index 732eb171f6a8fe1b02044a00fcf85217c41116ac..3b7d72f035d7fd74971af043294047ff
 +    }
 +
 +    public void sendMessage(@Nullable String message, UUID sender) {
-+        if (message != null) {
++        if (org.apache.commons.lang3.StringUtils.isNotEmpty(message)) {
 +            sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(message), sender);
 +        }
 +    }


### PR DESCRIPTION
Fix #684. Use empty message for cannot-ride-mob. This adds