### PR TITLE
Setup Paperweight Dev Bundle Publishing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,20 @@ paperweight {
     }
 }
 
+tasks.generateDevelopmentBundle {
+    apiCoordinates.set("org.purpurmc.purpur:purpur-api")
+    mojangApiCoordinates.set("io.papermc.paper:paper-mojangapi")
+    libraryRepositories.set(
+        listOf(
+            "https://repo.maven.apache.org/maven2/",
+            "https://libraries.minecraft.net/",
+            "https://papermc.io/repo/repository/maven-public/",
+            "https://maven.quiltmc.org/repository/release/",
+	    "https://repo.purpurmc.org/snapshots",
+        )
+    )
+}
+
 allprojects {
     publishing {
         repositories {
@@ -83,6 +97,14 @@ allprojects {
                 name = "purpur"
                 credentials(PasswordCredentials::class)
             }
+        }
+    }
+}
+
+publishing {
+    publications.create<MavenPublication>("devBundle") {
+        artifact(tasks.generateDevelopmentBundle) {
+            artifactId = "dev-bundle"
         }
     }
 }


### PR DESCRIPTION
Nothing is needed extra in CI to publish to repo. It is automatic with current setup if you set credentials. 

Here is how you use it, very simple! https://github.com/Oharass/paperweight-test-plugin/blob/master/build.gradle.kts#L20-L25

mavenLocal() is not needed 100% once published, I just use for my own testing.