### PR TITLE
Split allowUnsafeEnchants setting

### DIFF
--- a/patches/server/0004-Purpur-config-files.patch
+++ b/patches/server/0004-Purpur-config-files.patch
@@ -172,7 +172,7 @@ index c55ae77807e0ec3698f0d0443caaf18928b41017..2fae47d9e75a33416e27b6a225636554
                          .withRequiredArg()
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e784bc02ee6bf9848396a1e3a3af58b0b959b0d3
+index 0000000000000000000000000000000000000000..6dbb2e10ed244845fe9f857b237589900ea3cf40
 --- /dev/null
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -0,0 +1,170 @@
@@ -250,8 +250,8 @@ index 0000000000000000000000000000000000000000..e784bc02ee6bf9848396a1e3a3af58b0
 +        commands = new HashMap<>();
 +        commands.put("purpur", new PurpurCommand("purpur"));
 +
-+        version = getInt("config-version", 29);
-+        set("config-version", 29);
++        version = getInt("config-version", 30);
++        set("config-version", 30);
 +
 +        readConfig(PurpurConfig.class, null);
 +    }

--- a/patches/server/0162-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0162-Config-to-allow-for-unsafe-enchants.patch
@@ -27,37 +27,40 @@ index 7c012f1e37b0085c0939797b0dae8996b4953ab8..155b0a1aa58b891e98a55e10f112f611
                              ++i;
                          } else if (targets.size() == 1) {
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 800df3b7c04ce7ed52f265d681e7752f63ae4ec7..c01faa0d2900230a323c7e1f41093c691fb394aa 100644
+index 800df3b7c04ce7ed52f265d681e7752f63ae4ec7..dd643d9ded515808c33a37e97da1700fc4919cee 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-@@ -209,7 +209,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -209,7 +209,8 @@ public class AnvilMenu extends ItemCombinerMenu {
                              int i2 = (Integer) map1.get(enchantment);
  
                              i2 = l1 == i2 ? i2 + 1 : Math.max(i2, l1);
 -                            boolean flag3 = canDoUnsafeEnchants || enchantment.canEnchant(itemstack); // Purpur
-+                            boolean flag3 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants || enchantment.canEnchant(itemstack); // Purpur
++                            boolean flag3 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowInapplicableEnchants || enchantment.canEnchant(itemstack); // Purpur
++                            boolean flag4 = true; // Purpur
  
                              if (this.player.getAbilities().instabuild || itemstack.is(Items.ENCHANTED_BOOK)) {
                                  flag3 = true;
-@@ -221,7 +221,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -221,16 +222,16 @@ public class AnvilMenu extends ItemCombinerMenu {
                                  Enchantment enchantment1 = (Enchantment) iterator1.next();
  
                                  if (enchantment1 != enchantment && !enchantment.isCompatibleWith(enchantment1)) {
 -                                    flag3 = canDoUnsafeEnchants; // Purpur
-+                                    flag3 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants; // Purpur
++                                    flag4 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowIncompatibleEnchants; // Purpur flag3 -> flag4
                                      ++i;
                                  }
                              }
-@@ -230,7 +230,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+ 
+-                            if (!flag3) {
++                            if (!flag3 || !flag4) { // Purpur
                                  flag2 = true;
                              } else {
                                  flag1 = true;
 -                                if (i2 > enchantment.getMaxLevel()) {
-+                                if (!org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && i2 > enchantment.getMaxLevel()) { // Purpur
++                                if ((!org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants || !org.purpurmc.purpur.PurpurConfig.allowHigherEnchantsLevels) && i2 > enchantment.getMaxLevel()) { // Purpur
                                      i2 = enchantment.getMaxLevel();
                                  }
  
-@@ -333,7 +333,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -333,7 +334,7 @@ public class AnvilMenu extends ItemCombinerMenu {
              sendAllDataToRemote(); // CraftBukkit - SPIGOT-6686: Always send completed inventory to stay in sync with client
              this.broadcastChanges();
              // Purpur start
@@ -84,23 +87,49 @@ index 5b79adf2e036b4e9c2abd7cea53f1ef064252d7a..520c76a7a2baa3091224c96580a861a6
          this.getOrCreateTag().put(key, element);
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 111bea3e08b998003ee4c8d81f61ab43247ca793..bd8c2caaf717621eda0427e4cdea240245180f1a 100644
+index 111bea3e08b998003ee4c8d81f61ab43247ca793..79929c701983c1ac316c2623e3375175859cf068 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -278,6 +278,8 @@ public class PurpurConfig {
+@@ -72,8 +72,8 @@ public class PurpurConfig {
+         commands = new HashMap<>();
+         commands.put("purpur", new PurpurCommand("purpur"));
+ 
+-        version = getInt("config-version", 29);
+-        set("config-version", 29);
++        version = getInt("config-version", 30);
++        set("config-version", 30);
+ 
+         readConfig(PurpurConfig.class, null);
+     }
+@@ -278,14 +278,32 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
 +    public static boolean allowUnsafeEnchants = false;
++    public static boolean allowInapplicableEnchants = true;
++    public static boolean allowIncompatibleEnchants = true;
++    public static boolean allowHigherEnchantsLevels = true;
 +    public static boolean allowUnsafeEnchantCommand = false;
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -286,6 +288,8 @@ public class PurpurConfig {
+             set("settings.enchantment.allow-infinity-and-mending-together", oldValue);
+             set("settings.enchantment.allow-infinite-and-mending-together", null);
          }
++        if (version < 30) {
++            boolean oldValue = getBoolean("settings.enchantment.allow-unsafe-enchants", false);
++            set("settings.enchantment.anvil.allow-unsafe-enchants", oldValue);
++            set("settings.enchantment.anvil.allow-inapplicable-enchants", true);
++            set("settings.enchantment.anvil.allow-incompatible-enchants", true);
++            set("settings.enchantment.anvil.allow-higher-enchants-levels", true);
++            set("settings.enchantment.allow-unsafe-enchants", null);
++        }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);
-+        allowUnsafeEnchants = getBoolean("settings.enchantment.allow-unsafe-enchants", allowUnsafeEnchants);
++        allowUnsafeEnchants = getBoolean("settings.enchantment.anvil.allow-unsafe-enchants", allowUnsafeEnchants);
++        allowInapplicableEnchants = getBoolean("settings.enchantment.anvil.allow-inapplicable-enchants", allowInapplicableEnchants);
++        allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);
++        allowHigherEnchantsLevels = getBoolean("settings.enchantment.anvil.allow-higher-enchants-levels", allowHigherEnchantsLevels);
 +        allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability
      }
  

--- a/patches/server/0162-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0162-Config-to-allow-for-unsafe-enchants.patch
@@ -27,7 +27,7 @@ index 7c012f1e37b0085c0939797b0dae8996b4953ab8..155b0a1aa58b891e98a55e10f112f611
                              ++i;
                          } else if (targets.size() == 1) {
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 800df3b7c04ce7ed52f265d681e7752f63ae4ec7..dd643d9ded515808c33a37e97da1700fc4919cee 100644
+index 800df3b7c04ce7ed52f265d681e7752f63ae4ec7..33c33a953cdd47c30720225b10a5378f16daf225 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 @@ -209,7 +209,8 @@ public class AnvilMenu extends ItemCombinerMenu {
@@ -35,7 +35,7 @@ index 800df3b7c04ce7ed52f265d681e7752f63ae4ec7..dd643d9ded515808c33a37e97da1700f
  
                              i2 = l1 == i2 ? i2 + 1 : Math.max(i2, l1);
 -                            boolean flag3 = canDoUnsafeEnchants || enchantment.canEnchant(itemstack); // Purpur
-+                            boolean flag3 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowInapplicableEnchants || enchantment.canEnchant(itemstack); // Purpur
++                            boolean flag3 = canDoUnsafeEnchants || (org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowInapplicableEnchants) || enchantment.canEnchant(itemstack); // Purpur
 +                            boolean flag4 = true; // Purpur
  
                              if (this.player.getAbilities().instabuild || itemstack.is(Items.ENCHANTED_BOOK)) {
@@ -45,7 +45,7 @@ index 800df3b7c04ce7ed52f265d681e7752f63ae4ec7..dd643d9ded515808c33a37e97da1700f
  
                                  if (enchantment1 != enchantment && !enchantment.isCompatibleWith(enchantment1)) {
 -                                    flag3 = canDoUnsafeEnchants; // Purpur
-+                                    flag4 = canDoUnsafeEnchants || org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowIncompatibleEnchants; // Purpur flag3 -> flag4
++                                    flag4 = canDoUnsafeEnchants || (org.purpurmc.purpur.PurpurConfig.allowUnsafeEnchants && org.purpurmc.purpur.PurpurConfig.allowIncompatibleEnchants); // Purpur flag3 -> flag4
                                      ++i;
                                  }
                              }
@@ -87,20 +87,9 @@ index 5b79adf2e036b4e9c2abd7cea53f1ef064252d7a..520c76a7a2baa3091224c96580a861a6
          this.getOrCreateTag().put(key, element);
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 111bea3e08b998003ee4c8d81f61ab43247ca793..79929c701983c1ac316c2623e3375175859cf068 100644
+index d4f66066dce1c6e4571ebefb68a4ef537718921c..79929c701983c1ac316c2623e3375175859cf068 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -72,8 +72,8 @@ public class PurpurConfig {
-         commands = new HashMap<>();
-         commands.put("purpur", new PurpurCommand("purpur"));
- 
--        version = getInt("config-version", 29);
--        set("config-version", 29);
-+        version = getInt("config-version", 30);
-+        set("config-version", 30);
- 
-         readConfig(PurpurConfig.class, null);
-     }
 @@ -278,14 +278,32 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;

--- a/patches/server/0182-Make-anvil-cumulative-cost-configurable.patch
+++ b/patches/server/0182-Make-anvil-cumulative-cost-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make anvil cumulative cost configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index c01faa0d2900230a323c7e1f41093c691fb394aa..0587d845531376676e38d43eadb016f5931a7fd0 100644
+index 15d1981b42539996e36ece3e6094f04f48902b9c..f7acd3c8d8296a3177d038f915d50e245124c0db 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-@@ -342,7 +342,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -343,7 +343,7 @@ public class AnvilMenu extends ItemCombinerMenu {
      }
  
      public static int calculateIncreasedRepairCost(int cost) {
@@ -18,7 +18,7 @@ index c01faa0d2900230a323c7e1f41093c691fb394aa..0587d845531376676e38d43eadb016f5
  
      public void setItemName(String newItemName) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 1463c422b4d3f94c58b6316da37a9af4b451f45e..d9ee324b4a7e903feeca1a31eb8cbd8317f76bef 100644
+index 18177e4140c58bb222cdff825296486d6be58e7c..c67d47334f673aef8f90d76f160cfbd3d7b3b122 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -262,6 +262,7 @@ public class PurpurConfig {

--- a/patches/server/0235-UPnP-Port-Forwarding.patch
+++ b/patches/server/0235-UPnP-Port-Forwarding.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] UPnP Port Forwarding
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index db39fd89be32f2f3d4d38b8e633f50a40bdd0235..b728506e933461bec663d5187e7c71ee2ba2acc3 100644
+index db66010c0106c8422fa8856a6cd7da3d183485de..0bc8f65bae27b4258cf2a72896c7b95fb5aa8461 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -293,6 +293,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -67,10 +67,10 @@ index 3f7b8e62bb79d8618f962af4ea5dbec9fffcdf4d..0af9a13501b8fcf2e008c5afb98a91c6
          // CraftBukkit start
          // this.setPlayerList(new DedicatedPlayerList(this, this.registryHolder, this.playerDataStorage)); // Spigot - moved up
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index edbda0b79ecce794254dc8e3e6e0847a20cf8fde..b4c7252e39a58312ed90e553a2a79a1ed768ce00 100644
+index 859a6fbbd99235016424ae2b7bbc20ce0484ad23..945c0fe5ec3dfc5dd05f779797d21469ddaddd33 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -420,4 +420,9 @@ public class PurpurConfig {
+@@ -434,4 +434,9 @@ public class PurpurConfig {
      private static void tpsCatchup() {
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }

--- a/patches/server/0250-Configurable-valid-characters-for-usernames.patch
+++ b/patches/server/0250-Configurable-valid-characters-for-usernames.patch
@@ -18,10 +18,10 @@ index 982a0bb5fc0a8d62e750926217dc36690709de8b..0a0f1da57fd85c521c84b127316a4816
              char c = in.charAt(i);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index b4c7252e39a58312ed90e553a2a79a1ed768ce00..1056b13937bebc5a8f20b78b0fdb7601d50a320e 100644
+index 945c0fe5ec3dfc5dd05f779797d21469ddaddd33..81980538e04f2d86d0198b6d6c89f748c32f138e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -425,4 +425,11 @@ public class PurpurConfig {
+@@ -439,4 +439,11 @@ public class PurpurConfig {
      private static void networkSettings() {
          useUPnP = getBoolean("settings.network.upnp-port-forwarding", useUPnP);
      }

--- a/patches/server/0251-Shears-can-have-looting-enchantment.patch
+++ b/patches/server/0251-Shears-can-have-looting-enchantment.patch
@@ -158,7 +158,7 @@ index 6b8a1535086aae7e4e3229d05615fb903188f507..60af917083de1b790b1d93d61835a669
      public int getMinCost(int level) {
          return 15 + (level - 1) * 9;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 1056b13937bebc5a8f20b78b0fdb7601d50a320e..db890f02f1b2359aecc8becf6a1caddf07cc7ce4 100644
+index 81980538e04f2d86d0198b6d6c89f748c32f138e..c46a141fb8eb1ee052bd9b4538efc2caeb570872 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -371,6 +371,7 @@ public class PurpurConfig {
@@ -167,13 +167,13 @@ index 1056b13937bebc5a8f20b78b0fdb7601d50a320e..db890f02f1b2359aecc8becf6a1caddf
      public static boolean allowCrossbowInfinity = false;
 +    public static boolean allowShearsLooting = false;
      public static boolean allowUnsafeEnchants = false;
-     public static boolean allowUnsafeEnchantCommand = false;
-     private static void enchantmentSettings() {
-@@ -381,6 +382,7 @@ public class PurpurConfig {
+     public static boolean allowInapplicableEnchants = true;
+     public static boolean allowIncompatibleEnchants = true;
+@@ -392,6 +393,7 @@ public class PurpurConfig {
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);
 +        allowShearsLooting = getBoolean("settings.enchantment.allow-looting-on-shears", allowShearsLooting);
-         allowUnsafeEnchants = getBoolean("settings.enchantment.allow-unsafe-enchants", allowUnsafeEnchants);
-         allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability
-     }
+         allowUnsafeEnchants = getBoolean("settings.enchantment.anvil.allow-unsafe-enchants", allowUnsafeEnchants);
+         allowInapplicableEnchants = getBoolean("settings.enchantment.anvil.allow-inapplicable-enchants", allowInapplicableEnchants);
+         allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);

--- a/patches/server/0259-Configurable-food-attributes.patch
+++ b/patches/server/0259-Configurable-food-attributes.patch
@@ -69,10 +69,10 @@ index 1ce51253b755c2ea4dca94c567935b074ffdbbd6..9814756a0a2aa11e15635954063c1355
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index af7ff4ace4a229fb255e88af1e367a8a1c8c900e..dc4bc16e191df0c9d22652873d545d2baca2e810 100644
+index c46a141fb8eb1ee052bd9b4538efc2caeb570872..13057b7ce15b356f3b039df5b2ddedb079bf9b08 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -434,4 +434,56 @@ public class PurpurConfig {
+@@ -448,4 +448,56 @@ public class PurpurConfig {
          String setPattern = getString("settings.username-valid-characters", defaultPattern);
          usernameValidCharactersPattern = java.util.regex.Pattern.compile(setPattern == null || setPattern.isBlank() ? defaultPattern : setPattern);
      }

--- a/patches/server/0260-Max-joins-per-second.patch
+++ b/patches/server/0260-Max-joins-per-second.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Max joins per second
 When this option is set to true the `max-joins-per-tick` setting in paper.yml will be used per second instead of per tick
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index c1e8d8674738eebaaf7bd918eacb5227a1331b67..fd23bb94194b94a203de8aa165096ebce11c2a63 100644
+index b65a3626d2e0817cd1e223ec3b10e82fa0339663..4b704fcce0951ffd3a8e29377f7b6893ed5bed87 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -545,11 +545,20 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -31,10 +31,10 @@ index c1e8d8674738eebaaf7bd918eacb5227a1331b67..fd23bb94194b94a203de8aa165096ebc
          }
          // Paper end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 5038d35ccb37a492d6a16242d876d18c02ccc35c..c482f598c79c8ff32fdcdf8cd1ac7920f4050862 100644
+index 13057b7ce15b356f3b039df5b2ddedb079bf9b08..64f27da6104ef4b247e1a73ee36eb0993566f052 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -424,8 +424,10 @@ public class PurpurConfig {
+@@ -438,8 +438,10 @@ public class PurpurConfig {
      }
  
      public static boolean useUPnP = false;

--- a/patches/server/0270-Add-toggle-for-enchant-level-clamping.patch
+++ b/patches/server/0270-Add-toggle-for-enchant-level-clamping.patch
@@ -31,20 +31,20 @@ index 4afa30753a90d9bbd3c71b21cb4a8deadf9ccb3b..1d79da7f8405f7dff3b2e10022a564a9
  
      @Nullable
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 8d4bd88270747bf905ce87573492382cb175d57b..127df4a4c5c84f5e260104a4cc8ef092f7cf9e07 100644
+index 5e69e2626c2e85c8ef8b29b556ebd81e27042122..ac6e4936b0ad1cef84eae68ebccb5279060d884b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -376,6 +376,7 @@ public class PurpurConfig {
-     public static boolean allowShearsLooting = false;
-     public static boolean allowUnsafeEnchants = false;
+@@ -379,6 +379,7 @@ public class PurpurConfig {
+     public static boolean allowIncompatibleEnchants = true;
+     public static boolean allowHigherEnchantsLevels = true;
      public static boolean allowUnsafeEnchantCommand = false;
 +    public static boolean clampEnchantLevels = true;
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -387,6 +388,7 @@ public class PurpurConfig {
-         allowShearsLooting = getBoolean("settings.enchantment.allow-looting-on-shears", allowShearsLooting);
-         allowUnsafeEnchants = getBoolean("settings.enchantment.allow-unsafe-enchants", allowUnsafeEnchants);
+@@ -401,6 +402,7 @@ public class PurpurConfig {
+         allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);
+         allowHigherEnchantsLevels = getBoolean("settings.enchantment.anvil.allow-higher-enchants-levels", allowHigherEnchantsLevels);
          allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability
 +        clampEnchantLevels = getBoolean("settings.enchantment.clamp-levels", clampEnchantLevels);
      }

--- a/patches/server/0277-Add-log-suppression-for-sent-expired-chat.patch
+++ b/patches/server/0277-Add-log-suppression-for-sent-expired-chat.patch
@@ -18,10 +18,10 @@ index 5868d67e0bc5a8f75b6719d727abac6f83a1513a..35b7e40810dce7fcde0e750df8ab8b6f
              }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index fecbd06816b3bd171a0a268bcda0cb545a893b1e..22b744c0b047e1fa071e08f7a030199b4d7544f0 100644
+index 72019819584bf7b48c7cdcbba569c0f7a9d1bfb2..093e994f7f7e78c5bb2e38324ff89e231e1da8ee 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -417,11 +417,13 @@ public class PurpurConfig {
+@@ -431,11 +431,13 @@ public class PurpurConfig {
      public static boolean loggerSuppressIgnoredAdvancementWarnings = false;
      public static boolean loggerSuppressUnrecognizedRecipeErrors = false;
      public static boolean loggerSuppressSetBlockFarChunk = false;

--- a/patches/server/0281-Option-to-disable-kick-for-out-of-order-chat.patch
+++ b/patches/server/0281-Option-to-disable-kick-for-out-of-order-chat.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Option to disable kick for out of order chat
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a7d1bd88ba6b36c2a80edad2e38471d72cba0451..91dadd78069d5e2a850d1aa6dd59149c3a527c2a 100644
+index 35b7e40810dce7fcde0e750df8ab8b6f8285c4e3..3bb51f34be4341c991487a78d8793f074ffdcba4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2268,7 +2268,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -18,10 +18,10 @@ index a7d1bd88ba6b36c2a80edad2e38471d72cba0451..91dadd78069d5e2a850d1aa6dd59149c
          } while (!this.lastChatTimeStamp.compareAndSet(instant1, timestamp));
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 22b744c0b047e1fa071e08f7a030199b4d7544f0..3bed3b7d7f35833b4d2d58ffb6900c707deb7c9b 100644
+index 093e994f7f7e78c5bb2e38324ff89e231e1da8ee..2cbf20aeb5d3a2c01c57f4bf525aef13f2a65ab3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -433,9 +433,11 @@ public class PurpurConfig {
+@@ -447,9 +447,11 @@ public class PurpurConfig {
  
      public static boolean useUPnP = false;
      public static boolean maxJoinsPerSecond = false;


### PR DESCRIPTION
`allowInapplicableEnchants` - allows applying, for example, sharpness to a pickaxe
`allowIncompatibleEnchants` - allows applying, for example, protection and fire protection at the same time
`allowHigherEnchantsLevels` - allows exceeding enchants' maximum levels, for example: Eff V + Eff V = Eff VI

`allowUnsafeEnchants` is required for all the following options to work