### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.18.1-R0.1-SNAPSHOT
 mcVersion = 1.18.1
 packageVersion = 1_18_R1
 
-paperCommit = 91f3edaac4de5261383ea8b32b29fd8d3b6028f9
+paperCommit = 51d168752bc22bc37ade1d4577355cad6146ba56
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/patches/server/0003-Purpur-config-files.patch
+++ b/patches/server/0003-Purpur-config-files.patch
@@ -106,7 +106,7 @@ index 4247dcb003626535dbb997f48ad9f61380bd17e9..03a4c5fa746033825c26a031fbf79f72
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 310c3e1590465412af6905eab33193c6bf5e5e47..549577e31840ce5f32adb2c0909b915da4362207 100644
+index 2c31a0c1e76c92aa3ca8aa97a30d79675dea7e85..5566c149b6c44a13ea65ab8ccb61055afbb2e277 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -931,6 +931,7 @@ public final class CraftServer implements Server {
@@ -133,7 +133,7 @@ index 310c3e1590465412af6905eab33193c6bf5e5e47..549577e31840ce5f32adb2c0909b915d
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2648,6 +2651,18 @@ public final class CraftServer implements Server {
+@@ -2641,6 +2644,18 @@ public final class CraftServer implements Server {
              return com.destroystokyo.paper.PaperConfig.config;
          }
  

--- a/patches/server/0012-Bring-back-server-name.patch
+++ b/patches/server/0012-Bring-back-server-name.patch
@@ -17,10 +17,10 @@ index f944e6beafc7876ed9c6923a22f58d82967b77cb..e1c7b7a659e56fa5b3a1f52cb2ccc99b
      public final boolean spawnNpcs = this.get("spawn-npcs", true);
      public final boolean pvp = this.get("pvp", true);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 549577e31840ce5f32adb2c0909b915da4362207..196f586380bd458c3f2c47a84dc7e2a36afb94aa 100644
+index 5566c149b6c44a13ea65ab8ccb61055afbb2e277..da5651f61be49bcceb9b912f155b24c511a9a5ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2817,4 +2817,11 @@ public final class CraftServer implements Server {
+@@ -2810,4 +2810,11 @@ public final class CraftServer implements Server {
      }
  
      // Paper end

--- a/patches/server/0015-Lagging-threshold.patch
+++ b/patches/server/0015-Lagging-threshold.patch
@@ -25,10 +25,10 @@ index 1cb6c989a0b21df7dff72062550daa09721d7687..4d89c9de4b4aae4452750fb941a2e610
                      }
                      // Spigot end
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 196f586380bd458c3f2c47a84dc7e2a36afb94aa..98f14ba75b0fed27effc5259eaf62c3fa372df26 100644
+index da5651f61be49bcceb9b912f155b24c511a9a5ca..cc0e2adaa6f857ad646b1a853faf7a979af9de7b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2823,5 +2823,10 @@ public final class CraftServer implements Server {
+@@ -2816,5 +2816,10 @@ public final class CraftServer implements Server {
      public String getServerName() {
          return this.getProperties().serverName;
      }

--- a/patches/server/0066-Add-5-second-tps-average-in-tps.patch
+++ b/patches/server/0066-Add-5-second-tps-average-in-tps.patch
@@ -69,10 +69,10 @@ index 55067e47a9907f038bf77f5dda2f395773472ceb..70dfa4d3b7a2c9b2a47000bf26100f17
                          lagging = recentTps[0] < org.purpurmc.purpur.PurpurConfig.laggingThreshold; // Purpur
                          tickSection = curTime;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 98f14ba75b0fed27effc5259eaf62c3fa372df26..d397daf9a6b2128735a0732565a41be9197742a4 100644
+index cc0e2adaa6f857ad646b1a853faf7a979af9de7b..0f3c8b754d8c349125c1debb060c3e17364aba9b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2605,6 +2605,7 @@ public final class CraftServer implements Server {
+@@ -2598,6 +2598,7 @@ public final class CraftServer implements Server {
      @Override
      public double[] getTPS() {
          return new double[] {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@c1bd3cc Updated Upstream (CraftBukkit) (#7105)
PaperMC/Paper@df1301b Make org.bukkit.Keyed extend Adventure's Keyed (#7090)
PaperMC/Paper@d8747c1 [ci skip] Add nullable annotation to field (#7042)
PaperMC/Paper@7f31095 Add more Campfire API (#5779)
PaperMC/Paper@51d1687 Update log4j to 2.16.0