### PR TITLE
[1.17.1] Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ version = 1.17.1-R0.1-SNAPSHOT
 mcVersion = 1.17.1
 packageVersion = 1_17_R1
 
-paperCommit = 5bd2611b3a4bbbd2cbcb7cca185573052e791d11
+paperCommit = 6625db387ea9fe5296a6c6f984975b387c3089f0
 
 org.gradle.caching = true
 org.gradle.parallel = true


### PR DESCRIPTION
1.17 was previously unable to build due to dependency errors. This fixes it and adds other new paper improvements. I doubt this is necessary but it may be useful for people trying to build 1.17.1 for NMS. 

Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@1bc077b Only write chunk data to disk if it serializes without throwing
PaperMC/Paper@ed8c512 Fix migration logic for old player saving config option
PaperMC/Paper@2513373 https://youtu.be/NIH6j7-w198
PaperMC/Paper@2a827e3 Validate usernames
PaperMC/Paper@b1af5ea Allow . in usernames
PaperMC/Paper@bf23668 Backport "Provide option to disable username validation" to 1.17 (#7255)
PaperMC/Paper@cc43ba7 Fix filtered text not being applied on sign update
PaperMC/Paper@c53577e [1.17.1] Backport #5740 and #7355 to 1.17.1 (#7384)
PaperMC/Paper@2c0515f Switch to fabric yarn
PaperMC/Paper@0954966 Use patched spigot decompiler
PaperMC/Paper@6625db3 Replace third party repos with Paper repo