### PR TITLE
re-add gradle wrapper validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ jobs:
     if: "!contains(github.event.commits[0].message, '[ci-skip]')"
     steps:
       - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v2
         with:
           distribution: temurin


### PR DESCRIPTION
I accidentally removed the gradle wrapper validation in my last pull request. Everything else works better, cache means 1 minute build times. But no wrapper validation adds place for possible malware injection.