### PR TITLE
Configurable minimum demand for trades

### DIFF
--- a/patches/server/0257-Configurable-minimum-demand-for-trades.patch
+++ b/patches/server/0257-Configurable-minimum-demand-for-trades.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Totorewa <76272501+totorewa@users.noreply.github.com>
+Date: Fri, 7 Jan 2022 21:34:57 +1300
+Subject: [PATCH] Configurable minimum demand for trades
+
+Addresses MC-163962 where villager demand decreases indefinitely. Paper
+adds a patch to fix this by preventing demand from going below zero.
+This patch adds a config option to allow the minimum demand to instead
+be configurable.
+
+diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+index 0141d4d2dfaacfbce174e82e2d7c1a9419c64982..c20c0bb9351fcc8360ce0b4864d838e9e72e469e 100644
+--- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
++++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+@@ -527,7 +527,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+         while (iterator.hasNext()) {
+             MerchantOffer merchantrecipe = (MerchantOffer) iterator.next();
+ 
+-            merchantrecipe.updateDemand();
++            merchantrecipe.updateDemand(this.level.purpurConfig.villagerMinimumDemand); // Purpur
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/item/trading/MerchantOffer.java b/src/main/java/net/minecraft/world/item/trading/MerchantOffer.java
+index c9cb0717c2793acd5b5870a6cc4d672d69a40026..1b4ec1e2f25c66f9372aa004224556a9a7307ae1 100644
+--- a/src/main/java/net/minecraft/world/item/trading/MerchantOffer.java
++++ b/src/main/java/net/minecraft/world/item/trading/MerchantOffer.java
+@@ -132,9 +132,15 @@ public class MerchantOffer {
+     }
+ 
+     public void updateDemand() {
+-        this.demand = Math.max(0, this.demand + this.uses - (this.maxUses - this.uses)); // Paper
++        this.updateDemand(0); // Purpur
+     }
+ 
++    // Purpur start
++    public void updateDemand(int minimumDemand) {
++        this.demand = Math.max(minimumDemand, this.demand + this.uses - (this.maxUses - this.uses));
++    }
++    // Purpur end
++
+     public ItemStack assemble() {
+         return this.result.copy();
+     }
+diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+index 4bdd91dc2cd76525af4ba2f6d361e10efdf6fda3..24b1ede3b8ffc598ac8d43b56e6392e9cbcd0d25 100644
+--- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
++++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+@@ -2514,6 +2514,7 @@ public class PurpurWorldConfig {
+     public boolean villagerTakeDamageFromWater = false;
+     public boolean villagerAllowTrading = true;
+     public boolean villagerAlwaysDropExp = false;
++    public int villagerMinimumDemand = 0;
+     private void villagerSettings() {
+         villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
+         villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
+@@ -2537,6 +2538,7 @@ public class PurpurWorldConfig {
+         villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
+         villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
+         villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);
++        villagerMinimumDemand = getInt("mobs.villager.minimum-demand", villagerMinimumDemand);
+     }
+ 
+     public boolean vindicatorRidable = false;

--- a/patches/server/0263-Configurable-minimum-demand-for-trades.patch
+++ b/patches/server/0263-Configurable-minimum-demand-for-trades.patch
@@ -9,10 +9,10 @@ This patch adds a config option to allow the minimum demand to instead
 be configurable.
 
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index 0141d4d2dfaacfbce174e82e2d7c1a9419c64982..c20c0bb9351fcc8360ce0b4864d838e9e72e469e 100644
+index 9755517f0c1d66db5bfd00946114fab5db6776d6..b9f228d660b2279284e64fc3bbfa90fc7d2d20b0 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-@@ -527,7 +527,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+@@ -532,7 +532,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
          while (iterator.hasNext()) {
              MerchantOffer merchantrecipe = (MerchantOffer) iterator.next();
  
@@ -22,31 +22,28 @@ index 0141d4d2dfaacfbce174e82e2d7c1a9419c64982..c20c0bb9351fcc8360ce0b4864d838e9
  
      }
 diff --git a/src/main/java/net/minecraft/world/item/trading/MerchantOffer.java b/src/main/java/net/minecraft/world/item/trading/MerchantOffer.java
-index c9cb0717c2793acd5b5870a6cc4d672d69a40026..1b4ec1e2f25c66f9372aa004224556a9a7307ae1 100644
+index c9cb0717c2793acd5b5870a6cc4d672d69a40026..9a402505375af2051673245ec0a1daf9f3a66dc7 100644
 --- a/src/main/java/net/minecraft/world/item/trading/MerchantOffer.java
 +++ b/src/main/java/net/minecraft/world/item/trading/MerchantOffer.java
-@@ -132,9 +132,15 @@ public class MerchantOffer {
+@@ -132,7 +132,12 @@ public class MerchantOffer {
      }
  
      public void updateDemand() {
 -        this.demand = Math.max(0, this.demand + this.uses - (this.maxUses - this.uses)); // Paper
-+        this.updateDemand(0); // Purpur
-     }
- 
-+    // Purpur start
++        // Purpur start
++        this.updateDemand(0);
++    }
 +    public void updateDemand(int minimumDemand) {
 +        this.demand = Math.max(minimumDemand, this.demand + this.uses - (this.maxUses - this.uses));
-+    }
-+    // Purpur end
-+
-     public ItemStack assemble() {
-         return this.result.copy();
++        // Purpur end
      }
+ 
+     public ItemStack assemble() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4bdd91dc2cd76525af4ba2f6d361e10efdf6fda3..24b1ede3b8ffc598ac8d43b56e6392e9cbcd0d25 100644
+index 8a2ecb3a3728cc603017a1d5f06be1d5fb3d47a8..287941dc162c47303ec12c18c0ea4747169ffcd6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2514,6 +2514,7 @@ public class PurpurWorldConfig {
+@@ -2663,6 +2663,7 @@ public class PurpurWorldConfig {
      public boolean villagerTakeDamageFromWater = false;
      public boolean villagerAllowTrading = true;
      public boolean villagerAlwaysDropExp = false;
@@ -54,7 +51,7 @@ index 4bdd91dc2cd76525af4ba2f6d361e10efdf6fda3..24b1ede3b8ffc598ac8d43b56e6392e9
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2537,6 +2538,7 @@ public class PurpurWorldConfig {
+@@ -2687,6 +2688,7 @@ public class PurpurWorldConfig {
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
          villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);


### PR DESCRIPTION
Paper adds [a patch](https://github.com/PaperMC/Paper/blob/master/patches/server/0436-Fix-villager-trading-demand-MC-163962.patch) which stops demand for villager trade offers from going below zero, addressing the issue tracked by [MC-163962](https://bugs.mojang.com/browse/MC-163962). This does have a noticeable effect on trading, as prices can increase quite substantially (with cure discounts) after a single restock where as in vanilla it can take a few restocks to happen.  
  
It's unknown whether going below zero is intentional. It could be but maybe not quite as far in to the negatives as it does go if you don't trade for a long time.

This patch extends the change made by the previous patch by making the minimum demand configurable to leave it up to server administrators to decide.