### PR TITLE
axolotl options to choose hunting/hostile targets

### DIFF
--- a/patches/server/0261-axolotl-options-to-choose-hunting-hostile-targets.patch
+++ b/patches/server/0261-axolotl-options-to-choose-hunting-hostile-targets.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: granny <granny@pl3x.net>
+Date: Fri, 15 Oct 2021 02:22:19 -0700
+Subject: [PATCH] axolotl options to choose hunting/hostile targets
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/AxolotlAttackablesSensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/AxolotlAttackablesSensor.java
+index 4433c567cce113dc7cd53b517beb94f63ed2606c..cc5de6bcaad6bfc0cfc1292de272aad1b89c782b 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/sensing/AxolotlAttackablesSensor.java
++++ b/src/main/java/net/minecraft/world/entity/ai/sensing/AxolotlAttackablesSensor.java
+@@ -17,11 +17,11 @@ public class AxolotlAttackablesSensor extends NearestVisibleLivingEntitySensor {
+     }
+ 
+     private boolean isHuntTarget(LivingEntity axolotl, LivingEntity target) {
+-        return !axolotl.getBrain().hasMemoryValue(MemoryModuleType.HAS_HUNTING_COOLDOWN) && EntityTypeTags.AXOLOTL_HUNT_TARGETS.contains(target.getType());
++        return !axolotl.getBrain().hasMemoryValue(MemoryModuleType.HAS_HUNTING_COOLDOWN) && axolotl.level.purpurConfig.axolotlHuntTargets.contains(target.getType()); // Purpur
+     }
+ 
+     private boolean isHostileTarget(LivingEntity axolotl) {
+-        return EntityTypeTags.AXOLOTL_ALWAYS_HOSTILES.contains(axolotl.getType());
++        return axolotl.level.purpurConfig.axolotlAlwaysHostiles.contains(axolotl.getType()); // Purpur
+     }
+ 
+     private boolean isClose(LivingEntity axolotl, LivingEntity target) {
+diff --git a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+index d31fba4f062e9fe4e3f52827936edbb3f81f234b..7d0c39065dc65e74724d70e17891ab3343356e14 100644
+--- a/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
++++ b/src/main/java/net/pl3x/purpur/PurpurWorldConfig.java
+@@ -3,7 +3,7 @@ package net.pl3x.purpur;
+ import net.minecraft.core.Registry;
+ import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.server.level.ServerLevel;
+-import net.minecraft.world.Difficulty;
++import net.minecraft.world.entity.EntityType;
+ import net.minecraft.world.item.DyeColor;
+ import net.minecraft.world.item.Item;
+ import net.minecraft.world.item.Items;
+@@ -1032,11 +1032,32 @@ public class PurpurWorldConfig {
+     public boolean axolotlRidable = false;
+     public double axolotlMaxHealth = 14.0D;
+     public int axolotlBreedingTicks = 6000;
++    public ArrayList<EntityType> axolotlHuntTargets = new ArrayList<>();
++    public ArrayList<EntityType> axolotlAlwaysHostiles = new ArrayList<>();
+     private void axolotlSettings() {
+         axolotlRidable = getBoolean("mobs.axolotl.ridable", axolotlRidable);
+         axolotlMaxHealth = getDouble("mobs.axolotl.attributes.max_health", axolotlMaxHealth);
+         axolotlBreedingTicks = getInt("mobs.axolotl.breeding-delay-ticks", axolotlBreedingTicks);
+         axolotlTakeDamageFromWater = getBoolean("mobs.axolotl.takes-damage-from-water", axolotlTakeDamageFromWater);
++        getList("mobs.axolotl.hunt-targets", new ArrayList<String>(){{
++            add("minecraft:tropical_fish");
++            add("minecraft:pufferfish");
++            add("minecraft:salmon");
++            add("minecraft:cod");
++            add("minecraft:squid");
++            add("minecraft:glow_squid");
++        }}).forEach(key -> {
++            EntityType<?> entity = Registry.ENTITY_TYPE.get(new ResourceLocation(key.toString()));
++            axolotlHuntTargets.add(entity);
++        });
++        getList("mobs.axolotl.always-hostiles", new ArrayList<String>(){{
++            add("minecraft:drowned");
++            add("minecraft:guardian");
++            add("minecraft:elder_guardian");
++        }}).forEach(key -> {
++            EntityType<?> entity = Registry.ENTITY_TYPE.get(new ResourceLocation(key.toString()));
++            axolotlAlwaysHostiles.add(entity);
++        });
+     }
+ 
+     public boolean batRidable = false;


### PR DESCRIPTION
Whenever you run the `/purpur reload`, all axolotls will "freeze" until the command finishes running (which makes sense since targets are tied to the config options now).

Attempting to remove a mob from the list and running `/purpur reload` will not actually remove the mob from the list; it will just add onto what the list already has (so essentially duplicates the list if there's no changes). I replicated how `getList` is used similarly to other `getList` declarations in `PurpurWorldConfig` soo not sure if this is an issue with just my usage of `getList` or if it's reproducible with the other list options as well.