### PR TITLE
Add Player send death screen API

### DIFF
--- a/build-data/dev-imports.txt
+++ b/build-data/dev-imports.txt
@@ -8,3 +8,4 @@
 # To import classes from the vanilla Minecraft jar use `minecraft` as the artifactId:
 #     minecraft net.minecraft.world.level.entity.LevelEntityGetterAdapter
 #     minecraft net/minecraft/world/level/entity/LevelEntityGetter.java
+minecraft net.minecraft.network.protocol.game.ClientboundPlayerCombatKillPacket

--- a/build-data/dev-imports.txt
+++ b/build-data/dev-imports.txt
@@ -8,4 +8,3 @@
 # To import classes from the vanilla Minecraft jar use `minecraft` as the artifactId:
 #     minecraft net.minecraft.world.level.entity.LevelEntityGetterAdapter
 #     minecraft net/minecraft/world/level/entity/LevelEntityGetter.java
-minecraft net.minecraft.network.protocol.game.ClientboundPlayerCombatKillPacket

--- a/patches/api/0052-Add-death-screen-API.patch
+++ b/patches/api/0052-Add-death-screen-API.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Fri, 23 Sep 2022 18:35:28 -0700
+Subject: [PATCH] Add death screen API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index f50c61a8c375af03f3f0f5469e376e3f9c19f03e..872a1c0f4ac33ee6739b3d73ee99670da05e33c6 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -2948,5 +2948,21 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * Clears all debug block highlights
+      */
+     void clearBlockHighlights();
++
++    /**
++     * Sends a player the death screen with a specified death message.
++     *
++     * @param message The death message to show the player
++     */
++    void sendDeathScreen(@NotNull Component message);
++
++    /**
++     * Sends a player the death screen with a specified death message,
++     * along with the entity that caused the death.
++     *
++     * @param message The death message to show the player
++     * @param killer The entity that killed the player
++     */
++    void sendDeathScreen(@NotNull Component message, @Nullable Entity killer);
+     // Purpur end
+ }

--- a/patches/server/0299-Add-death-screen-API.patch
+++ b/patches/server/0299-Add-death-screen-API.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Fri, 23 Sep 2022 18:41:05 -0700
+Subject: [PATCH] Add death screen API
+
+
+diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerCombatKillPacket.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerCombatKillPacket.java
+index 53b75f5737a910ffc5448cd9a85eae57f9c1488f..ea95873dd034779e56a8b924cd27f9375be05daf 100644
+--- a/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerCombatKillPacket.java
++++ b/src/main/java/net/minecraft/network/protocol/game/ClientboundPlayerCombatKillPacket.java
+@@ -9,6 +9,7 @@ public class ClientboundPlayerCombatKillPacket implements Packet<ClientGamePacke
+     private final int playerId;
+     private final int killerId;
+     private final Component message;
++    public net.kyori.adventure.text.Component adventure$message; // Purpur
+ 
+     public ClientboundPlayerCombatKillPacket(CombatTracker damageTracker, Component message) {
+         this(damageTracker.getMob().getId(), damageTracker.getKillerId(), message);
+@@ -30,6 +31,12 @@ public class ClientboundPlayerCombatKillPacket implements Packet<ClientGamePacke
+     public void write(FriendlyByteBuf buf) {
+         buf.writeVarInt(this.playerId);
+         buf.writeInt(this.killerId);
++        // Purpur start
++        if (this.adventure$message != null) {
++            buf.writeComponent(this.adventure$message);
++            return;
++        }
++        // Purpur end
+         buf.writeComponent(this.message);
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 3b5ff0b3013a10b5515b13d1b660ec421531d772..c503b886013bc053d32b8afd8cd9bca09132a882 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -3026,5 +3026,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         if (this.getHandle().connection == null) return;
+         this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket(ClientboundCustomPayloadPacket.DEBUG_GAME_TEST_CLEAR, new FriendlyByteBuf(io.netty.buffer.Unpooled.buffer())));
+     }
++
++    @Override
++    public void sendDeathScreen(net.kyori.adventure.text.Component message) {
++        sendDeathScreen(message, null);
++    }
++
++    @Override
++    public void sendDeathScreen(net.kyori.adventure.text.Component message, org.bukkit.entity.Entity killer) {
++        if (this.getHandle().connection == null) return;
++        net.minecraft.network.protocol.game.ClientboundPlayerCombatKillPacket packet = new net.minecraft.network.protocol.game.ClientboundPlayerCombatKillPacket(getEntityId(), killer == null ? -1 : killer.getEntityId(), null);
++        packet.adventure$message = message;
++        this.getHandle().connection.send(packet);
++    }
+     // Purpur end
+ }


### PR DESCRIPTION
This pull request adds an API for sending fake player death screens to players via Player#sendDeathScreen. This method takes a Component argument for the message to be shown on the screen, along with an optional Entity for specifying the entity that killed the player. 