### PR TITLE
fix #1025

### DIFF
--- a/patches/api/0047-Spark-Profiler.patch
+++ b/patches/api/0047-Spark-Profiler.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: granny <granny@pl3x.net>
+Date: Thu, 30 Jun 2022 02:32:52 -0700
+Subject: [PATCH] Spark Profiler
+
+
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index aed2209b66f11a0d03473cf19437f3da0e9e573a..353bed51cf7a5be0e7a75c72290976348631381e 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -164,6 +164,12 @@ public final class SimplePluginManager implements PluginManager {
+                 server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "'", ex); // Paper
+                 continue;
+             }
++            // Purpur start
++            if (plugins.containsKey(description.getName()) && description.getName().equalsIgnoreCase("spark")) {
++                server.getLogger().log(Level.INFO, "Purpur: Using user-provided spark plugin instead of our own.");
++                continue;
++            }
++            // Purpur end
+ 
+             File replacedFile = plugins.put(description.getName(), file);
+             if (replacedFile != null) {

--- a/patches/server/0280-Spark-Profiler.patch
+++ b/patches/server/0280-Spark-Profiler.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Spark Profiler
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7960433f8278e3bd0ec43db3d3820ff2740a7c13..a376045e94d1811645f84b3e4963726fe12545a4 100644
+index 7960433f8278e3bd0ec43db3d3820ff2740a7c13..c0dab34feadf9e3e681a78ff8717e8c059b04cac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -410,6 +410,7 @@ public final class CraftServer implements Server {
+@@ -410,13 +410,43 @@ public final class CraftServer implements Server {
          this.pluginManager.registerInterface(JavaPluginLoader.class);
  
          File pluginFolder = this.getPluginsFolder(); // Paper
@@ -16,21 +16,12 @@ index 7960433f8278e3bd0ec43db3d3820ff2740a7c13..a376045e94d1811645f84b3e4963726f
  
          // Paper start
          if (true || pluginFolder.exists()) {
-@@ -423,6 +424,7 @@ public final class CraftServer implements Server {
-                     String message = String.format("Loading %s", plugin.getDescription().getFullName());
-                     plugin.getLogger().info(message);
-                     plugin.onLoad();
-+                    sparkLoaded = sparkLoaded || plugin.getDescription().getName().equalsIgnoreCase("spark"); // Purpur
-                 } catch (Throwable ex) {
-                     Logger.getLogger(CraftServer.class.getName()).log(Level.SEVERE, ex.getMessage() + " initializing " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
-                 }
-@@ -430,6 +432,40 @@ public final class CraftServer implements Server {
-         } else {
-             pluginFolder.mkdir();
-         }
-+
-+        // Purpur start
-+        if (!sparkLoaded) {
+             if (!pluginFolder.exists()) {
+                 pluginFolder.mkdirs();
+             }
+-            Plugin[] plugins = this.pluginManager.loadPlugins(pluginFolder, this.extraPluginJars());
++            // Purpur start
++            List<File> extraJars = this.extraPluginJars();
 +            try {
 +                File file = new File("cache", "spark.jar");
 +                file.getParentFile().mkdirs();
@@ -52,16 +43,13 @@ index 7960433f8278e3bd0ec43db3d3820ff2740a7c13..a376045e94d1811645f84b3e4963726f
 +                    java.nio.file.Files.copy(new java.net.URL("https://sparkapi.lucko.me/download/bukkit").openStream(), file.toPath(), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
 +                }
 +
-+                Plugin spark = this.pluginManager.loadPlugin(file);
-+                String message = String.format("Loading %s", spark.getDescription().getFullName());
-+                spark.getLogger().info(message);
-+                spark.onLoad();
++                extraJars.add(file);
 +            } catch (Exception e) {
-+                getLogger().severe("Failed to download and load spark plugin");
++                getLogger().severe("Purpur: Failed to download and install spark plugin");
 +                e.printStackTrace();
 +            }
-+        }
-+        // Purpur end
-     }
- 
-     // Paper start
++            Plugin[] plugins = this.pluginManager.loadPlugins(pluginFolder, extraJars);
++            // Purpur end
+             // Paper end
+             for (Plugin plugin : plugins) {
+                 try {

--- a/patches/server/0280-Spark-Profiler.patch
+++ b/patches/server/0280-Spark-Profiler.patch
@@ -5,17 +5,10 @@ Subject: [PATCH] Spark Profiler
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7960433f8278e3bd0ec43db3d3820ff2740a7c13..c0dab34feadf9e3e681a78ff8717e8c059b04cac 100644
+index 7960433f8278e3bd0ec43db3d3820ff2740a7c13..b2dd88730e775dbe694cbb2c17d45ceabfbbf033 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -410,13 +410,43 @@ public final class CraftServer implements Server {
-         this.pluginManager.registerInterface(JavaPluginLoader.class);
- 
-         File pluginFolder = this.getPluginsFolder(); // Paper
-+        boolean sparkLoaded = false; // Purpur
- 
-         // Paper start
-         if (true || pluginFolder.exists()) {
+@@ -416,7 +416,36 @@ public final class CraftServer implements Server {
              if (!pluginFolder.exists()) {
                  pluginFolder.mkdirs();
              }


### PR DESCRIPTION
### Changes
* the server will continue to download the spark jar as it did before with the only difference being that it'll download/update our spark jar even if there's already a user-provided spark jar
* i force our spark jar into the `extraPluginJars` list AFTER it's already grabbed all the files added by the `add-plugin` command line option
   * if the plugin loader gets to our plugin and there's already been a spark jar that's been loaded, skip ours and use the user-provided jar

### Issue
it will always load the first spark jar it detects if the user provides multiple spark jars. no warnings will be given if that happens.

### "simple" solution
rename our cached jar that isn't something an end-user would use as a name, then just add a third check in the plugin manager for the file name.




### Note: I had a long day of manual labor, and it is late at night. I most likely missed something completely obvious that makes this easier on us to handle.
