### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.18.1-R0.1-SNAPSHOT
 mcVersion = 1.18.1
 packageVersion = 1_18_R1
 
-paperCommit = 8c189d0faf0d76465dc39dd1774f5ad67a282229
+paperCommit = 8c5be166861b662d0b4aa775f0e38c8acb9a30f1
 
 org.gradle.caching = true
 org.gradle.parallel = true


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@8c5be16 Only write chunk data to disk if it serializes without throwing