### PR TITLE
Update Image in README to use new Purpur url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<a href="https://purpurmc.org"><img src="https://repository-images.githubusercontent.com/184300222/14b11480-3303-11eb-8ca4-ea5711d942fb" alt="Purpur"></a>
+<a href="https://purpurmc.org"><img src="https://user-images.githubusercontent.com/74448585/150906023-101cd383-da82-4a3c-9603-a3b5741c3994.png" alt="Purpur"></a>
 
 ## Purpur
 


### PR DESCRIPTION
Changed the url in the image from purpur.pl3x.net to purpurmc.org