### PR TITLE
Additional configuration for grindstones

### DIFF
--- a/patches/server/0003-Purpur-config-files.patch
+++ b/patches/server/0003-Purpur-config-files.patch
@@ -105,7 +105,7 @@ index 90aa1d75b5c23e5ee27ceae9f6ef90de913a6601..37884e05689288d56ef0efe92296b80e
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3ccb381b11cec8dcd8c23de3efaa3a27902a5ac5..f69516d01a634a08b75744bfe26e5d9f6831c8f3 100644
+index ebcfbfbe8569525640ddb1d0a35724e920592aa8..4839fd36286c20f11d6bcd737ffdffb5289fc1ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -952,6 +952,7 @@ public final class CraftServer implements Server {
@@ -172,7 +172,7 @@ index 55bae3efbc630be6d40d415509de4c3e744a5004..9d649923e28f4839106b336fce41bd3f
                          .withRequiredArg()
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..fdfb20170c27711085aa0772866876035e0d98c2
+index 0000000000000000000000000000000000000000..0272581e93b573937ee4d449687217f7564887d7
 --- /dev/null
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -0,0 +1,159 @@
@@ -239,8 +239,8 @@ index 0000000000000000000000000000000000000000..fdfb20170c27711085aa077286687603
 +        commands = new HashMap<>();
 +        commands.put("purpur", new PurpurCommand("purpur"));
 +
-+        version = getInt("config-version", 23);
-+        set("config-version", 23);
++        version = getInt("config-version", 24);
++        set("config-version", 24);
 +
 +        readConfig(PurpurConfig.class, null);
 +    }

--- a/patches/server/0236-Config-for-grindstone-to-ignore-specified-enchants.patch
+++ b/patches/server/0236-Config-for-grindstone-to-ignore-specified-enchants.patch
@@ -36,7 +36,7 @@ index 0bdf874ddb951daf8d469575a44144504472d12d..f8fe06c65c87b877f22ea7c0df0bfe15
  
          EnchantmentHelper.setEnchantments(map, itemstack1);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 258ef634bac087710c77abff0a52954aa591ddd2..6085305b161ee8e90031c46eada8c193fc822492 100644
+index 258ef634bac087710c77abff0a52954aa591ddd2..db40a001cd7bb65615d5df1e7623774ccda45807 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -4,9 +4,13 @@ import co.aikar.timings.TimingsManager;
@@ -49,22 +49,24 @@ index 258ef634bac087710c77abff0a52954aa591ddd2..6085305b161ee8e90031c46eada8c193
  import net.minecraft.world.entity.EntityDimensions;
  import net.minecraft.world.entity.EntityType;
 +import net.minecraft.world.item.enchantment.Enchantment;
-+import net.minecraft.world.item.enchantment.Enchantments;
++
  import org.purpurmc.purpur.command.PurpurCommand;
  import org.purpurmc.purpur.task.TPSBarTask;
  import org.bukkit.Bukkit;
-@@ -20,9 +24,7 @@ import java.io.IOException;
+@@ -20,9 +24,12 @@ import java.io.IOException;
  import java.lang.reflect.InvocationTargetException;
  import java.lang.reflect.Method;
  import java.lang.reflect.Modifier;
--import java.util.HashMap;
--import java.util.List;
--import java.util.Map;
-+import java.util.*;
++import java.util.ArrayList;
+ import java.util.HashMap;
++import java.util.HashSet;
+ import java.util.List;
+ import java.util.Map;
++import java.util.Set;
  import java.util.logging.Level;
  
  @SuppressWarnings("unused")
-@@ -300,6 +302,7 @@ public class PurpurConfig {
+@@ -300,6 +307,7 @@ public class PurpurConfig {
      public static int beeInsideBeeHive = 3;
      public static boolean anvilCumulativeCost = true;
      public static int lightningRodRange = 128;
@@ -72,7 +74,7 @@ index 258ef634bac087710c77abff0a52954aa591ddd2..6085305b161ee8e90031c46eada8c193
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -334,6 +337,17 @@ public class PurpurConfig {
+@@ -334,6 +342,17 @@ public class PurpurConfig {
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
          anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);
          lightningRodRange = getInt("settings.blocks.lightning_rod.range", lightningRodRange);

--- a/patches/server/0236-Config-for-grindstone-to-ignore-specified-enchants.patch
+++ b/patches/server/0236-Config-for-grindstone-to-ignore-specified-enchants.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Encode42 <me@encode42.dev>
 Date: Wed, 29 Sep 2021 13:37:57 -0400
-Subject: [PATCH] Config for Grindstones ignoring curses
+Subject: [PATCH] Config for grindstone to ignore specified enchants
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
-index 0bdf874ddb951daf8d469575a44144504472d12d..66d1b438227e004d7ffb6e7c5d0cd3e6da3d2a49 100644
+index 0bdf874ddb951daf8d469575a44144504472d12d..f8fe06c65c87b877f22ea7c0df0bfe15adc42746 100644
 --- a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 @@ -130,7 +130,7 @@ public class GrindstoneMenu extends AbstractContainerMenu {
@@ -13,7 +13,7 @@ index 0bdf874ddb951daf8d469575a44144504472d12d..66d1b438227e004d7ffb6e7c5d0cd3e6
                      Integer integer = (Integer) entry.getValue();
  
 -                    if (!enchantment.isCurse()) {
-+                    if (!org.purpurmc.purpur.PurpurConfig.grindstoneIgnoreCurses || !enchantment.isCurse()) { // Purpur
++                    if (!org.purpurmc.purpur.PurpurConfig.grindstoneIgnoredEnchants.contains(enchantment)) { // Purpur
                          j += enchantment.getMinCost(integer);
                      }
                  }
@@ -22,7 +22,7 @@ index 0bdf874ddb951daf8d469575a44144504472d12d..66d1b438227e004d7ffb6e7c5d0cd3e6
              Enchantment enchantment = (Enchantment) entry.getKey();
  
 -            if (!enchantment.isCurse() || EnchantmentHelper.getItemEnchantmentLevel(enchantment, itemstack2) == 0) {
-+            if (!org.purpurmc.purpur.PurpurConfig.grindstoneIgnoreCurses || !enchantment.isCurse() || EnchantmentHelper.getItemEnchantmentLevel(enchantment, itemstack2) == 0) { // Purpur
++            if (!org.purpurmc.purpur.PurpurConfig.grindstoneIgnoredEnchants.contains(enchantment) || EnchantmentHelper.getItemEnchantmentLevel(enchantment, itemstack2) == 0) { // Purpur
                  itemstack2.enchant(enchantment, (Integer) entry.getValue());
              }
          }
@@ -31,27 +31,62 @@ index 0bdf874ddb951daf8d469575a44144504472d12d..66d1b438227e004d7ffb6e7c5d0cd3e6
          itemstack1.setCount(amount);
          Map<Enchantment, Integer> map = (Map) EnchantmentHelper.getEnchantments(item).entrySet().stream().filter((entry) -> {
 -            return ((Enchantment) entry.getKey()).isCurse();
-+            return org.purpurmc.purpur.PurpurConfig.grindstoneIgnoreCurses && ((Enchantment) entry.getKey()).isCurse(); // Purpur
++            return org.purpurmc.purpur.PurpurConfig.grindstoneIgnoredEnchants.contains((Enchantment) entry.getKey()); // Purpur
          }).collect(Collectors.toMap(Entry::getKey, Entry::getValue));
  
          EnchantmentHelper.setEnchantments(map, itemstack1);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 209d563791695bfca5becdcdd0e088d88d2d354c..bf666e87d20de7df7470cc0618685f9711f59241 100644
+index 258ef634bac087710c77abff0a52954aa591ddd2..6085305b161ee8e90031c46eada8c193fc822492 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -300,6 +300,7 @@ public class PurpurConfig {
+@@ -4,9 +4,13 @@ import co.aikar.timings.TimingsManager;
+ import com.google.common.base.Throwables;
+ import com.google.common.collect.ImmutableMap;
+ import net.kyori.adventure.bossbar.BossBar;
++import net.minecraft.core.Registry;
++import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.server.MinecraftServer;
+ import net.minecraft.world.entity.EntityDimensions;
+ import net.minecraft.world.entity.EntityType;
++import net.minecraft.world.item.enchantment.Enchantment;
++import net.minecraft.world.item.enchantment.Enchantments;
+ import org.purpurmc.purpur.command.PurpurCommand;
+ import org.purpurmc.purpur.task.TPSBarTask;
+ import org.bukkit.Bukkit;
+@@ -20,9 +24,7 @@ import java.io.IOException;
+ import java.lang.reflect.InvocationTargetException;
+ import java.lang.reflect.Method;
+ import java.lang.reflect.Modifier;
+-import java.util.HashMap;
+-import java.util.List;
+-import java.util.Map;
++import java.util.*;
+ import java.util.logging.Level;
+ 
+ @SuppressWarnings("unused")
+@@ -300,6 +302,7 @@ public class PurpurConfig {
      public static int beeInsideBeeHive = 3;
      public static boolean anvilCumulativeCost = true;
      public static int lightningRodRange = 128;
-+    public static boolean grindstoneIgnoreCurses = true;
++    public static Set<Enchantment> grindstoneIgnoredEnchants = new HashSet<>();
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -334,6 +335,7 @@ public class PurpurConfig {
+@@ -334,6 +337,17 @@ public class PurpurConfig {
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
          anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);
          lightningRodRange = getInt("settings.blocks.lightning_rod.range", lightningRodRange);
-+        grindstoneIgnoreCurses = getBoolean("settings.blocks.grindstone.ignore-curses", grindstoneIgnoreCurses);
++        ArrayList<String> defaultCurses = new ArrayList<>(){{
++            add("minecraft:binding_curse");
++            add("minecraft:vanishing_curse");
++        }};
++        if (version < 24 && !getBoolean("settings.blocks.grindstone.ignore-curses", true)) {
++            defaultCurses.clear();
++        }
++        getList("settings.blocks.grindstone.ignored-enchants", defaultCurses).forEach(key -> {
++            Enchantment enchantment = Registry.ENCHANTMENT.get(new ResourceLocation(key.toString()));
++            grindstoneIgnoredEnchants.add(enchantment);
++        });
      }
  
      public static boolean allowInfinityMending = false;

--- a/patches/server/0237-UPnP-Port-Forwarding.patch
+++ b/patches/server/0237-UPnP-Port-Forwarding.patch
@@ -67,10 +67,10 @@ index 9e83f2dea73461f698185f5ffdb6060e422b9494..6b503d7bdd0eb202ff3466dc1f691102
          // CraftBukkit start
          // this.setPlayerList(new DedicatedPlayerList(this, this.registryHolder, this.playerDataStorage)); // Spigot - moved up
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 6085305b161ee8e90031c46eada8c193fc822492..6f1a1d6cb5dd50ed9a55057f4f5c3db73da93337 100644
+index db40a001cd7bb65615d5df1e7623774ccda45807..ccffa0ffac58da97334c7f1a95f28b1a485f9303 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -397,4 +397,9 @@ public class PurpurConfig {
+@@ -402,4 +402,9 @@ public class PurpurConfig {
      private static void tpsCatchup() {
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }

--- a/patches/server/0237-UPnP-Port-Forwarding.patch
+++ b/patches/server/0237-UPnP-Port-Forwarding.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] UPnP Port Forwarding
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 80322847f36a255a9e6fa01223f10771531fa15c..ceac9acc88d7d6c012c5b985f4cb9ae2fdcbf98c 100644
+index ba2c31e1b9f9bac1762ae53a12ebfb2da43612d1..23bf348c31bebf508467c124c42aed68ea5f2913 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -309,6 +309,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -67,10 +67,10 @@ index 9e83f2dea73461f698185f5ffdb6060e422b9494..6b503d7bdd0eb202ff3466dc1f691102
          // CraftBukkit start
          // this.setPlayerList(new DedicatedPlayerList(this, this.registryHolder, this.playerDataStorage)); // Spigot - moved up
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index bf666e87d20de7df7470cc0618685f9711f59241..9b07f3ff8ea84aa231e6b183bcd2947bb1b7e4bc 100644
+index 6085305b161ee8e90031c46eada8c193fc822492..6f1a1d6cb5dd50ed9a55057f4f5c3db73da93337 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -385,4 +385,9 @@ public class PurpurConfig {
+@@ -397,4 +397,9 @@ public class PurpurConfig {
      private static void tpsCatchup() {
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }

--- a/patches/server/0252-Configurable-valid-characters-for-usernames.patch
+++ b/patches/server/0252-Configurable-valid-characters-for-usernames.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable valid characters for usernames
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index c25df7de9adf6cc06d8d49d53c51d843f61565fa..757469c94ece79d1753db7f55d4d417ad8c0d489 100644
+index 3fa13053722387db199f482307559219c381f4da..fd0f5b13c4254dd976a38a6e60d9e1567df32390 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -236,6 +236,8 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -18,10 +18,10 @@ index c25df7de9adf6cc06d8d49d53c51d843f61565fa..757469c94ece79d1753db7f55d4d417a
              char c = in.charAt(i);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 9b07f3ff8ea84aa231e6b183bcd2947bb1b7e4bc..6eb138a83460e049f711c67055fe6db4ff812e8c 100644
+index 6f1a1d6cb5dd50ed9a55057f4f5c3db73da93337..83b76b91fcc5199bd67b4eb216ed0747d85625b8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -390,4 +390,11 @@ public class PurpurConfig {
+@@ -402,4 +402,11 @@ public class PurpurConfig {
      private static void networkSettings() {
          useUPnP = getBoolean("settings.network.upnp-port-forwarding", useUPnP);
      }

--- a/patches/server/0252-Configurable-valid-characters-for-usernames.patch
+++ b/patches/server/0252-Configurable-valid-characters-for-usernames.patch
@@ -18,10 +18,10 @@ index 3fa13053722387db199f482307559219c381f4da..fd0f5b13c4254dd976a38a6e60d9e156
              char c = in.charAt(i);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 6f1a1d6cb5dd50ed9a55057f4f5c3db73da93337..83b76b91fcc5199bd67b4eb216ed0747d85625b8 100644
+index ccffa0ffac58da97334c7f1a95f28b1a485f9303..7d3f8eb6db6193b8151d732232171a9a455e1470 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -402,4 +402,11 @@ public class PurpurConfig {
+@@ -407,4 +407,11 @@ public class PurpurConfig {
      private static void networkSettings() {
          useUPnP = getBoolean("settings.network.upnp-port-forwarding", useUPnP);
      }

--- a/patches/server/0253-Shears-can-have-looting-enchantment.patch
+++ b/patches/server/0253-Shears-can-have-looting-enchantment.patch
@@ -158,10 +158,10 @@ index 6b8a1535086aae7e4e3229d05615fb903188f507..60af917083de1b790b1d93d61835a669
      public int getMinCost(int level) {
          return 15 + (level - 1) * 9;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 6eb138a83460e049f711c67055fe6db4ff812e8c..f19e6c9af8cd559ba5a1492b0d579bf6182f342a 100644
+index 83b76b91fcc5199bd67b4eb216ed0747d85625b8..cb86fafdf066d31f91efb97e3c88761b8b992414 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -340,6 +340,7 @@ public class PurpurConfig {
+@@ -352,6 +352,7 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
@@ -169,7 +169,7 @@ index 6eb138a83460e049f711c67055fe6db4ff812e8c..f19e6c9af8cd559ba5a1492b0d579bf6
      public static boolean allowUnsafeEnchants = false;
      private static void enchantmentSettings() {
          if (version < 5) {
-@@ -349,6 +350,7 @@ public class PurpurConfig {
+@@ -361,6 +362,7 @@ public class PurpurConfig {
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);

--- a/patches/server/0253-Shears-can-have-looting-enchantment.patch
+++ b/patches/server/0253-Shears-can-have-looting-enchantment.patch
@@ -158,10 +158,10 @@ index 6b8a1535086aae7e4e3229d05615fb903188f507..60af917083de1b790b1d93d61835a669
      public int getMinCost(int level) {
          return 15 + (level - 1) * 9;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 83b76b91fcc5199bd67b4eb216ed0747d85625b8..cb86fafdf066d31f91efb97e3c88761b8b992414 100644
+index 7d3f8eb6db6193b8151d732232171a9a455e1470..469f40bf9a31a254950e56b85605c5e729f22e16 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -352,6 +352,7 @@ public class PurpurConfig {
+@@ -357,6 +357,7 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
@@ -169,7 +169,7 @@ index 83b76b91fcc5199bd67b4eb216ed0747d85625b8..cb86fafdf066d31f91efb97e3c88761b
      public static boolean allowUnsafeEnchants = false;
      private static void enchantmentSettings() {
          if (version < 5) {
-@@ -361,6 +362,7 @@ public class PurpurConfig {
+@@ -366,6 +367,7 @@ public class PurpurConfig {
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);

--- a/patches/server/0260-Config-for-grindstones-to-remove-item-attributes.patch
+++ b/patches/server/0260-Config-for-grindstones-to-remove-item-attributes.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Encode42 <me@encode42.dev>
+Date: Sun, 16 Jan 2022 14:54:28 -0500
+Subject: [PATCH] Config for grindstones to remove item attributes
+
+
+diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
+index f061ea886b8e87a5b24567f5f3f80187e711dc5b..24dc7535ca60ba49666b45c8cf6327ce0541ca1a 100644
+--- a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
+@@ -268,6 +268,14 @@ public class GrindstoneMenu extends AbstractContainerMenu {
+             itemstack1.setRepairCost(AnvilMenu.calculateIncreasedRepairCost(itemstack1.getBaseRepairCost()));
+         }
+ 
++        // Purpur start
++        if (org.purpurmc.purpur.PurpurConfig.grindstoneRemoveAttributes) {
++            for (String key : itemstack1.getTag().getAllKeys()) {
++                itemstack1.getTag().remove(key);
++            }
++        }
++        // Purpur end
++
+         return itemstack1;
+     }
+ 
+diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+index 469f40bf9a31a254950e56b85605c5e729f22e16..f36632cc8a5f842d58922d1a6b2ff41f180897ec 100644
+--- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
++++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+@@ -308,6 +308,7 @@ public class PurpurConfig {
+     public static boolean anvilCumulativeCost = true;
+     public static int lightningRodRange = 128;
+     public static Set<Enchantment> grindstoneIgnoredEnchants = new HashSet<>();
++    public static boolean grindstoneRemoveAttributes = false;
+     private static void blockSettings() {
+         if (version < 3) {
+             boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
+@@ -353,6 +354,7 @@ public class PurpurConfig {
+             Enchantment enchantment = Registry.ENCHANTMENT.get(new ResourceLocation(key.toString()));
+             grindstoneIgnoredEnchants.add(enchantment);
+         });
++        grindstoneRemoveAttributes = getBoolean("settings.blocks.grindstone.remove-attributes", grindstoneRemoveAttributes);
+     }
+ 
+     public static boolean allowInfinityMending = false;


### PR DESCRIPTION
Adds a list of enchants the grindstone should ignore when unenchanting items. This *shouldn't* affect performance in any way, but if anyone knows different, lmk. Useful for custom curses, ignoring nerf enchants, etc.

Also adds the ability to remove attributes, such as off-hand speed, jump height, etc.