### PR TITLE
Potion NamespacedKey. again...

### DIFF
--- a/patches/api/0045-Potion-NamespacedKey.patch
+++ b/patches/api/0045-Potion-NamespacedKey.patch
@@ -17,7 +17,7 @@ index 8e2f474a44a9b6355c4582d4f51c1fd83a51584a..3a097dbf7736f2d8d3d3dbd2f55f4cfe
  import org.bukkit.potion.PotionEffect;
  import org.bukkit.potion.PotionEffectType;
 diff --git a/src/main/java/org/bukkit/potion/PotionEffect.java b/src/main/java/org/bukkit/potion/PotionEffect.java
-index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00397e9578 100644
+index 74767751199bce03d63f2a9524712656193f850c..abe804d749989b2974b2fcbf42e60258e5ed4ef2 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffect.java
 +++ b/src/main/java/org/bukkit/potion/PotionEffect.java
 @@ -5,6 +5,7 @@ import java.util.Map;
@@ -28,7 +28,7 @@ index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00
  import org.bukkit.configuration.serialization.ConfigurationSerializable;
  import org.bukkit.configuration.serialization.SerializableAs;
  import org.bukkit.entity.LivingEntity;
-@@ -26,12 +27,15 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -26,12 +27,14 @@ public class PotionEffect implements ConfigurationSerializable {
      private static final String AMBIENT = "ambient";
      private static final String PARTICLES = "has-particles";
      private static final String ICON = "has-icon";
@@ -39,12 +39,11 @@ index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00
      private final boolean ambient;
      private final boolean particles;
      private final boolean icon;
-+    @Nullable
-+    private final NamespacedKey key; // Purpur
++    @Nullable private final NamespacedKey key; // Purpur
  
      /**
       * Creates a potion effect.
-@@ -42,8 +46,9 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -42,8 +45,9 @@ public class PotionEffect implements ConfigurationSerializable {
       * @param ambient the ambient status, see {@link PotionEffect#isAmbient()}
       * @param particles the particle status, see {@link PotionEffect#hasParticles()}
       * @param icon the icon status, see {@link PotionEffect#hasIcon()}
@@ -55,14 +54,14 @@ index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00
          Validate.notNull(type, "effect type cannot be null");
          this.type = type;
          this.duration = duration;
-@@ -51,8 +56,38 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -51,8 +55,38 @@ public class PotionEffect implements ConfigurationSerializable {
          this.ambient = ambient;
          this.particles = particles;
          this.icon = icon;
-+        this.key = key; // Purpur
++    // Purpur start - Add key, Key instead of icon constructor and keyless normal.
++        this.key = key;
 +    }
 +
-+    // Purpur start - Key instead of icon constructor and keyless normal.
 +    /**
 +     * Create a potion effect.
 +     * @param duration measured in ticks, see {@link
@@ -94,7 +93,7 @@ index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00
      /**
       * Creates a potion effect with no defined color.
       *
-@@ -98,35 +133,42 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -98,36 +132,43 @@ public class PotionEffect implements ConfigurationSerializable {
       * @param map the map to deserialize from
       */
      public PotionEffect(@NotNull Map<String, Object> map) {
@@ -102,51 +101,50 @@ index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00
 +        this(getEffectType(map), getInt(map, DURATION), getInt(map, AMPLIFIER), getBool(map, AMBIENT, false), getBool(map, PARTICLES, true), getBool(map, ICON, getBool(map, PARTICLES, true)), getKey(map)); // Purpur - getKey
      }
  
--    // Paper start
-+    // Paper start // Purpur start - add key
+     // Paper start
      @NotNull
      public PotionEffect withType(@NotNull PotionEffectType type) {
 -        return new PotionEffect(type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(type, duration, amplifier, ambient, particles, icon, key);
++        return new PotionEffect(type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
      }
      @NotNull
      public PotionEffect withDuration(int duration) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
      }
      @NotNull
      public PotionEffect withAmplifier(int amplifier) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
      }
      @NotNull
      public PotionEffect withAmbient(boolean ambient) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
      }
      @NotNull
      public PotionEffect withParticles(boolean particles) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
      }
      @NotNull
      public PotionEffect withIcon(boolean icon) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
-+    }
-+    // Paper end // Purpur end
-+
 +    // Purpur start
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
+     }
+     // Paper end
+ 
 +    @NotNull
 +    public PotionEffect withKey(@Nullable NamespacedKey key) {
 +        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
-     }
--    // Paper end
++    }
 +    // Purpur end
- 
++
      @NotNull
      private static PotionEffectType getEffectType(@NotNull Map<?, ?> map) {
-@@ -154,17 +196,33 @@ public class PotionEffect implements ConfigurationSerializable {
+         int type = getInt(map, TYPE);
+@@ -154,17 +195,33 @@ public class PotionEffect implements ConfigurationSerializable {
          return def;
      }
  
@@ -188,7 +186,7 @@ index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00
      }
  
      /**
-@@ -188,7 +246,7 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -188,7 +245,7 @@ public class PotionEffect implements ConfigurationSerializable {
              return false;
          }
          PotionEffect that = (PotionEffect) obj;
@@ -197,20 +195,7 @@ index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00
      }
  
      /**
-@@ -242,9 +300,9 @@ public class PotionEffect implements ConfigurationSerializable {
-      * @return color of this potion's particles. May be null if the potion has no particles or defined color.
-      * @deprecated color is not part of potion effects
-      */
--     @Deprecated
--     @Nullable
--     @Contract("-> null")
-+    @Deprecated
-+    @Nullable
-+    @Contract("-> null")
-     public Color getColor() {
-         return null;
-     }
-@@ -256,6 +314,23 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -256,6 +313,23 @@ public class PotionEffect implements ConfigurationSerializable {
          return icon;
      }
  
@@ -234,7 +219,7 @@ index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00
      @Override
      public int hashCode() {
          int hash = 1;
-@@ -270,6 +345,6 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -270,6 +344,6 @@ public class PotionEffect implements ConfigurationSerializable {
  
      @Override
      public String toString() {

--- a/patches/api/0045-Potion-NamespacedKey.patch
+++ b/patches/api/0045-Potion-NamespacedKey.patch
@@ -17,7 +17,7 @@ index 8e2f474a44a9b6355c4582d4f51c1fd83a51584a..3a097dbf7736f2d8d3d3dbd2f55f4cfe
  import org.bukkit.potion.PotionEffect;
  import org.bukkit.potion.PotionEffectType;
 diff --git a/src/main/java/org/bukkit/potion/PotionEffect.java b/src/main/java/org/bukkit/potion/PotionEffect.java
-index 74767751199bce03d63f2a9524712656193f850c..249d492e72eaecc399665ab7374c745c92446eb7 100644
+index 74767751199bce03d63f2a9524712656193f850c..0d503d7e5470eae136965449f9c39c00397e9578 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffect.java
 +++ b/src/main/java/org/bukkit/potion/PotionEffect.java
 @@ -5,6 +5,7 @@ import java.util.Map;
@@ -55,7 +55,7 @@ index 74767751199bce03d63f2a9524712656193f850c..249d492e72eaecc399665ab7374c745c
          Validate.notNull(type, "effect type cannot be null");
          this.type = type;
          this.duration = duration;
-@@ -51,7 +56,37 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -51,8 +56,38 @@ public class PotionEffect implements ConfigurationSerializable {
          this.ambient = ambient;
          this.particles = particles;
          this.icon = icon;
@@ -74,8 +74,8 @@ index 74767751199bce03d63f2a9524712656193f850c..249d492e72eaecc399665ab7374c745c
 +     */
 +    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, @Nullable NamespacedKey key) {
 +        this(type, duration, amplifier, ambient, particles, particles, key);
-+    }
-+
+     }
+ 
 +    /**
 +     * Creates a potion effect.
 +     * @param type effect type
@@ -88,11 +88,12 @@ index 74767751199bce03d63f2a9524712656193f850c..249d492e72eaecc399665ab7374c745c
 +     */
 +    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, boolean icon) {
 +        this(type, duration, amplifier, ambient, particles, icon, null);
-     }
++    }
 +    // Purpur end
- 
++
      /**
       * Creates a potion effect with no defined color.
+      *
 @@ -98,35 +133,42 @@ public class PotionEffect implements ConfigurationSerializable {
       * @param map the map to deserialize from
       */
@@ -218,13 +219,13 @@ index 74767751199bce03d63f2a9524712656193f850c..249d492e72eaecc399665ab7374c745c
 +     * @return if the key isn't the default namespacedKey
 +     */
 +    public boolean hasKey() {
-+        return !key.getNamespace().equals("minecraft");
++        return key != null;
 +    }
 +
 +    /**
 +     * @return the key attached to the potion
 +     */
-+    @NotNull
++    @Nullable
 +    public NamespacedKey getKey() {
 +        return key;
 +    }

--- a/patches/api/0045-Potion-NamespacedKey.patch
+++ b/patches/api/0045-Potion-NamespacedKey.patch
@@ -1,0 +1,223 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Da_Racci <tangentmoons@gmail.com>
+Date: Fri, 19 Nov 2021 18:27:40 +1100
+Subject: [PATCH] Potion NamespacedKey
+
+
+diff --git a/src/main/java/org/bukkit/potion/PotionEffect.java b/src/main/java/org/bukkit/potion/PotionEffect.java
+index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720ceda3ac9 100644
+--- a/src/main/java/org/bukkit/potion/PotionEffect.java
++++ b/src/main/java/org/bukkit/potion/PotionEffect.java
+@@ -5,6 +5,7 @@ import java.util.Map;
+ import java.util.NoSuchElementException;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Color;
++import org.bukkit.NamespacedKey;
+ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.configuration.serialization.SerializableAs;
+ import org.bukkit.entity.LivingEntity;
+@@ -26,12 +27,14 @@ public class PotionEffect implements ConfigurationSerializable {
+     private static final String AMBIENT = "ambient";
+     private static final String PARTICLES = "has-particles";
+     private static final String ICON = "has-icon";
++    private static final String KEY = "namespacedKey"; // Purpur
+     private final int amplifier;
+     private final int duration;
+     private final PotionEffectType type;
+     private final boolean ambient;
+     private final boolean particles;
+     private final boolean icon;
++    private final NamespacedKey key; // Purpur
+ 
+     /**
+      * Creates a potion effect.
+@@ -42,8 +45,9 @@ public class PotionEffect implements ConfigurationSerializable {
+      * @param ambient the ambient status, see {@link PotionEffect#isAmbient()}
+      * @param particles the particle status, see {@link PotionEffect#hasParticles()}
+      * @param icon the icon status, see {@link PotionEffect#hasIcon()}
++     * @param key the namespacedKey, see {@link PotionEffect#getKey()}
+      */
+-    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, boolean icon) {
++    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, boolean icon, @Nullable NamespacedKey key) { // Purpur
+         Validate.notNull(type, "effect type cannot be null");
+         this.type = type;
+         this.duration = duration;
+@@ -51,7 +55,37 @@ public class PotionEffect implements ConfigurationSerializable {
+         this.ambient = ambient;
+         this.particles = particles;
+         this.icon = icon;
++        this.key = key != null ? key : NamespacedKey.minecraft("default"); // Purpur
++    }
++
++    // Purpur start - Key instead of icon constructor and keyless normal.
++    /**
++     * Create a potion effect.
++     * @param duration measured in ticks, see {@link
++     *     PotionEffect#getDuration()}
++     * @param amplifier the amplifier, see {@link PotionEffect#getAmplifier()}
++     * @param ambient the ambient status, see {@link PotionEffect#isAmbient()}
++     * @param particles the particle status, see {@link PotionEffect#hasParticles()}
++     * @param key the namespacedKey, see {@link PotionEffect#getKey()}
++     */
++    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, @Nullable NamespacedKey key) {
++        this(type, duration, amplifier, ambient, particles, particles, key);
++    }
++
++    /**
++     * Creates a potion effect.
++     * @param type effect type
++     * @param duration measured in ticks, see {@link
++     *     PotionEffect#getDuration()}
++     * @param amplifier the amplifier, see {@link PotionEffect#getAmplifier()}
++     * @param ambient the ambient status, see {@link PotionEffect#isAmbient()}
++     * @param particles the particle status, see {@link PotionEffect#hasParticles()}
++     * @param icon the icon status, see {@link PotionEffect#hasIcon()}
++     */
++    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, boolean icon) {
++        this(type, duration, amplifier, ambient, particles, icon, null);
+     }
++    // Purpur end
+ 
+     /**
+      * Creates a potion effect with no defined color.
+@@ -98,36 +132,43 @@ public class PotionEffect implements ConfigurationSerializable {
+      * @param map the map to deserialize from
+      */
+     public PotionEffect(@NotNull Map<String, Object> map) {
+-        this(getEffectType(map), getInt(map, DURATION), getInt(map, AMPLIFIER), getBool(map, AMBIENT, false), getBool(map, PARTICLES, true), getBool(map, ICON, getBool(map, PARTICLES, true)));
++        this(getEffectType(map), getInt(map, DURATION), getInt(map, AMPLIFIER), getBool(map, AMBIENT, false), getBool(map, PARTICLES, true), getBool(map, ICON, getBool(map, PARTICLES, true)), getKey(map)); // Purpur - getKey
+     }
+ 
+     // Paper start
+     @NotNull
+     public PotionEffect withType(@NotNull PotionEffectType type) {
+-        return new PotionEffect(type, duration, amplifier, ambient, particles, icon);
++        return new PotionEffect(type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
+     }
+     @NotNull
+     public PotionEffect withDuration(int duration) {
+-        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
+     }
+     @NotNull
+     public PotionEffect withAmplifier(int amplifier) {
+-        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
+     }
+     @NotNull
+     public PotionEffect withAmbient(boolean ambient) {
+-        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
+     }
+     @NotNull
+     public PotionEffect withParticles(boolean particles) {
+-        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
+     }
+     @NotNull
+     public PotionEffect withIcon(boolean icon) {
+-        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
+     }
+     // Paper end
+ 
++    // Purpur start
++    @NotNull
++    public PotionEffect withKey(NamespacedKey key) {
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
++    }
++    // Purpur end
++
+     @NotNull
+     private static PotionEffectType getEffectType(@NotNull Map<?, ?> map) {
+         int type = getInt(map, TYPE);
+@@ -154,17 +195,28 @@ public class PotionEffect implements ConfigurationSerializable {
+         return def;
+     }
+ 
++    // Purpur start
++    private static NamespacedKey getKey(@NotNull Map<?, ?> map) {
++        Object key = map.get(KEY);
++        if (key instanceof String stringKey) {
++            return NamespacedKey.fromString(stringKey);
++        }
++        return NamespacedKey.minecraft("default");
++    }
++    // Purpur end
++
+     @Override
+     @NotNull
+     public Map<String, Object> serialize() {
+         return ImmutableMap.<String, Object>builder()
+-            .put(TYPE, type.getId())
+-            .put(DURATION, duration)
+-            .put(AMPLIFIER, amplifier)
+-            .put(AMBIENT, ambient)
+-            .put(PARTICLES, particles)
+-            .put(ICON, icon)
+-            .build();
++                .put(TYPE, type.getId())
++                .put(DURATION, duration)
++                .put(AMPLIFIER, amplifier)
++                .put(AMBIENT, ambient)
++                .put(PARTICLES, particles)
++                .put(ICON, icon)
++                .put(KEY, key.toString()) // Purpur - add key
++                .build();
+     }
+ 
+     /**
+@@ -188,7 +240,7 @@ public class PotionEffect implements ConfigurationSerializable {
+             return false;
+         }
+         PotionEffect that = (PotionEffect) obj;
+-        return this.type.equals(that.type) && this.ambient == that.ambient && this.amplifier == that.amplifier && this.duration == that.duration && this.particles == that.particles && this.icon == that.icon;
++        return this.type.equals(that.type) && this.ambient == that.ambient && this.amplifier == that.amplifier && this.duration == that.duration && this.particles == that.particles && this.icon == that.icon && this.key == that.key; // Purpur = add key
+     }
+ 
+     /**
+@@ -242,9 +294,9 @@ public class PotionEffect implements ConfigurationSerializable {
+      * @return color of this potion's particles. May be null if the potion has no particles or defined color.
+      * @deprecated color is not part of potion effects
+      */
+-     @Deprecated
+-     @Nullable
+-     @Contract("-> null")
++    @Deprecated
++    @Nullable
++    @Contract("-> null")
+     public Color getColor() {
+         return null;
+     }
+@@ -256,6 +308,23 @@ public class PotionEffect implements ConfigurationSerializable {
+         return icon;
+     }
+ 
++    // Purpur start
++    /**
++     * @return if the key isn't the default namespacedKey
++     */
++    public boolean hasKey() {
++        return !key.getNamespace().equals("minecraft");
++    }
++
++    /**
++     * @return the key attached to the potion
++     */
++    @NotNull
++    public NamespacedKey getKey() {
++        return key;
++    }
++    // Purpur end
++
+     @Override
+     public int hashCode() {
+         int hash = 1;
+@@ -270,6 +339,6 @@ public class PotionEffect implements ConfigurationSerializable {
+ 
+     @Override
+     public String toString() {
+-        return type.getName() + (ambient ? ":(" : ":") + duration + "t-x" + amplifier + (ambient ? ")" : "");
++        return type.getName() + (ambient ? ":(" : ":") + duration + "t-x" + amplifier + (ambient ? ")" : "") + (hasKey() ? "(" + key + ")" : ""); // Purpur - add key if it isn't the default
+     }
+ }

--- a/patches/api/0045-Potion-NamespacedKey.patch
+++ b/patches/api/0045-Potion-NamespacedKey.patch
@@ -4,8 +4,20 @@ Date: Fri, 19 Nov 2021 18:27:40 +1100
 Subject: [PATCH] Potion NamespacedKey
 
 
+diff --git a/src/main/java/org/bukkit/inventory/meta/PotionMeta.java b/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
+index 8e2f474a44a9b6355c4582d4f51c1fd83a51584a..3a097dbf7736f2d8d3d3dbd2f55f4cfefa70fe85 100644
+--- a/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/PotionMeta.java
+@@ -2,6 +2,7 @@ package org.bukkit.inventory.meta;
+ 
+ import java.util.List;
+ import org.bukkit.Color;
++import org.bukkit.NamespacedKey;
+ import org.bukkit.potion.PotionData;
+ import org.bukkit.potion.PotionEffect;
+ import org.bukkit.potion.PotionEffectType;
 diff --git a/src/main/java/org/bukkit/potion/PotionEffect.java b/src/main/java/org/bukkit/potion/PotionEffect.java
-index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720ceda3ac9 100644
+index 74767751199bce03d63f2a9524712656193f850c..249d492e72eaecc399665ab7374c745c92446eb7 100644
 --- a/src/main/java/org/bukkit/potion/PotionEffect.java
 +++ b/src/main/java/org/bukkit/potion/PotionEffect.java
 @@ -5,6 +5,7 @@ import java.util.Map;
@@ -16,7 +28,7 @@ index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720
  import org.bukkit.configuration.serialization.ConfigurationSerializable;
  import org.bukkit.configuration.serialization.SerializableAs;
  import org.bukkit.entity.LivingEntity;
-@@ -26,12 +27,14 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -26,12 +27,15 @@ public class PotionEffect implements ConfigurationSerializable {
      private static final String AMBIENT = "ambient";
      private static final String PARTICLES = "has-particles";
      private static final String ICON = "has-icon";
@@ -27,26 +39,27 @@ index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720
      private final boolean ambient;
      private final boolean particles;
      private final boolean icon;
++    @Nullable
 +    private final NamespacedKey key; // Purpur
  
      /**
       * Creates a potion effect.
-@@ -42,8 +45,9 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -42,8 +46,9 @@ public class PotionEffect implements ConfigurationSerializable {
       * @param ambient the ambient status, see {@link PotionEffect#isAmbient()}
       * @param particles the particle status, see {@link PotionEffect#hasParticles()}
       * @param icon the icon status, see {@link PotionEffect#hasIcon()}
 +     * @param key the namespacedKey, see {@link PotionEffect#getKey()}
       */
 -    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, boolean icon) {
-+    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, boolean icon, @Nullable NamespacedKey key) { // Purpur
++    public PotionEffect(@NotNull PotionEffectType type, int duration, int amplifier, boolean ambient, boolean particles, boolean icon, @Nullable NamespacedKey key) { // Purpur - add key
          Validate.notNull(type, "effect type cannot be null");
          this.type = type;
          this.duration = duration;
-@@ -51,7 +55,37 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -51,7 +56,37 @@ public class PotionEffect implements ConfigurationSerializable {
          this.ambient = ambient;
          this.particles = particles;
          this.icon = icon;
-+        this.key = key != null ? key : NamespacedKey.minecraft("default"); // Purpur
++        this.key = key; // Purpur
 +    }
 +
 +    // Purpur start - Key instead of icon constructor and keyless normal.
@@ -80,7 +93,7 @@ index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720
  
      /**
       * Creates a potion effect with no defined color.
-@@ -98,36 +132,43 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -98,35 +133,42 @@ public class PotionEffect implements ConfigurationSerializable {
       * @param map the map to deserialize from
       */
      public PotionEffect(@NotNull Map<String, Object> map) {
@@ -88,67 +101,69 @@ index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720
 +        this(getEffectType(map), getInt(map, DURATION), getInt(map, AMPLIFIER), getBool(map, AMBIENT, false), getBool(map, PARTICLES, true), getBool(map, ICON, getBool(map, PARTICLES, true)), getKey(map)); // Purpur - getKey
      }
  
-     // Paper start
+-    // Paper start
++    // Paper start // Purpur start - add key
      @NotNull
      public PotionEffect withType(@NotNull PotionEffectType type) {
 -        return new PotionEffect(type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
++        return new PotionEffect(type, duration, amplifier, ambient, particles, icon, key);
      }
      @NotNull
      public PotionEffect withDuration(int duration) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
      }
      @NotNull
      public PotionEffect withAmplifier(int amplifier) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
      }
      @NotNull
      public PotionEffect withAmbient(boolean ambient) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
      }
      @NotNull
      public PotionEffect withParticles(boolean particles) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
      }
      @NotNull
      public PotionEffect withIcon(boolean icon) {
 -        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon);
-+        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key); // Purpur - add key
-     }
-     // Paper end
- 
-+    // Purpur start
-+    @NotNull
-+    public PotionEffect withKey(NamespacedKey key) {
 +        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
 +    }
-+    // Purpur end
++    // Paper end // Purpur end
 +
++    // Purpur start
++    @NotNull
++    public PotionEffect withKey(@Nullable NamespacedKey key) {
++        return new PotionEffect(this.type, duration, amplifier, ambient, particles, icon, key);
+     }
+-    // Paper end
++    // Purpur end
+ 
      @NotNull
      private static PotionEffectType getEffectType(@NotNull Map<?, ?> map) {
-         int type = getInt(map, TYPE);
-@@ -154,17 +195,28 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -154,17 +196,33 @@ public class PotionEffect implements ConfigurationSerializable {
          return def;
      }
  
 +    // Purpur start
++    @Nullable
 +    private static NamespacedKey getKey(@NotNull Map<?, ?> map) {
 +        Object key = map.get(KEY);
 +        if (key instanceof String stringKey) {
 +            return NamespacedKey.fromString(stringKey);
 +        }
-+        return NamespacedKey.minecraft("default");
++        return null;
 +    }
 +    // Purpur end
 +
      @Override
      @NotNull
      public Map<String, Object> serialize() {
-         return ImmutableMap.<String, Object>builder()
+-        return ImmutableMap.<String, Object>builder()
 -            .put(TYPE, type.getId())
 -            .put(DURATION, duration)
 -            .put(AMPLIFIER, amplifier)
@@ -156,27 +171,32 @@ index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720
 -            .put(PARTICLES, particles)
 -            .put(ICON, icon)
 -            .build();
++        // Purpur start - add key, don't serialize if null.
++        ImmutableMap.Builder<String, Object> builder = ImmutableMap.<String, Object>builder()
 +                .put(TYPE, type.getId())
 +                .put(DURATION, duration)
 +                .put(AMPLIFIER, amplifier)
 +                .put(AMBIENT, ambient)
 +                .put(PARTICLES, particles)
-+                .put(ICON, icon)
-+                .put(KEY, key.toString()) // Purpur - add key
-+                .build();
++                .put(ICON, icon);
++        if(key != null) {
++            builder.put(KEY, key.toString());
++        }
++        return builder.build();
++        // Purpur end
      }
  
      /**
-@@ -188,7 +240,7 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -188,7 +246,7 @@ public class PotionEffect implements ConfigurationSerializable {
              return false;
          }
          PotionEffect that = (PotionEffect) obj;
 -        return this.type.equals(that.type) && this.ambient == that.ambient && this.amplifier == that.amplifier && this.duration == that.duration && this.particles == that.particles && this.icon == that.icon;
-+        return this.type.equals(that.type) && this.ambient == that.ambient && this.amplifier == that.amplifier && this.duration == that.duration && this.particles == that.particles && this.icon == that.icon && this.key == that.key; // Purpur = add key
++        return this.type.equals(that.type) && this.ambient == that.ambient && this.amplifier == that.amplifier && this.duration == that.duration && this.particles == that.particles && this.icon == that.icon && this.key == that.key; // Purpur - add key
      }
  
      /**
-@@ -242,9 +294,9 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -242,9 +300,9 @@ public class PotionEffect implements ConfigurationSerializable {
       * @return color of this potion's particles. May be null if the potion has no particles or defined color.
       * @deprecated color is not part of potion effects
       */
@@ -189,7 +209,7 @@ index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720
      public Color getColor() {
          return null;
      }
-@@ -256,6 +308,23 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -256,6 +314,23 @@ public class PotionEffect implements ConfigurationSerializable {
          return icon;
      }
  
@@ -213,11 +233,11 @@ index 74767751199bce03d63f2a9524712656193f850c..6d3240c6a4903b44073b4265f726d720
      @Override
      public int hashCode() {
          int hash = 1;
-@@ -270,6 +339,6 @@ public class PotionEffect implements ConfigurationSerializable {
+@@ -270,6 +345,6 @@ public class PotionEffect implements ConfigurationSerializable {
  
      @Override
      public String toString() {
 -        return type.getName() + (ambient ? ":(" : ":") + duration + "t-x" + amplifier + (ambient ? ")" : "");
-+        return type.getName() + (ambient ? ":(" : ":") + duration + "t-x" + amplifier + (ambient ? ")" : "") + (hasKey() ? "(" + key + ")" : ""); // Purpur - add key if it isn't the default
++        return type.getName() + (ambient ? ":(" : ":") + duration + "t-x" + amplifier + (ambient ? ")" : "") + (hasKey() ? "(" + key + ")" : ""); // Purpur - add key if not null
      }
  }

--- a/patches/server/0257-Potion-NamespacedKey.patch
+++ b/patches/server/0257-Potion-NamespacedKey.patch
@@ -1,0 +1,260 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Da_Racci <tangentmoons@gmail.com>
+Date: Fri, 19 Nov 2021 21:07:47 +1100
+Subject: [PATCH] Potion NamespacedKey
+
+
+diff --git a/src/main/java/net/minecraft/world/effect/MobEffectInstance.java b/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
+index 544b3711bc7538609f64ad30995ef927f562a36f..407d9218dffcc5384ffd4e24d66ca9afb92f7b40 100644
+--- a/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
++++ b/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
+@@ -6,6 +6,7 @@ import net.minecraft.nbt.CompoundTag;
+ import net.minecraft.world.entity.LivingEntity;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
++import org.bukkit.NamespacedKey;
+ 
+ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+     private static final Logger LOGGER = LogManager.getLogger();
+@@ -17,6 +18,8 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+     private boolean visible;
+     private boolean showIcon;
+     @Nullable
++    private NamespacedKey key; // Purpur - add key
++    @Nullable
+     private MobEffectInstance hiddenEffect;
+ 
+     public MobEffectInstance(MobEffect type) {
+@@ -39,13 +42,28 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+         this(type, duration, amplifier, ambient, showParticles, showIcon, (MobEffectInstance)null);
+     }
+ 
++    // Purpur start
++    public MobEffectInstance(MobEffect type, int duration, int amplifier, boolean ambient, boolean showParticles, @Nullable NamespacedKey key) {
++        this(type, duration, amplifier, ambient, showParticles, showParticles, key, (MobEffectInstance)null);
++    }
++
+     public MobEffectInstance(MobEffect type, int duration, int amplifier, boolean ambient, boolean showParticles, boolean showIcon, @Nullable MobEffectInstance hiddenEffect) {
++        this(type, duration, amplifier, ambient, showParticles, showIcon, (NamespacedKey)null, hiddenEffect);
++    }
++
++    public MobEffectInstance(MobEffect type, int duration, int amplifier, boolean ambient, boolean showParticles, boolean showIcon, @Nullable NamespacedKey key) {
++        this(type, duration, amplifier, ambient, showParticles, showIcon, key, (MobEffectInstance)null);
++    }
++    // Purpur end
++
++    public MobEffectInstance(MobEffect type, int duration, int amplifier, boolean ambient, boolean showParticles, boolean showIcon, @Nullable NamespacedKey key, @Nullable MobEffectInstance hiddenEffect) { // Purpur - add key
+         this.effect = type;
+         this.duration = duration;
+         this.amplifier = amplifier;
+         this.ambient = ambient;
+         this.visible = showParticles;
+         this.showIcon = showIcon;
++        this.key = key; // Purpur - add key
+         this.hiddenEffect = hiddenEffect;
+     }
+ 
+@@ -60,6 +78,7 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+         this.ambient = that.ambient;
+         this.visible = that.visible;
+         this.showIcon = that.showIcon;
++        this.key = that.key; // Purpur - add key
+     }
+ 
+     public boolean update(MobEffectInstance that) {
+@@ -104,6 +123,13 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+             bl = true;
+         }
+ 
++        // Purpur start
++        if (that.key != this.key) {
++            this.key = that.key;
++            bl = true;
++        }
++        // Purpur end
++
+         return bl;
+     }
+ 
+@@ -131,6 +157,17 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+         return this.showIcon;
+     }
+ 
++    // Purpur start
++    public boolean hasKey() {
++        return this.key != null;
++    }
++
++    @Nullable
++    public NamespacedKey getKey() {
++        return this.key;
++    }
++    // Purpur end
++
+     public boolean tick(LivingEntity entity, Runnable overwriteCallback) {
+         if (this.duration > 0) {
+             if (this.effect.isDurationEffectTick(this.duration, this.amplifier)) {
+@@ -184,6 +221,12 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+             string = string + ", Show Icon: false";
+         }
+ 
++        // Purpur start
++        if (this.hasKey()) {
++            string = string + ", Key: " + this.key;
++        }
++        // Purpur end
++
+         return string;
+     }
+ 
+@@ -195,7 +238,7 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+             return false;
+         } else {
+             MobEffectInstance mobEffectInstance = (MobEffectInstance)object;
+-            return this.duration == mobEffectInstance.duration && this.amplifier == mobEffectInstance.amplifier && this.ambient == mobEffectInstance.ambient && this.effect.equals(mobEffectInstance.effect);
++            return this.duration == mobEffectInstance.duration && this.amplifier == mobEffectInstance.amplifier && this.ambient == mobEffectInstance.ambient && this.effect.equals(mobEffectInstance.effect) && this.key == mobEffectInstance.key; // Purpur - add key
+         }
+     }
+ 
+@@ -219,6 +262,11 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+         nbt.putBoolean("Ambient", this.isAmbient());
+         nbt.putBoolean("ShowParticles", this.isVisible());
+         nbt.putBoolean("ShowIcon", this.showIcon());
++        // Purpur start
++        if (this.key != null) {
++            nbt.putString("Key", this.key.toString());
++        }
++        // Purpur end
+         if (this.hiddenEffect != null) {
+             CompoundTag compoundTag = new CompoundTag();
+             this.hiddenEffect.save(compoundTag);
+@@ -248,12 +296,19 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+             bl3 = nbt.getBoolean("ShowIcon");
+         }
+ 
++        // Purpur start
++        NamespacedKey key = null;
++        if (nbt.contains("Key")) {
++            key = NamespacedKey.fromString(nbt.getString("Key"));
++        }
++        // Purpur end
++
+         MobEffectInstance mobEffectInstance = null;
+         if (nbt.contains("HiddenEffect", 10)) {
+             mobEffectInstance = loadSpecifiedEffect(type, nbt.getCompound("HiddenEffect"));
+         }
+ 
+-        return new MobEffectInstance(type, j, i < 0 ? 0 : i, bl, bl2, bl3, mobEffectInstance);
++        return new MobEffectInstance(type, j, i < 0 ? 0 : i, bl, bl2, bl3, key, mobEffectInstance); // Purpur - add key
+     }
+ 
+     public void setNoCounter(boolean permanent) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index a59d71769db5452f9e16c514928dce20d1b99408..ea36470890c6fb6a52b7c7c93b6320d6d45c5c84 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -436,7 +436,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+ 
+     @Override
+     public boolean addPotionEffect(PotionEffect effect, boolean force) {
+-        this.getHandle().addEffect(new MobEffectInstance(MobEffect.byId(effect.getType().getId()), effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles(), effect.hasIcon()), EntityPotionEffectEvent.Cause.PLUGIN); // Paper - Don't ignore icon
++        this.getHandle().addEffect(new MobEffectInstance(MobEffect.byId(effect.getType().getId()), effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles(), effect.hasIcon(), effect.getKey()), EntityPotionEffectEvent.Cause.PLUGIN); // Purpur - add key // Paper - Don't ignore icon
+         return true;
+     }
+ 
+@@ -457,7 +457,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     @Override
+     public PotionEffect getPotionEffect(PotionEffectType type) {
+         MobEffectInstance handle = this.getHandle().getEffect(MobEffect.byId(type.getId()));
+-        return (handle == null) ? null : new PotionEffect(PotionEffectType.getById(MobEffect.getId(handle.getEffect())), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible());
++        return (handle == null) ? null : new PotionEffect(PotionEffectType.getById(MobEffect.getId(handle.getEffect())), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible(), handle.getKey()); // Purpur - add key
+     }
+ 
+     @Override
+@@ -469,7 +469,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public Collection<PotionEffect> getActivePotionEffects() {
+         List<PotionEffect> effects = new ArrayList<PotionEffect>();
+         for (MobEffectInstance handle : this.getHandle().activeEffects.values()) {
+-            effects.add(new PotionEffect(PotionEffectType.getById(MobEffect.getId(handle.getEffect())), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible()));
++            effects.add(new PotionEffect(PotionEffectType.getById(MobEffect.getId(handle.getEffect())), handle.getDuration(), handle.getAmplifier(), handle.isAmbient(), handle.isVisible(), handle.getKey())); // Purpur - add key
+         }
+         return effects;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
+index 4d325f61e9171b9e1a069ae69a87ec397735da79..1ce9e54879bea2331e050a04b003efe59d7c72cd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaPotion.java
+@@ -11,6 +11,7 @@ import net.minecraft.nbt.ListTag;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Color;
+ import org.bukkit.Material;
++import org.bukkit.NamespacedKey;
+ import org.bukkit.configuration.serialization.DelegateDeserialization;
+ import org.bukkit.craftbukkit.inventory.CraftMetaItem.ItemMetaKey;
+ import org.bukkit.craftbukkit.inventory.CraftMetaItem.SerializableMeta;
+@@ -33,6 +34,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+     static final ItemMetaKey POTION_COLOR = new ItemMetaKey("CustomPotionColor", "custom-color");
+     static final ItemMetaKey ID = new ItemMetaKey("Id", "potion-id");
+     static final ItemMetaKey DEFAULT_POTION = new ItemMetaKey("Potion", "potion-type");
++    static final ItemMetaKey KEY = new ItemMetaKey("Key", "namespacedkey"); // Purpur - add key
+ 
+     // Having an initial "state" in ItemMeta seems bit dirty but the UNCRAFTABLE potion type
+     // is treated as the empty form of the meta because it represents an empty potion with no effect
+@@ -83,7 +85,13 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+                 boolean ambient = effect.getBoolean(AMBIENT.NBT);
+                 boolean particles = tag.contains(SHOW_PARTICLES.NBT, CraftMagicNumbers.NBT.TAG_BYTE) ? effect.getBoolean(SHOW_PARTICLES.NBT) : true;
+                 boolean icon = tag.contains(SHOW_ICON.NBT, CraftMagicNumbers.NBT.TAG_BYTE) ? effect.getBoolean(SHOW_ICON.NBT) : particles;
+-                this.customEffects.add(new PotionEffect(type, duration, amp, ambient, particles, icon));
++                // Purpur start
++                NamespacedKey key = null;
++                if (tag.contains(KEY.NBT)) {
++                    key = NamespacedKey.fromString(effect.getString(KEY.NBT));
++                }
++                // Purpur end
++                this.customEffects.add(new PotionEffect(type, duration, amp, ambient, particles, icon, key)); // Purpur - add key
+             }
+         }
+     }
+@@ -132,6 +140,11 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+                 effectData.putBoolean(AMBIENT.NBT, effect.isAmbient());
+                 effectData.putBoolean(SHOW_PARTICLES.NBT, effect.hasParticles());
+                 effectData.putBoolean(SHOW_ICON.NBT, effect.hasIcon());
++                // Purpur start
++                if (effect.hasKey()) {
++                    effectData.putString(KEY.NBT, effect.getKey().toString());
++                }
++                // Purpur end
+                 effectList.add(effectData);
+             }
+         }
+@@ -201,7 +214,7 @@ class CraftMetaPotion extends CraftMetaItem implements PotionMeta {
+         if (index != -1) {
+             if (overwrite) {
+                 PotionEffect old = this.customEffects.get(index);
+-                if (old.getAmplifier() == effect.getAmplifier() && old.getDuration() == effect.getDuration() && old.isAmbient() == effect.isAmbient()) {
++                if (old.getAmplifier() == effect.getAmplifier() && old.getDuration() == effect.getDuration() && old.isAmbient() == effect.isAmbient() && old.getKey() == effect.getKey()) { // Purpur - add key
+                     return false;
+                 }
+                 this.customEffects.set(index, effect);
+diff --git a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
+index acb69821a99aa69bce6d127e10976089c85be223..c5abd73981c5f4b41605eba0d44e6573dfd2a77a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
++++ b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionUtil.java
+@@ -101,7 +101,7 @@ public class CraftPotionUtil {
+ 
+     public static MobEffectInstance fromBukkit(PotionEffect effect) {
+         MobEffect type = MobEffect.byId(effect.getType().getId());
+-        return new MobEffectInstance(type, effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles());
++        return new MobEffectInstance(type, effect.getDuration(), effect.getAmplifier(), effect.isAmbient(), effect.hasParticles(), effect.getKey()); // Purpur - add key
+     }
+ 
+     public static PotionEffect toBukkit(MobEffectInstance effect) {
+@@ -110,7 +110,7 @@ public class CraftPotionUtil {
+         int duration = effect.getDuration();
+         boolean ambient = effect.isAmbient();
+         boolean particles = effect.isVisible();
+-        return new PotionEffect(type, duration, amp, ambient, particles);
++        return new PotionEffect(type, duration, amp, ambient, particles, effect.getKey()); // Purpur - add key
+     }
+ 
+     public static boolean equals(MobEffect mobEffect, PotionEffectType type) {

--- a/patches/server/0257-Potion-NamespacedKey.patch
+++ b/patches/server/0257-Potion-NamespacedKey.patch
@@ -258,3 +258,43 @@ index acb69821a99aa69bce6d127e10976089c85be223..c5abd73981c5f4b41605eba0d44e6573
      }
  
      public static boolean equals(MobEffect mobEffect, PotionEffectType type) {
+diff --git a/src/test/java/org/bukkit/potion/PotionTest.java b/src/test/java/org/bukkit/potion/PotionTest.java
+index 7ea3cc4f8e35b61b3eba717ed58ee98cf835168c..46ca2b52d774d75b7e4bac1d8bba86a42446bdc9 100644
+--- a/src/test/java/org/bukkit/potion/PotionTest.java
++++ b/src/test/java/org/bukkit/potion/PotionTest.java
+@@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.world.effect.MobEffect;
+ import net.minecraft.world.effect.MobEffectInstance;
+ import net.minecraft.world.item.alchemy.Potion;
++import org.bukkit.NamespacedKey;
+ import org.bukkit.support.AbstractTestingBase;
+ import org.junit.Test;
+ 
+@@ -32,6 +33,27 @@ public class PotionTest extends AbstractTestingBase {
+         assertEquals(effects.entrySet().size(), PotionType.values().length - /* PotionTypes with no/shared Effects */ 6);
+     }
+ 
++    @Test
++    public void testNamespacedKey() {
++        NamespacedKey key = new NamespacedKey("testnamespace", "testkey");
++        PotionEffect namedSpacedEffect = new PotionEffect(PotionEffectType.DOLPHINS_GRACE, 20, 0, true, true, true, key);
++        assertNotNull(namedSpacedEffect.getKey());
++        assertTrue(namedSpacedEffect.hasKey());
++        assertFalse(namedSpacedEffect.withKey(null).hasKey());
++
++        PotionEffect effect = new PotionEffect(PotionEffectType.DOLPHINS_GRACE, 20, 0, true, true, true);
++        assertNull(effect.getKey());
++        assertFalse(effect.hasKey());
++        assertTrue(namedSpacedEffect.withKey(key).hasKey());
++
++        Map<String, Object> s1 = namedSpacedEffect.serialize();
++        Map<String, Object> s2 = effect.serialize();
++        assertTrue(s1.containsKey("namespacedKey"));
++        assertFalse(s2.containsKey("namespacedKey"));
++        assertNotNull(new PotionEffect(s1).getKey());
++        assertNull(new PotionEffect(s2).getKey());
++    }
++
+     @Test
+     public void testEffectType() {
+         for (MobEffect nms : Registry.MOB_EFFECT) {

--- a/patches/server/0257-Potion-NamespacedKey.patch
+++ b/patches/server/0257-Potion-NamespacedKey.patch
@@ -259,7 +259,7 @@ index acb69821a99aa69bce6d127e10976089c85be223..c5abd73981c5f4b41605eba0d44e6573
  
      public static boolean equals(MobEffect mobEffect, PotionEffectType type) {
 diff --git a/src/test/java/org/bukkit/potion/PotionTest.java b/src/test/java/org/bukkit/potion/PotionTest.java
-index 7ea3cc4f8e35b61b3eba717ed58ee98cf835168c..46ca2b52d774d75b7e4bac1d8bba86a42446bdc9 100644
+index 7ea3cc4f8e35b61b3eba717ed58ee98cf835168c..20c1609067f02a00e67ac0851feef089ca778804 100644
 --- a/src/test/java/org/bukkit/potion/PotionTest.java
 +++ b/src/test/java/org/bukkit/potion/PotionTest.java
 @@ -9,6 +9,7 @@ import net.minecraft.resources.ResourceLocation;
@@ -270,10 +270,11 @@ index 7ea3cc4f8e35b61b3eba717ed58ee98cf835168c..46ca2b52d774d75b7e4bac1d8bba86a4
  import org.bukkit.support.AbstractTestingBase;
  import org.junit.Test;
  
-@@ -32,6 +33,27 @@ public class PotionTest extends AbstractTestingBase {
+@@ -32,6 +33,29 @@ public class PotionTest extends AbstractTestingBase {
          assertEquals(effects.entrySet().size(), PotionType.values().length - /* PotionTypes with no/shared Effects */ 6);
      }
  
++    // Purpur start
 +    @Test
 +    public void testNamespacedKey() {
 +        NamespacedKey key = new NamespacedKey("testnamespace", "testkey");
@@ -294,6 +295,7 @@ index 7ea3cc4f8e35b61b3eba717ed58ee98cf835168c..46ca2b52d774d75b7e4bac1d8bba86a4
 +        assertNotNull(new PotionEffect(s1).getKey());
 +        assertNull(new PotionEffect(s2).getKey());
 +    }
++    // Purpur end
 +
      @Test
      public void testEffectType() {


### PR DESCRIPTION
Continued from https://github.com/pl3xgaming/Purpur/pull/710
Sorry for closing and reopening a new pr again, i was having issue with my previous fork and I'm not too experienced with pr and fork stuff so i deleted it and forked again to make the changes needed.

I've had these changes in use on a production server for about a month or so with no more issues so it should be all good with plugins and what not.

- I've fixed an issue that caused  serialized potion effects to cause null issues etc
- Now custom potion effects on CraftMetaPotion have the namespacedKeys too
- No longer serialize null namespaces for potions
- Added some annotations
- Probably other misc stuff too