### PR TITLE
add new event

### DIFF
--- a/patches/api/0051-add-player-packet-event.patch
+++ b/patches/api/0051-add-player-packet-event.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Sat, 25 Sep 2021 21:34:34 -0500
+Subject: [PATCH] add player packet event
+
+Co-authored by: oharass <oharass@bk.ru>
+
+
+diff --git a/src/main/java/net/pl3x/purpur/event/player/PlayerPacketSendEvent.java b/src/main/java/net/pl3x/purpur/event/player/PlayerPacketSendEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..b2dcbd94f24dc9906499310cf977874d64198340
+--- /dev/null
++++ b/src/main/java/net/pl3x/purpur/event/player/PlayerPacketSendEvent.java
+@@ -0,0 +1,54 @@
++package net.pl3x.purpur.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++
++/**
++ * Called when players send a packet while in Play state.
++ * Always called on the main thread, before any packet is processed.
++ * If packet is not processed on main thread, event is not fired.
++ * If canceled, server will ignore the packet.
++ */
++public class PlayerPacketSendEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private int id;
++    private Object packet;
++    private boolean cancelled;
++
++    public PlayerPacketSendEvent(@NotNull Player player, int id, @NotNull Object packet) {
++        super(player);
++        this.id = id;
++        this.packet = packet;
++    }
++
++    public int getId() {
++        return this.id;
++    }
++
++    public @NotNull Object getPacket() {
++        return this.packet;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/patches/server/0259-add-player-packet-event.patch
+++ b/patches/server/0259-add-player-packet-event.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Sat, 25 Sep 2021 21:34:34 -0500
+Subject: [PATCH] add player packet event
+
+Co-authored by: oharass <oharass@bk.ru>
+
+
+diff --git a/src/main/java/net/minecraft/network/protocol/PacketUtils.java b/src/main/java/net/minecraft/network/protocol/PacketUtils.java
+index acc12307f61e1e055896b68fe16654c9c4a606a0..3311833f31b0bf911faf32e7b2fd6fc63325656e 100644
+--- a/src/main/java/net/minecraft/network/protocol/PacketUtils.java
++++ b/src/main/java/net/minecraft/network/protocol/PacketUtils.java
+@@ -53,6 +53,7 @@ public class PacketUtils {
+                 if (MinecraftServer.getServer().hasStopped() || (listener instanceof ServerGamePacketListenerImpl && ((ServerGamePacketListenerImpl) listener).processedDisconnect)) return; // CraftBukkit, MC-142590
+                 if (listener.getConnection().isConnected()) {
+                     try (Timing ignored = timing.startTiming()) { // Paper - timings
++                    if (!createEvent(packet, listener)) return; // Purpur
+                     packet.handle(listener);
+                     } // Paper - timings
+                     // Paper start
+@@ -87,5 +88,16 @@ public class PacketUtils {
+             throw RunningOnDifferentThreadException.RUNNING_ON_DIFFERENT_THREAD;
+             // CraftBukkit end
+         }
++        if (!createEvent(packet, listener)) throw RunningOnDifferentThreadException.RUNNING_ON_DIFFERENT_THREAD; // Purpur
+     }
++    // Purpur start
++    private static <T extends PacketListener> boolean createEvent(Packet<T> packet, T listener) {
++        if (listener instanceof ServerGamePacketListenerImpl connection) {
++            Integer id = net.minecraft.network.ConnectionProtocol.PLAY.getPacketId(PacketFlow.SERVERBOUND, packet);
++            if (id == null) return false;
++            return new net.pl3x.purpur.event.player.PlayerPacketSendEvent(connection.getCraftPlayer(), id, packet).callEvent();
++        }
++        return true;
++    }
++    // Purpur end
+ }


### PR DESCRIPTION
add event for player packets. Packet can not be api ever because too super unstable. Because of this, packet is object. Nothing more nothing less. Not real packet. Just object. This is useful for plugin like protocollib can not do easy. This is most expansive move for purpur api yet. This adds.

if you do not like tell me. I accept defeat.


This is much more useful because of MOJMAP and PAPERWEIGHT. Much more stable for different versions.

I would like to add a send packet method in the future with this. This new method can replace protocollib without true packet api.