### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.18.1-R0.1-SNAPSHOT
 mcVersion = 1.18.1
 packageVersion = 1_18_R1
 
-paperCommit = 95d881f91681b2ff3a659578f42dd890f2b6ceec
+paperCommit = 5ad1d9a01da7d9faa6fd170c617d77927cbeeedc
 
 org.gradle.caching = true
 org.gradle.parallel = true


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@5ad1d9a Fix empty voxel shape usage (Fixes #7043)