### PR TITLE
Add patch to prevent block desyncs

### DIFF
--- a/patches/server/0275-Prevent-block-destroy-desync.patch
+++ b/patches/server/0275-Prevent-block-destroy-desync.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: spookyoctopus <spookyoctopus@gmail.com>
+Date: Fri, 1 Jul 2022 11:50:46 -0700
+Subject: [PATCH] Prevent block destroy desync
+
+It is quite common to have blocks get desynced between the client and
+server, Especially with the use of plugins. This patch reduces the
+consequences of such a desync, by sending a BlockUpdatePacket on a block
+action such as digging.
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 9916b862e4836bffb6dc033d5900c63045b6ec48..f82a84456ff5fd9cd83eb704340ab6df81aae26e 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1842,6 +1842,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+                 }
+                 this.player.gameMode.handleBlockBreakAction(blockposition, packetplayinblockdig_enumplayerdigtype, packet.getDirection(), this.player.level.getMaxBuildHeight());
+                 // Paper end - Don't allow digging in unloaded chunks
++		// Purpur start - Prevent block state desync
++		this.player.connection.send(new ClientboundBlockUpdatePacket(this.player.getLevel(), blockposition));
++		// Purpur end - Prevent block state desync
+                 return;
+             default:
+                 throw new IllegalArgumentException("Invalid player action");


### PR DESCRIPTION
It is quite common to have blocks get desynced between the client and
server, Especially with the use of plugins. 

This patch reduces the consequences and likely hood of such a desync, by sending a BlockUpdatePacket on a block
action such as digging.