### PR TITLE
[ci-skip] Build script cleanup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.papermc.paperweight.util.constants.PAPERCLIP_CONFIG
-
 plugins {
     java
     `maven-publish`
@@ -7,20 +5,7 @@ plugins {
     id("io.papermc.paperweight.patcher") version "1.3.7"
 }
 
-repositories {
-    mavenCentral()
-    maven("https://papermc.io/repo/repository/maven-public/") {
-        content {
-            onlyForConfigurations(PAPERCLIP_CONFIG)
-        }
-    }
-}
-
-dependencies {
-    remapper("net.fabricmc:tiny-remapper:0.8.2:fat")
-    decompiler("net.minecraftforge:forgeflower:1.5.605.7")
-    paperclip("io.papermc:paperclip:3.0.2")
-}
+val paperMavenPublicUrl = "https://papermc.io/repo/repository/maven-public/"
 
 allprojects {
     apply(plugin = "java")
@@ -38,33 +23,40 @@ subprojects {
         options.encoding = Charsets.UTF_8.name()
         options.release.set(17)
     }
-
     tasks.withType<Javadoc> {
         options.encoding = Charsets.UTF_8.name()
     }
-
     tasks.withType<ProcessResources> {
         filteringCharset = Charsets.UTF_8.name()
     }
 
     repositories {
         mavenCentral()
-        maven("https://oss.sonatype.org/content/groups/public/")
-        maven("https://papermc.io/repo/repository/maven-public/")
-        maven("https://ci.emc.gs/nexus/content/groups/aikar/")
-        maven("https://repo.aikar.co/content/groups/aikar")
-        maven("https://repo.md-5.net/content/repositories/releases/")
-        maven("https://hub.spigotmc.org/nexus/content/groups/public/")
-        maven("https://oss.sonatype.org/content/repositories/snapshots/")
+        maven(paperMavenPublicUrl)
         maven("https://jitpack.io")
     }
+}
+
+repositories {
+    mavenCentral()
+    maven(paperMavenPublicUrl) {
+        content {
+            onlyForConfigurations(configurations.paperclip.name)
+        }
+    }
+}
+
+dependencies {
+    remapper("net.fabricmc:tiny-remapper:0.8.2:fat")
+    decompiler("net.minecraftforge:forgeflower:1.5.605.7")
+    paperclip("io.papermc:paperclip:3.0.2")
 }
 
 paperweight {
     serverProject.set(project(":purpur-server"))
 
-    remapRepo.set("https://maven.fabricmc.net/")
-    decompileRepo.set("https://files.minecraftforge.net/maven/")
+    remapRepo.set(paperMavenPublicUrl)
+    decompileRepo.set(paperMavenPublicUrl)
 
     usePaperUpstream(providers.gradleProperty("paperCommit")) {
         withPaperPatcher {
@@ -83,9 +75,7 @@ tasks.generateDevelopmentBundle {
     libraryRepositories.set(
         listOf(
             "https://repo.maven.apache.org/maven2/",
-            "https://libraries.minecraft.net/",
-            "https://papermc.io/repo/repository/maven-public/",
-            "https://maven.quiltmc.org/repository/release/",
+            paperMavenPublicUrl,
             "https://repo.purpurmc.org/snapshots",
         )
     )


### PR DESCRIPTION
This brings `build.gradle.kts` up-to-date with Paper and `paperweight-examples`' build scripts.

I am unsure if I broke anything, so simple testing should be done on a clean machine.