### PR TITLE
Add an option to disable the TPS limit

### DIFF
--- a/patches/server/0300-Add-option-to-disable-tps-limit.patch
+++ b/patches/server/0300-Add-option-to-disable-tps-limit.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Mon, 26 Sep 2022 07:50:30 -0700
+Subject: [PATCH] Add option to disable tps limit
+
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 24f767663b1190dcada3da554375e3a01064c462..e495349d349d096ca3a9110c4a4bc99f2b4f9325 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -1332,6 +1332,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+     // CraftBukkit end
+ 
+     protected void waitUntilNextTick() {
++        if (org.purpurmc.purpur.PurpurConfig.disableTpsLimit) return; // Purpur
+         //this.executeAll(); // Paper - move this into the tick method for timings
+         this.managedBlock(() -> {
+             return !this.canSleepForTickNoOversleep(); // Paper - move oversleep into full server tick
+diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+index d44b8ce90db7c6c27f71aa841d6fb64b159b7b42..95b4e802e078af706198f7f2e6d247d07504ad00 100644
+--- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
++++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+@@ -512,4 +512,8 @@ public class PurpurConfig {
+             }
+         });
+     }
++    public static boolean disableTpsLimit = false;
++    private static void disableTpsLimit() {
++        disableTpsLimit = getBoolean("settings.disable-tps-limit", disableTpsLimit);
++    }
+ }


### PR DESCRIPTION
This adds an option to disable the TPS limit by disabling the waitUntilNextTick method. This allows for more than 20 ticks per second.