### PR TITLE
Update MiniMessage

### DIFF
--- a/patches/api/0001-Build-System-Changes.patch
+++ b/patches/api/0001-Build-System-Changes.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Build System Changes
 todo: merge with rebrand patch
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 241ee5c98275a4517e040c86355ae6702f8efca1..43ce7fe6b65488d00c69986908c788761ccd74ad 100644
+index 241ee5c98275a4517e040c86355ae6702f8efca1..4f0591d8f778ff403f475b3ac51f31fb399187dc 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -40,6 +40,7 @@ dependencies {
      apiAndDocs("net.kyori:adventure-text-serializer-plain")
      api("org.apache.logging.log4j:log4j-api:2.14.1")
      api("org.slf4j:slf4j-api:1.8.0-beta4")
-+    api("net.kyori:adventure-text-minimessage:4.1.0-SNAPSHOT") // Purpur
++    api("net.kyori:adventure-text-minimessage:4.10.0-SNAPSHOT") // Purpur
  
      implementation("org.ow2.asm:asm:9.2")
      implementation("org.ow2.asm:asm-commons:9.2")

--- a/patches/server/0003-Purpur-config-files.patch
+++ b/patches/server/0003-Purpur-config-files.patch
@@ -30,7 +30,7 @@ index 218f5bafeed8551b55b91c7fccaf6935c8b631ca..7bc497bcae6a6a752e3c432178cb1e3c
                  metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {
                      Map<String, Map<String, Integer>> map = new HashMap<>();
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index cb0045fc4ddd738c45dee89d57b213a633b9a136..6e8111ef16439d2b3025ebe2a0418b245420bd88 100644
+index cb0045fc4ddd738c45dee89d57b213a633b9a136..5e91119e72666496ddff26fee425c202728e3c6c 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -236,6 +236,30 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
@@ -46,7 +46,7 @@ index cb0045fc4ddd738c45dee89d57b213a633b9a136..6e8111ef16439d2b3025ebe2a0418b24
 +        if (message == null) {
 +            return;
 +        }
-+        sendSuccess(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(message), broadcastToOps);
++        sendSuccess(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().parse(message), broadcastToOps);
 +    }
 +
 +    public void sendSuccess(@Nullable net.kyori.adventure.text.Component message) {

--- a/patches/server/0005-Component-related-conveniences.patch
+++ b/patches/server/0005-Component-related-conveniences.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Component related conveniences
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 08cb39a9af8adbd048a91a7cfa76863c7b1a13af..3e91bb85adc33434b278bf2ca83164dae3f7a6e5 100644
+index 4b842e78d3e8fbca90f5f3d975bee654ec87d91d..c84108ef376ce7bd0c53c1892855c9b9d29054a7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1693,6 +1693,26 @@ public class ServerPlayer extends Player {
@@ -15,7 +15,7 @@ index 08cb39a9af8adbd048a91a7cfa76863c7b1a13af..3e91bb85adc33434b278bf2ca83164da
 +    // Purpur start
 +    public void sendActionBarMessage(@Nullable String message) {
 +        if (message != null) {
-+            sendActionBarMessage(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(message));
++            sendActionBarMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().parse(message));
 +        }
 +    }
 +
@@ -36,7 +36,7 @@ index 08cb39a9af8adbd048a91a7cfa76863c7b1a13af..3e91bb85adc33434b278bf2ca83164da
      public void displayClientMessage(Component message, boolean actionBar) {
          this.sendMessage(message, actionBar ? ChatType.GAME_INFO : ChatType.CHAT, Util.NIL_UUID);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 042be2cf60a9d01698808d84f2e537a5eb952079..6ec5a8a52ec06be917f2ca682f5920ed5ae1a82c 100644
+index 042be2cf60a9d01698808d84f2e537a5eb952079..a6bca7a0eecbc92a267c3fa0a2454b8a250dca4e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1373,6 +1373,62 @@ public abstract class PlayerList {
@@ -58,7 +58,7 @@ index 042be2cf60a9d01698808d84f2e537a5eb952079..6ec5a8a52ec06be917f2ca682f5920ed
 +
 +    public void broadcast(@Nullable String message, ChatType type, UUID sender) {
 +        if (message != null) {
-+            broadcast(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(message), type, sender);
++            broadcast(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().parse(message), type, sender);
 +        }
 +    }
 +
@@ -103,7 +103,7 @@ index 042be2cf60a9d01698808d84f2e537a5eb952079..6ec5a8a52ec06be917f2ca682f5920ed
          this.server.sendMessage(message, sender);
          Iterator iterator = this.players.iterator();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1dd646bb8d1c153a3d034de1c208b3bacebd067f..390f8398af00b770d48d274970b8b164925b63b5 100644
+index 9bb44918af119d9afae4a0a050c6a5381f028364..dfd353cb627234d9ba7de44346650ea19ce035f2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3601,6 +3601,34 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -117,7 +117,7 @@ index 1dd646bb8d1c153a3d034de1c208b3bacebd067f..390f8398af00b770d48d274970b8b164
 +
 +    public void sendMessage(@Nullable String message, UUID sender) {
 +        if (org.apache.commons.lang3.StringUtils.isNotEmpty(message)) {
-+            sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(message), sender);
++            sendMessage(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().parse(message), sender);
 +        }
 +    }
 +

--- a/patches/server/0011-AFK-API.patch
+++ b/patches/server/0011-AFK-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] AFK API
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 618595add09eef5381307ba2fe154adfc97b2a0e..100d01814aca6cbb26c721f55851df27dc654880 100644
+index 51027b0f79f0b1c103f594cd72efea6fb67f9d44..fe32cea2af458a65a540945c42451e7486305254 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1969,8 +1969,58 @@ public class ServerPlayer extends Player {
@@ -213,7 +213,7 @@ index 6df710cecea9a5c91ccf8bdaec60bdc88a601777..6b0cee0bd6218492b184f94a84da9acf
                  if (range < 0.0D || d < range * range) {
                      return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f32a4aaa0f027b71043109c78c8a5e18e0397350..db49d331e76a0c86515cb06caba8d6e1853c77f4 100644
+index f32a4aaa0f027b71043109c78c8a5e18e0397350..f23b8644c3e36b637efc9e08e207dea3ad588648 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -429,10 +429,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -229,7 +229,7 @@ index f32a4aaa0f027b71043109c78c8a5e18e0397350..db49d331e76a0c86515cb06caba8d6e1
              name = getName();
          }
 -        this.getHandle().listName = name.equals(getName()) ? null : CraftChatMessage.fromStringOrNull(name);
-+        this.getHandle().listName = name.equals(getName()) ? null : useMM ? io.papermc.paper.adventure.PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(name)) : CraftChatMessage.fromStringOrNull(name); // Purpur
++        this.getHandle().listName = name.equals(getName()) ? null : useMM ? io.papermc.paper.adventure.PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().parse(name)) : CraftChatMessage.fromStringOrNull(name); // Purpur
          for (ServerPlayer player : (List<ServerPlayer>) server.getHandle().players) {
              if (player.getBukkitEntity().canSee(this)) {
                  player.connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.UPDATE_DISPLAY_NAME, this.getHandle()));

--- a/patches/server/0022-Silk-touch-spawners.patch
+++ b/patches/server/0022-Silk-touch-spawners.patch
@@ -30,15 +30,17 @@ index 20444c6887cbdd444b23bf018a6d63f22359e5e7..85329295afacad3edb6865846166aa56
      public static final Item CHEST = registerBlock(Blocks.CHEST, CreativeModeTab.TAB_DECORATIONS);
      public static final Item CRAFTING_TABLE = registerBlock(Blocks.CRAFTING_TABLE, CreativeModeTab.TAB_DECORATIONS);
 diff --git a/src/main/java/net/minecraft/world/level/block/SpawnerBlock.java b/src/main/java/net/minecraft/world/level/block/SpawnerBlock.java
-index 130ffb06b12565efb35afb55b6da20b1b16f6f06..bc4646a7a72c33a3671115953a2bbd7cfe5d7d92 100644
+index 130ffb06b12565efb35afb55b6da20b1b16f6f06..e0ff998eb12b03463a49104e86e2dfda43270f3d 100644
 --- a/src/main/java/net/minecraft/world/level/block/SpawnerBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/SpawnerBlock.java
-@@ -1,9 +1,19 @@
+@@ -1,9 +1,21 @@
  package net.minecraft.world.level.block;
  
  import javax.annotation.Nullable;
 +
 +import net.kyori.adventure.text.minimessage.MiniMessage;
++import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
++import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
  import net.minecraft.core.BlockPos;
 +import net.minecraft.nbt.CompoundTag;
 +import net.minecraft.nbt.ListTag;
@@ -53,7 +55,7 @@ index 130ffb06b12565efb35afb55b6da20b1b16f6f06..bc4646a7a72c33a3671115953a2bbd7c
  import net.minecraft.world.level.BlockGetter;
  import net.minecraft.world.level.Level;
  import net.minecraft.world.level.block.entity.BlockEntity;
-@@ -13,6 +23,20 @@ import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
+@@ -13,6 +25,20 @@ import net.minecraft.world.level.block.entity.SpawnerBlockEntity;
  import net.minecraft.world.level.block.state.BlockBehaviour;
  import net.minecraft.world.level.block.state.BlockState;
  
@@ -74,7 +76,7 @@ index 130ffb06b12565efb35afb55b6da20b1b16f6f06..bc4646a7a72c33a3671115953a2bbd7c
  public class SpawnerBlock extends BaseEntityBlock {
  
      protected SpawnerBlock(BlockBehaviour.Properties settings) {
-@@ -30,6 +54,55 @@ public class SpawnerBlock extends BaseEntityBlock {
+@@ -30,6 +56,55 @@ public class SpawnerBlock extends BaseEntityBlock {
          return createTickerHelper(type, BlockEntityType.MOB_SPAWNER, world.isClientSide ? SpawnerBlockEntity::clientTick : SpawnerBlockEntity::serverTick);
      }
  
@@ -90,7 +92,7 @@ index 130ffb06b12565efb35afb55b6da20b1b16f6f06..bc4646a7a72c33a3671115953a2bbd7c
 +
 +                String name = level.purpurConfig.silkTouchSpawnerName;
 +                if (name != null && !name.isEmpty() && !name.equals("Spawner")) {
-+                    Component displayName = MiniMessage.get().parse(name, "mob", mobName);
++                    Component displayName = MiniMessage.miniMessage().deserialize(name, PlaceholderResolver.placeholders(Placeholder.component("mob", mobName)));
 +                    if (name.startsWith("<reset>")) {
 +                        displayName = displayName.decoration(ITALIC, false);
 +                    }
@@ -102,7 +104,7 @@ index 130ffb06b12565efb35afb55b6da20b1b16f6f06..bc4646a7a72c33a3671115953a2bbd7c
 +                if (lore != null && !lore.isEmpty()) {
 +                    ListTag list = new ListTag();
 +                    for (String line : lore) {
-+                        Component lineComponent = MiniMessage.get().parse(line, "mob", mobName);
++                        Component lineComponent = MiniMessage.miniMessage().deserialize(line, PlaceholderResolver.placeholders(Placeholder.component("mob", mobName)));
 +                        if (line.startsWith("<reset>")) {
 +                            lineComponent = lineComponent.decoration(ITALIC, false);
 +                        }
@@ -130,7 +132,7 @@ index 130ffb06b12565efb35afb55b6da20b1b16f6f06..bc4646a7a72c33a3671115953a2bbd7c
      @Override
      public void spawnAfterBreak(BlockState state, ServerLevel world, BlockPos pos, ItemStack stack) {
          super.spawnAfterBreak(state, world, pos, stack);
-@@ -38,6 +111,7 @@ public class SpawnerBlock extends BaseEntityBlock {
+@@ -38,6 +113,7 @@ public class SpawnerBlock extends BaseEntityBlock {
  
      @Override
      public int getExpDrop(BlockState iblockdata, ServerLevel worldserver, BlockPos blockposition, ItemStack itemstack) {
@@ -139,7 +141,7 @@ index 130ffb06b12565efb35afb55b6da20b1b16f6f06..bc4646a7a72c33a3671115953a2bbd7c
  
          // this.popExperience(worldserver, blockposition, i);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 65d6e1b08862d4760d4fdf5838e60f8b9c755de9..d4602c11c149836974bb3722a00547f3908b0529 100644
+index f32045fa03634879dd88711c1f657a7635ce3011..4019c768748b65a0d039d3ef0a86a01b098e91c0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -116,6 +116,38 @@ public class PurpurWorldConfig {

--- a/patches/server/0127-Implement-TPSBar.patch
+++ b/patches/server/0127-Implement-TPSBar.patch
@@ -42,7 +42,7 @@ index 8bf98d8f8e9f0baaf203a9e8d18683236856eab7..455776981274e64724376a3182b60784
          }
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index dfe547b7a2caa2ecfdddef9b9a49be40d26c5da8..951e45f7b17f6f903c99634177395464a1889c0f 100644
+index 34c3751e1d2a103f6b0ef74fddf9cb6e90541363..175f8e6e989d277245193032e3634cbc2a652691 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -256,6 +256,7 @@ public class ServerPlayer extends Player {
@@ -84,7 +84,7 @@ index dfe547b7a2caa2ecfdddef9b9a49be40d26c5da8..951e45f7b17f6f903c99634177395464
      // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 5c11e91e1eebb0e24aaca9af323a9d5ecdc0a411..63e8397d6eff95ed81ab5d7cdb69495e188d931b 100644
+index 4ceea6e2f57aa2be274dac9a0bc86e7875ec5c21..ad5c94004868f6586e69bf672362312daac91025 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -482,6 +482,7 @@ public abstract class PlayerList {
@@ -282,16 +282,17 @@ index 0000000000000000000000000000000000000000..d38b3c4a722396cc3b61a9a8ed7e39ce
 +}
 diff --git a/src/main/java/org/purpurmc/purpur/task/TPSBarTask.java b/src/main/java/org/purpurmc/purpur/task/TPSBarTask.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6c4d5167a9d965edbb25f4c24e6bb885afe281ca
+index 0000000000000000000000000000000000000000..f9e3ae54bf6a7302ae21abcec19c3fb6e8a9fe0d
 --- /dev/null
 +++ b/src/main/java/org/purpurmc/purpur/task/TPSBarTask.java
-@@ -0,0 +1,142 @@
+@@ -0,0 +1,146 @@
 +package org.purpurmc.purpur.task;
 +
 +import net.kyori.adventure.bossbar.BossBar;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.minimessage.MiniMessage;
-+import net.kyori.adventure.text.minimessage.Template;
++import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
++import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
 +import org.purpurmc.purpur.PurpurConfig;
 +import org.bukkit.Bukkit;
 +import org.bukkit.entity.Player;
@@ -318,11 +319,14 @@ index 0000000000000000000000000000000000000000..6c4d5167a9d965edbb25f4c24e6bb885
 +    void updateBossBar(BossBar bossbar, Player player) {
 +        bossbar.progress(getBossBarProgress());
 +        bossbar.color(getBossBarColor());
-+        bossbar.name(MiniMessage.get().parse(PurpurConfig.commandTPSBarTitle,
-+                Template.of("tps", getTPSColor()),
-+                Template.of("mspt", getMSPTColor()),
-+                Template.of("ping", getPingColor(player.getPing()))
-+        ));
++        bossbar.name(MiniMessage.miniMessage().deserialize(
++                PurpurConfig.commandTPSBarTitle,
++                PlaceholderResolver.placeholders(
++                        Placeholder.component("tps", getTPSColor()),
++                        Placeholder.component("mspt", getMSPTColor()),
++                        Placeholder.component("ping", getPingColor(player.getPing()))
++                ))
++        );
 +    }
 +
 +    @Override
@@ -397,7 +401,7 @@ index 0000000000000000000000000000000000000000..6c4d5167a9d965edbb25f4c24e6bb885
 +        } else {
 +            color = PurpurConfig.commandTPSBarTextColorLow;
 +        }
-+        return MiniMessage.get().parse(color, Template.of("text", String.format("%.2f", tps)));
++        return MiniMessage.miniMessage().deserialize(color, PlaceholderResolver.placeholders(Placeholder.component("text", Component.text(String.format("%.2f", tps)))));
 +    }
 +
 +    private Component getMSPTColor() {
@@ -409,7 +413,7 @@ index 0000000000000000000000000000000000000000..6c4d5167a9d965edbb25f4c24e6bb885
 +        } else {
 +            color = PurpurConfig.commandTPSBarTextColorLow;
 +        }
-+        return MiniMessage.get().parse(color, Template.of("text", String.format("%.2f", mspt)));
++        return MiniMessage.miniMessage().deserialize(color, PlaceholderResolver.placeholders(Placeholder.component("text", Component.text(String.format("%.2f", mspt)))));
 +    }
 +
 +    private Component getPingColor(int ping) {
@@ -421,7 +425,7 @@ index 0000000000000000000000000000000000000000..6c4d5167a9d965edbb25f4c24e6bb885
 +        } else {
 +            color = PurpurConfig.commandTPSBarTextColorLow;
 +        }
-+        return MiniMessage.get().parse(color, Template.of("text", String.format("%s", ping)));
++        return MiniMessage.miniMessage().deserialize(color, PlaceholderResolver.placeholders(Placeholder.component("text", Component.text(String.format("%s", ping)))));
 +    }
 +
 +    public enum FillMode {

--- a/patches/server/0184-Config-for-unverified-username-message.patch
+++ b/patches/server/0184-Config-for-unverified-username-message.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config for unverified username message
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..b86d5e736d786ac3c74fec3ad1285400f6f4e583 100644
+index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..1e875c1d0d627516a804da799e7db14476649eda 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -310,7 +310,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -13,12 +13,12 @@ index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..b86d5e736d786ac3c74fec3ad1285400
                          ServerLoginPacketListenerImpl.this.state = ServerLoginPacketListenerImpl.State.READY_TO_ACCEPT;
                      } else {
 -                        ServerLoginPacketListenerImpl.this.disconnect(new TranslatableComponent("multiplayer.disconnect.unverified_username"));
-+                        ServerLoginPacketListenerImpl.this.disconnect(org.purpurmc.purpur.PurpurConfig.unverifiedUsername.equals("default") ? new TranslatableComponent("multiplayer.disconnect.unverified_username") : PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(org.purpurmc.purpur.PurpurConfig.unverifiedUsername))); // Purpur
++                        ServerLoginPacketListenerImpl.this.disconnect(org.purpurmc.purpur.PurpurConfig.unverifiedUsername.equals("default") ? new TranslatableComponent("multiplayer.disconnect.unverified_username") : PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().parse(org.purpurmc.purpur.PurpurConfig.unverifiedUsername))); // Purpur
                          ServerLoginPacketListenerImpl.LOGGER.error("Username '{}' tried to join with an invalid session", gameprofile.getName());
                      }
                  } catch (AuthenticationUnavailableException authenticationunavailableexception) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 47a731efd6f28096439089d69a3502193ba3f000..552e3cbd352302fb0dbc4c2b80df465c13012b84 100644
+index 111efe9539cb8e70cb2302aa1c4045871509c324..a1a6f7ae168c3cd4cdc0a002c74c803024e41190 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -166,6 +166,7 @@ public class PurpurConfig {

--- a/patches/server/0204-Add-uptime-command.patch
+++ b/patches/server/0204-Add-uptime-command.patch
@@ -82,16 +82,17 @@ index 6be7293e6e368b2b05502b3e086cceb113a3cad4..64a8dad26d17a9f921d4fd57991dab95
      public static int barrelRows = 3;
 diff --git a/src/main/java/org/purpurmc/purpur/command/UptimeCommand.java b/src/main/java/org/purpurmc/purpur/command/UptimeCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..177a03c07c331a505d2b0ccfeb5509058e5449a1
+index 0000000000000000000000000000000000000000..51a63c3012f5d2cac219125feb7823e2763d628e
 --- /dev/null
 +++ b/src/main/java/org/purpurmc/purpur/command/UptimeCommand.java
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,56 @@
 +package org.purpurmc.purpur.command;
 +
 +import com.mojang.brigadier.CommandDispatcher;
 +import net.kyori.adventure.text.Component;
 +import net.kyori.adventure.text.minimessage.MiniMessage;
-+import net.kyori.adventure.text.minimessage.Template;
++import net.kyori.adventure.text.minimessage.placeholder.Placeholder;
++import net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver;
 +import net.minecraft.commands.CommandSourceStack;
 +import net.minecraft.commands.Commands;
 +import net.minecraft.server.MinecraftServer;
@@ -121,7 +122,7 @@ index 0000000000000000000000000000000000000000..177a03c07c331a505d2b0ccfeb550905
 +        data.hide = false; // never hide seconds
 +        process(data, "<seconds>", PurpurConfig.uptimeSecond, PurpurConfig.uptimeSeconds, TimeUnit.SECONDS, TimeUnit.MILLISECONDS::toSeconds);
 +
-+        Component output = MiniMessage.get().parse(PurpurConfig.uptimeCommandOutput, Template.of("uptime", data.format));
++        Component output = MiniMessage.miniMessage().deserialize(PurpurConfig.uptimeCommandOutput, PlaceholderResolver.placeholders(Placeholder.component("uptime", Component.text(data.format))));
 +        sender.sendSuccess(output, false);
 +        return 1;
 +    }

--- a/patches/server/0209-Customizable-sleeping-actionbar-messages.patch
+++ b/patches/server/0209-Customizable-sleeping-actionbar-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Customizable sleeping actionbar messages
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2eba2af9bb3fb0aaa9b2f5af6ae5fd207e1db93d..40466cdbd97228662a1eeb3bb08e8172bf344410 100644
+index 2eba2af9bb3fb0aaa9b2f5af6ae5fd207e1db93d..fe17e99a8dcca2948f08632681b6c8a3edba5398 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -945,11 +945,29 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -945,11 +945,33 @@ public class ServerLevel extends Level implements WorldGenLevel {
          if (this.canSleepThroughNights()) {
              if (!this.getServer().isSingleplayer() || this.getServer().isPublished()) {
                  int i = this.getGameRules().getInt(GameRules.RULE_PLAYERS_SLEEPING_PERCENTAGE);
@@ -21,7 +21,7 @@ index 2eba2af9bb3fb0aaa9b2f5af6ae5fd207e1db93d..40466cdbd97228662a1eeb3bb08e8172
 +                        return;
 +                    }
 +                    if (!org.purpurmc.purpur.PurpurConfig.sleepSkippingNight.equalsIgnoreCase("default")) {
-+                        chatmessage = io.papermc.paper.adventure.PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(org.purpurmc.purpur.PurpurConfig.sleepSkippingNight));
++                        chatmessage = io.papermc.paper.adventure.PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().parse(org.purpurmc.purpur.PurpurConfig.sleepSkippingNight));
 +                    } else
 +                    // Purpur end
                      chatmessage = new TranslatableComponent("sleep.skipping_night");
@@ -31,16 +31,20 @@ index 2eba2af9bb3fb0aaa9b2f5af6ae5fd207e1db93d..40466cdbd97228662a1eeb3bb08e8172
 +                        return;
 +                    }
 +                    if (!org.purpurmc.purpur.PurpurConfig.sleepingPlayersPercent.equalsIgnoreCase("default")) {
-+                        chatmessage = io.papermc.paper.adventure.PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.get().parse(org.purpurmc.purpur.PurpurConfig.sleepingPlayersPercent,
-+                                net.kyori.adventure.text.minimessage.Template.of("count", Integer.toString(this.sleepStatus.amountSleeping())),
-+                                net.kyori.adventure.text.minimessage.Template.of("total", Integer.toString(this.sleepStatus.sleepersNeeded(i)))));
++                        chatmessage = io.papermc.paper.adventure.PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(
++                                org.purpurmc.purpur.PurpurConfig.sleepingPlayersPercent,
++                                net.kyori.adventure.text.minimessage.placeholder.PlaceholderResolver.placeholders(
++                                        net.kyori.adventure.text.minimessage.placeholder.Placeholder.component("count", net.kyori.adventure.text.Component.text(this.sleepStatus.amountSleeping())),
++                                        net.kyori.adventure.text.minimessage.placeholder.Placeholder.component("total", net.kyori.adventure.text.Component.text(this.sleepStatus.sleepersNeeded(i)))
++                                )
++                        ));
 +                    } else
 +                    // Purpur end
                      chatmessage = new TranslatableComponent("sleep.players_sleeping", new Object[]{this.sleepStatus.amountSleeping(), this.sleepStatus.sleepersNeeded(i)});
                  }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 0ccb09e9c00f7434f4158001c983ab547c7b56e0..049bf902e8e77d7eac8dc868593c215bf04838a9 100644
+index ad8d92f04524fa6e7a7a4c390e8b744889dae968..e230f65d8599f1d6f8c567227859935a905426f8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -168,6 +168,8 @@ public class PurpurConfig {

--- a/patches/server/0231-Option-for-if-rain-and-thunder-should-stop-on-sleep.patch
+++ b/patches/server/0231-Option-for-if-rain-and-thunder-should-stop-on-sleep.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for if rain and thunder should stop on sleep
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 40466cdbd97228662a1eeb3bb08e8172bf344410..1eed6e330118954796d4d642bd78c896d95eb496 100644
+index fe17e99a8dcca2948f08632681b6c8a3edba5398..17c983925150bd5750418204e65a8a76420236fe 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1106,6 +1106,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1110,6 +1110,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      private void resetWeatherCycle() {
          // CraftBukkit start
@@ -16,7 +16,7 @@ index 40466cdbd97228662a1eeb3bb08e8172bf344410..1eed6e330118954796d4d642bd78c896
          this.serverLevelData.setRaining(false, org.bukkit.event.weather.WeatherChangeEvent.Cause.SLEEP); // Paper - when passing the night
          // If we stop due to everyone sleeping we should reset the weather duration to some other random value.
          // Not that everyone ever manages to get the whole server to sleep at the same time....
-@@ -1113,6 +1114,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1117,6 +1118,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              this.serverLevelData.setRainTime(0);
          }
          // CraftBukkit end


### PR DESCRIPTION
I am converting patches to Kyori API with MiniMessage and I notice MiniMessage added by Purpur is very very very old. It is version `4.1.0` while Kyori has version `4.10.0`. I do one patch in #791 but I do more now after update.