### PR TITLE
requirement in issues 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -62,6 +62,8 @@ body:
           required: true
         - label: My version of Minecraft is supported by Purpur.
           required: true
+        - label: My server is running in online mode or behind any kind of proxy wich is in online mode.
+          required: true
   - type: textarea
     attributes:
       label: Other

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Feature Request
     url: https://github.com/PurpurMC/Purpur/discussions/new
-    about: Suggest an idea for Purpur
+    about: Suggest an idea for Purpur.
   - name: Purpur Discord
     url: https://purpurmc.org/discord
     about: If you are having issues with timings or have other minor issues, come join our Discord server for help!

--- a/.github/ISSUE_TEMPLATE/performance_problem.yml
+++ b/.github/ISSUE_TEMPLATE/performance_problem.yml
@@ -50,6 +50,8 @@ body:
           required: true
         - label: My version of Minecraft is supported by Purpur.
           required: true
+        - label: My server is running in online mode or behind any kind of proxy wich is in online mode.
+          required: true
   - type: textarea
     attributes:
       label: Other

--- a/.github/ISSUE_TEMPLATE/server_crash.yml
+++ b/.github/ISSUE_TEMPLATE/server_crash.yml
@@ -65,6 +65,8 @@ body:
           required: true
         - label: My version of Minecraft is supported by Purpur.
           required: true
+        - label: My server is running in online mode or behind any kind of proxy wich is in online mode.
+          required: true
   - type: textarea
     attributes:
       label: Other

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Maven
 <dependency>
     <groupId>org.purpurmc.purpur</groupId>
     <artifactId>purpur-api</artifactId>
-    <version>1.18.1-R0.1-SNAPSHOT</version>
+    <version>1.18.2-R0.1-SNAPSHOT</version>
     <scope>provided</scope>
 </dependency>
 ```
@@ -77,7 +77,7 @@ repositories {
 ```
 ```kotlin
 dependencies {
-    compileOnly("org.purpurmc.purpur", "purpur-api", "1.18.1-R0.1-SNAPSHOT")
+    compileOnly("org.purpurmc.purpur", "purpur-api", "1.18.2-R0.1-SNAPSHOT")
 }
 ```
 


### PR DESCRIPTION
I added a requirement in the issues that offline mode servers aren't supported by purpur. Im not sure if this should be an option for itself or in () behind the supported option