### PR TITLE
[ci-skip] Bump Gradle 7.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
PaperMC and old Tuinity used Gradle 7.2, update ?
https://github.com/PaperMC/Paper/blob/f905057070b0a272c281ff767adcea3a0aca9601/gradle/wrapper/gradle-wrapper.properties#L3