### PR TITLE
Split allowUnsafeEnchants setting

### DIFF
--- a/patches/server/0162-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0162-Config-to-allow-for-unsafe-enchants.patch
@@ -84,7 +84,7 @@ index 5b79adf2e036b4e9c2abd7cea53f1ef064252d7a..520c76a7a2baa3091224c96580a861a6
          this.getOrCreateTag().put(key, element);
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 111bea3e08b998003ee4c8d81f61ab43247ca793..d72ccfec40542301c308375afaff4f6d33583b49 100644
+index 111bea3e08b998003ee4c8d81f61ab43247ca793..006f46244956c251aab44a64fcb6b4750dcf0afb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -72,8 +72,8 @@ public class PurpurConfig {
@@ -103,9 +103,9 @@ index 111bea3e08b998003ee4c8d81f61ab43247ca793..d72ccfec40542301c308375afaff4f6d
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
 +    public static boolean allowUnsafeEnchants = false;
-+    public static boolean allowInapplicableEnchants = false;
-+    public static boolean allowIncompatibleEnchants = false;
-+    public static boolean allowHigherEnchantsLevels = false;
++    public static boolean allowInapplicableEnchants = true;
++    public static boolean allowIncompatibleEnchants = true;
++    public static boolean allowHigherEnchantsLevels = true;
 +    public static boolean allowUnsafeEnchantCommand = false;
      private static void enchantmentSettings() {
          if (version < 5) {

--- a/patches/server/0162-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0162-Config-to-allow-for-unsafe-enchants.patch
@@ -27,7 +27,7 @@ index 7c012f1e37b0085c0939797b0dae8996b4953ab8..155b0a1aa58b891e98a55e10f112f611
                              ++i;
                          } else if (targets.size() == 1) {
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 10cd589e427f847936f29e33edee3923a4661210..a68dcf3ad04ef9c8e69a0d81eacfe50644463270 100644
+index 10cd589e427f847936f29e33edee3923a4661210..43b1cfb67031977ecacc6d9ce358dbbc4a63a689 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 @@ -208,7 +208,7 @@ public class AnvilMenu extends ItemCombinerMenu {
@@ -35,7 +35,7 @@ index 10cd589e427f847936f29e33edee3923a4661210..a68dcf3ad04ef9c8e69a0d81eacfe506
  
                              i2 = l1 == i2 ? i2 + 1 : Math.max(i2, l1);
 -                            boolean flag3 = canDoUnsafeEnchants || enchantment.canEnchant(itemstack); // Purpur
-+                            boolean flag3 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants || enchantment.canEnchant(itemstack); // Purpur
++                            boolean flag3 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowInapplicableEnchants || enchantment.canEnchant(itemstack); // Purpur
  
                              if (this.player.getAbilities().instabuild || itemstack.is(Items.ENCHANTED_BOOK)) {
                                  flag3 = true;
@@ -44,7 +44,7 @@ index 10cd589e427f847936f29e33edee3923a4661210..a68dcf3ad04ef9c8e69a0d81eacfe506
  
                                  if (enchantment1 != enchantment && !enchantment.isCompatibleWith(enchantment1)) {
 -                                    flag3 = canDoUnsafeEnchants; // Purpur
-+                                    flag3 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants; // Purpur
++                                    flag3 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowIncompatibleEnchants; // Purpur
                                      ++i;
                                  }
                              }
@@ -53,7 +53,7 @@ index 10cd589e427f847936f29e33edee3923a4661210..a68dcf3ad04ef9c8e69a0d81eacfe506
                              } else {
                                  flag1 = true;
 -                                if (i2 > enchantment.getMaxLevel()) {
-+                                if (!org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && i2 > enchantment.getMaxLevel()) { // Purpur
++                                if (!(org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowHigherEnchantsLevels) && i2 > enchantment.getMaxLevel()) { // Purpur
                                      i2 = enchantment.getMaxLevel();
                                  }
  
@@ -84,24 +84,50 @@ index 5b79adf2e036b4e9c2abd7cea53f1ef064252d7a..520c76a7a2baa3091224c96580a861a6
          this.getOrCreateTag().put(key, element);
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 111bea3e08b998003ee4c8d81f61ab43247ca793..bd8c2caaf717621eda0427e4cdea240245180f1a 100644
+index 111bea3e08b998003ee4c8d81f61ab43247ca793..d72ccfec40542301c308375afaff4f6d33583b49 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -278,6 +278,8 @@ public class PurpurConfig {
+@@ -72,8 +72,8 @@ public class PurpurConfig {
+         commands = new HashMap<>();
+         commands.put("purpur", new PurpurCommand("purpur"));
+ 
+-        version = getInt("config-version", 29);
+-        set("config-version", 29);
++        version = getInt("config-version", 30);
++        set("config-version", 30);
+ 
+         readConfig(PurpurConfig.class, null);
+     }
+@@ -278,14 +278,32 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
 +    public static boolean allowUnsafeEnchants = false;
++    public static boolean allowInapplicableEnchants = false;
++    public static boolean allowIncompatibleEnchants = false;
++    public static boolean allowHigherEnchantsLevels = false;
 +    public static boolean allowUnsafeEnchantCommand = false;
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -286,6 +288,8 @@ public class PurpurConfig {
+             set("settings.enchantment.allow-infinity-and-mending-together", oldValue);
+             set("settings.enchantment.allow-infinite-and-mending-together", null);
          }
++        if (version < 30) {
++            boolean oldValue = getBoolean("settings.enchantment.allow-unsafe-enchants", false);
++            set("settings.enchantment.anvil.allow-unsafe-enchants", oldValue);
++            set("settings.enchantment.anvil.allow-inapplicable-enchants", true);
++            set("settings.enchantment.anvil.allow-incompatible-enchants", true);
++            set("settings.enchantment.anvil.allow-higher-enchants-levels", true);
++            set("settings.enchantment.allow-unsafe-enchants", null);
++        }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);
-+        allowUnsafeEnchants = getBoolean("settings.enchantment.allow-unsafe-enchants", allowUnsafeEnchants);
-+        allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability
++        allowUnsafeEnchants = getBoolean("settings.enchantment.anvil.allow-unsafe-enchants", allowUnsafeEnchants);
++        allowInapplicableEnchants = getBoolean("settings.enchantment.anvil.allow-inapplicable-enchants", allowInapplicableEnchants);
++        allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);
++        allowHigherEnchantsLevels = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowHigherEnchantsLevels);
++        allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowInapplicableEnchants); // allowInapplicableEnchants as default for backwards compatability
      }
  
      public static boolean endermanShortHeight = false;

--- a/patches/server/0235-UPnP-Port-Forwarding.patch
+++ b/patches/server/0235-UPnP-Port-Forwarding.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] UPnP Port Forwarding
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index db39fd89be32f2f3d4d38b8e633f50a40bdd0235..b728506e933461bec663d5187e7c71ee2ba2acc3 100644
+index 8b9385ad447cd80b72b6fa2f72572fba03c30cea..f1538d7da02a7d576e69fa74aba520b1af5c9f10 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -293,6 +293,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -67,10 +67,10 @@ index 3f7b8e62bb79d8618f962af4ea5dbec9fffcdf4d..0af9a13501b8fcf2e008c5afb98a91c6
          // CraftBukkit start
          // this.setPlayerList(new DedicatedPlayerList(this, this.registryHolder, this.playerDataStorage)); // Spigot - moved up
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index edbda0b79ecce794254dc8e3e6e0847a20cf8fde..b4c7252e39a58312ed90e553a2a79a1ed768ce00 100644
+index eb008ed0450820b80ad016c7a26bf705ae38d5dc..e17cea3c216238c2acf5195420f1eec25824b1de 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -420,4 +420,9 @@ public class PurpurConfig {
+@@ -434,4 +434,9 @@ public class PurpurConfig {
      private static void tpsCatchup() {
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }

--- a/patches/server/0250-Configurable-valid-characters-for-usernames.patch
+++ b/patches/server/0250-Configurable-valid-characters-for-usernames.patch
@@ -18,10 +18,10 @@ index 982a0bb5fc0a8d62e750926217dc36690709de8b..0a0f1da57fd85c521c84b127316a4816
              char c = in.charAt(i);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index b4c7252e39a58312ed90e553a2a79a1ed768ce00..1056b13937bebc5a8f20b78b0fdb7601d50a320e 100644
+index e17cea3c216238c2acf5195420f1eec25824b1de..a614afd52e742e4d54a3e45a3df9ab574ccc6c3c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -425,4 +425,11 @@ public class PurpurConfig {
+@@ -439,4 +439,11 @@ public class PurpurConfig {
      private static void networkSettings() {
          useUPnP = getBoolean("settings.network.upnp-port-forwarding", useUPnP);
      }

--- a/patches/server/0251-Shears-can-have-looting-enchantment.patch
+++ b/patches/server/0251-Shears-can-have-looting-enchantment.patch
@@ -158,7 +158,7 @@ index 6b8a1535086aae7e4e3229d05615fb903188f507..60af917083de1b790b1d93d61835a669
      public int getMinCost(int level) {
          return 15 + (level - 1) * 9;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index a614afd52e742e4d54a3e45a3df9ab574ccc6c3c..37dc89a2800a5fb9ecce47ccc05217528370a47b 100644
+index 091c6ee78e1eac1bf0529ff66f9e069eafa1822b..5698ab49baa000cf01d01d2a7b2416c2e02a114b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -371,6 +371,7 @@ public class PurpurConfig {
@@ -167,8 +167,8 @@ index a614afd52e742e4d54a3e45a3df9ab574ccc6c3c..37dc89a2800a5fb9ecce47ccc0521752
      public static boolean allowCrossbowInfinity = false;
 +    public static boolean allowShearsLooting = false;
      public static boolean allowUnsafeEnchants = false;
-     public static boolean allowInapplicableEnchants = false;
-     public static boolean allowIncompatibleEnchants = false;
+     public static boolean allowInapplicableEnchants = true;
+     public static boolean allowIncompatibleEnchants = true;
 @@ -392,6 +393,7 @@ public class PurpurConfig {
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);

--- a/patches/server/0251-Shears-can-have-looting-enchantment.patch
+++ b/patches/server/0251-Shears-can-have-looting-enchantment.patch
@@ -158,7 +158,7 @@ index 6b8a1535086aae7e4e3229d05615fb903188f507..60af917083de1b790b1d93d61835a669
      public int getMinCost(int level) {
          return 15 + (level - 1) * 9;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 1056b13937bebc5a8f20b78b0fdb7601d50a320e..db890f02f1b2359aecc8becf6a1caddf07cc7ce4 100644
+index a614afd52e742e4d54a3e45a3df9ab574ccc6c3c..37dc89a2800a5fb9ecce47ccc05217528370a47b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -371,6 +371,7 @@ public class PurpurConfig {
@@ -167,13 +167,13 @@ index 1056b13937bebc5a8f20b78b0fdb7601d50a320e..db890f02f1b2359aecc8becf6a1caddf
      public static boolean allowCrossbowInfinity = false;
 +    public static boolean allowShearsLooting = false;
      public static boolean allowUnsafeEnchants = false;
-     public static boolean allowUnsafeEnchantCommand = false;
-     private static void enchantmentSettings() {
-@@ -381,6 +382,7 @@ public class PurpurConfig {
+     public static boolean allowInapplicableEnchants = false;
+     public static boolean allowIncompatibleEnchants = false;
+@@ -392,6 +393,7 @@ public class PurpurConfig {
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);
 +        allowShearsLooting = getBoolean("settings.enchantment.allow-looting-on-shears", allowShearsLooting);
-         allowUnsafeEnchants = getBoolean("settings.enchantment.allow-unsafe-enchants", allowUnsafeEnchants);
-         allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability
-     }
+         allowUnsafeEnchants = getBoolean("settings.enchantment.anvil.allow-unsafe-enchants", allowUnsafeEnchants);
+         allowInapplicableEnchants = getBoolean("settings.enchantment.anvil.allow-inapplicable-enchants", allowInapplicableEnchants);
+         allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);

--- a/patches/server/0259-Configurable-food-attributes.patch
+++ b/patches/server/0259-Configurable-food-attributes.patch
@@ -69,10 +69,10 @@ index 1ce51253b755c2ea4dca94c567935b074ffdbbd6..9814756a0a2aa11e15635954063c1355
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index db890f02f1b2359aecc8becf6a1caddf07cc7ce4..5038d35ccb37a492d6a16242d876d18c02ccc35c 100644
+index 37dc89a2800a5fb9ecce47ccc05217528370a47b..368d6618be28d3e1c79ca4736e8ba8552eea1d68 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -434,4 +434,57 @@ public class PurpurConfig {
+@@ -448,4 +448,57 @@ public class PurpurConfig {
          String setPattern = getString("settings.username-valid-characters", defaultPattern);
          usernameValidCharactersPattern = java.util.regex.Pattern.compile(setPattern == null || setPattern.isBlank() ? defaultPattern : setPattern);
      }

--- a/patches/server/0260-Max-joins-per-second.patch
+++ b/patches/server/0260-Max-joins-per-second.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Max joins per second
 When this option is set to true the `max-joins-per-tick` setting in paper.yml will be used per second instead of per tick
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index c1e8d8674738eebaaf7bd918eacb5227a1331b67..fd23bb94194b94a203de8aa165096ebce11c2a63 100644
+index b65a3626d2e0817cd1e223ec3b10e82fa0339663..4b704fcce0951ffd3a8e29377f7b6893ed5bed87 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -545,11 +545,20 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -31,10 +31,10 @@ index c1e8d8674738eebaaf7bd918eacb5227a1331b67..fd23bb94194b94a203de8aa165096ebc
          }
          // Paper end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 5038d35ccb37a492d6a16242d876d18c02ccc35c..c482f598c79c8ff32fdcdf8cd1ac7920f4050862 100644
+index 368d6618be28d3e1c79ca4736e8ba8552eea1d68..345bdbd50b662b094f84574576ebc3f28894e371 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -424,8 +424,10 @@ public class PurpurConfig {
+@@ -438,8 +438,10 @@ public class PurpurConfig {
      }
  
      public static boolean useUPnP = false;

--- a/patches/server/0270-Add-toggle-for-enchant-level-clamping.patch
+++ b/patches/server/0270-Add-toggle-for-enchant-level-clamping.patch
@@ -31,12 +31,12 @@ index 4afa30753a90d9bbd3c71b21cb4a8deadf9ccb3b..1d79da7f8405f7dff3b2e10022a564a9
  
      @Nullable
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index e8f02abcfbe9baa3a3c71d3105a9466e2f11f0a2..117773e1580e7fd65d7d22acf68d198613872ea9 100644
+index 57dcb604ea61cf68f5774600d572b7dbf5bea24a..67b749c51e8c6319844739bb2af6af38b2209b1d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -379,6 +379,7 @@ public class PurpurConfig {
-     public static boolean allowIncompatibleEnchants = false;
-     public static boolean allowHigherEnchantsLevels = false;
+     public static boolean allowIncompatibleEnchants = true;
+     public static boolean allowHigherEnchantsLevels = true;
      public static boolean allowUnsafeEnchantCommand = false;
 +    public static boolean clampEnchantLevels = true;
      private static void enchantmentSettings() {

--- a/patches/server/0270-Add-toggle-for-enchant-level-clamping.patch
+++ b/patches/server/0270-Add-toggle-for-enchant-level-clamping.patch
@@ -31,21 +31,21 @@ index 4afa30753a90d9bbd3c71b21cb4a8deadf9ccb3b..1d79da7f8405f7dff3b2e10022a564a9
  
      @Nullable
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 8d4bd88270747bf905ce87573492382cb175d57b..127df4a4c5c84f5e260104a4cc8ef092f7cf9e07 100644
+index e8f02abcfbe9baa3a3c71d3105a9466e2f11f0a2..117773e1580e7fd65d7d22acf68d198613872ea9 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -376,6 +376,7 @@ public class PurpurConfig {
-     public static boolean allowShearsLooting = false;
-     public static boolean allowUnsafeEnchants = false;
+@@ -379,6 +379,7 @@ public class PurpurConfig {
+     public static boolean allowIncompatibleEnchants = false;
+     public static boolean allowHigherEnchantsLevels = false;
      public static boolean allowUnsafeEnchantCommand = false;
 +    public static boolean clampEnchantLevels = true;
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -387,6 +388,7 @@ public class PurpurConfig {
-         allowShearsLooting = getBoolean("settings.enchantment.allow-looting-on-shears", allowShearsLooting);
-         allowUnsafeEnchants = getBoolean("settings.enchantment.allow-unsafe-enchants", allowUnsafeEnchants);
-         allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability
+@@ -401,6 +402,7 @@ public class PurpurConfig {
+         allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);
+         allowHigherEnchantsLevels = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowHigherEnchantsLevels);
+         allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowInapplicableEnchants); // allowInapplicableEnchants as default for backwards compatability
 +        clampEnchantLevels = getBoolean("settings.enchantment.clamp-levels", clampEnchantLevels);
      }
  

--- a/patches/server/0277-Add-log-suppression-for-sent-expired-chat.patch
+++ b/patches/server/0277-Add-log-suppression-for-sent-expired-chat.patch
@@ -18,10 +18,10 @@ index 05bda808496f38d10416c3702b1f97fe18247769..99c8b4957194868c36f9ea214c7f77a2
              }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 3d96a49cca34f0a3f3b37de839e476c2a4c1f1d6..fecfe935e09ff52a6ec582e6f2e09611adb1106f 100644
+index 2340a0ce689a5b83b3b1ed3726e6e14422c7db5e..4bebe841f1a031121569b20f4a39ef59b2e63e9e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -417,11 +417,13 @@ public class PurpurConfig {
+@@ -431,11 +431,13 @@ public class PurpurConfig {
      public static boolean loggerSuppressIgnoredAdvancementWarnings = false;
      public static boolean loggerSuppressUnrecognizedRecipeErrors = false;
      public static boolean loggerSuppressSetBlockFarChunk = false;


### PR DESCRIPTION
`allowInapplicableEnchants` - allows applying, for example, sharpness to a pickaxe
`allowIncompatibleEnchants` - allows applying, for example, protection and fire protection at the same time
`allowHigherEnchantsLevels` - allows exceeding enchants' maximum levels, for example: Eff V + Eff V = Eff VI