### PR TITLE
Allow configuring block blast resistance

### DIFF
--- a/patches/server/0004-Purpur-config-files.patch
+++ b/patches/server/0004-Purpur-config-files.patch
@@ -172,10 +172,10 @@ index f30621be24c6c3a4f173436fce1ad1c13507c84f..e859f1078a42de196a69818a34a8b2c2
                          .withRequiredArg()
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5907e78bb059bca4a63ea8043d0be730412d9c13
+index 0000000000000000000000000000000000000000..f05a9d7542c9c1b6c67c5328215c0926a50bf806
 --- /dev/null
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -0,0 +1,173 @@
+@@ -0,0 +1,175 @@
 +package org.purpurmc.purpur;
 +
 +import co.aikar.timings.TimingsManager;
@@ -193,6 +193,7 @@ index 0000000000000000000000000000000000000000..5907e78bb059bca4a63ea8043d0be730
 +import net.minecraft.world.food.FoodProperties;
 +import net.minecraft.world.food.Foods;
 +import net.minecraft.world.item.enchantment.Enchantment;
++import net.minecraft.world.level.block.Block;
 +import net.minecraft.world.level.block.Blocks;
 +import org.bukkit.Bukkit;
 +import org.bukkit.command.Command;
@@ -208,6 +209,7 @@ index 0000000000000000000000000000000000000000..5907e78bb059bca4a63ea8043d0be730
 +import java.lang.reflect.Method;
 +import java.lang.reflect.Modifier;
 +import java.util.ArrayList;
++import java.util.Collections;
 +import java.util.HashMap;
 +import java.util.HashSet;
 +import java.util.List;

--- a/patches/server/0008-Ridables.patch
+++ b/patches/server/0008-Ridables.patch
@@ -5222,10 +5222,10 @@ index 03d389f3458cd77166a0319fa38c7207e8714e6f..cc0f6a51e10c77928fccf372a45a56aa
              event = new EntityDamageEvent(damagee.getBukkitEntity(), cause, modifiers, modifierFunctions);
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 5907e78bb059bca4a63ea8043d0be730412d9c13..b5d8d9475e563a77c9a7923fc4e780e0fe980347 100644
+index f05a9d7542c9c1b6c67c5328215c0926a50bf806..1c969433099b5b0f4f6f946291baea3e28722f9f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -170,4 +170,9 @@ public class PurpurConfig {
+@@ -172,4 +172,9 @@ public class PurpurConfig {
          }
          return builder.build();
      }

--- a/patches/server/0010-Barrels-and-enderchests-6-rows.patch
+++ b/patches/server/0010-Barrels-and-enderchests-6-rows.patch
@@ -236,10 +236,10 @@ index 30ac442049088200e9ab77a561c59cbc58aaa28f..fb3c3c32b89e6a99b50bd04163d29892
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index b5d8d9475e563a77c9a7923fc4e780e0fe980347..492fb7fc8452bb214566e1ca1ebfd0f3ee5fde9e 100644
+index 1c969433099b5b0f4f6f946291baea3e28722f9f..5bbfde1c69339f4ba1a0ed856b5de19742742c74 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -175,4 +175,39 @@ public class PurpurConfig {
+@@ -177,4 +177,39 @@ public class PurpurConfig {
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
      }

--- a/patches/server/0012-AFK-API.patch
+++ b/patches/server/0012-AFK-API.patch
@@ -255,10 +255,10 @@ index b158f3add91becadd8faad67e20791f16b58583d..a5bedcf16df7665e428bbfabfac31403
      // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 492fb7fc8452bb214566e1ca1ebfd0f3ee5fde9e..88b76a75623d306da3bb3d935e7598a94d882181 100644
+index 5bbfde1c69339f4ba1a0ed856b5de19742742c74..c55c434263e0b85fa75c23e943c3bfbc2e836c6c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -172,8 +172,16 @@ public class PurpurConfig {
+@@ -174,8 +174,16 @@ public class PurpurConfig {
      }
  
      public static String cannotRideMob = "<red>You cannot mount that mob";

--- a/patches/server/0014-Configurable-server-mod-name.patch
+++ b/patches/server/0014-Configurable-server-mod-name.patch
@@ -18,10 +18,10 @@ index 7f0551e70c545f8e77d18b11e836233faeba9161..ffa6466c21ddc6a312a0a3aa400717a4
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 88b76a75623d306da3bb3d935e7598a94d882181..fae76fe21abd4aa5911d9c2d6248c189104d3063 100644
+index c55c434263e0b85fa75c23e943c3bfbc2e836c6c..28b122a4c91ffa509359fd14eb2d232769bbdfd1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -184,6 +184,11 @@ public class PurpurConfig {
+@@ -186,6 +186,11 @@ public class PurpurConfig {
          afkTabListSuffix = getString("settings.messages.afk-tab-list-suffix", afkTabListSuffix);
      }
  

--- a/patches/server/0016-Lagging-threshold.patch
+++ b/patches/server/0016-Lagging-threshold.patch
@@ -40,10 +40,10 @@ index e25f6e051880327873ffbfbc81aaef924ac27b5b..e90a16c47de51752b7afb6cc7c320779
      // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index fae76fe21abd4aa5911d9c2d6248c189104d3063..bbe9d16183bba54d6b2869ab23a9683497d15b8a 100644
+index 28b122a4c91ffa509359fd14eb2d232769bbdfd1..80dee74274ba6a95029db8c812feeb2861ea9a36 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -189,6 +189,11 @@ public class PurpurConfig {
+@@ -191,6 +191,11 @@ public class PurpurConfig {
          serverModName = getString("settings.server-mod-name", serverModName);
      }
  

--- a/patches/server/0022-Alternative-Keepalive-Handling.patch
+++ b/patches/server/0022-Alternative-Keepalive-Handling.patch
@@ -56,10 +56,10 @@ index 3a2b67b459692a30feaec8362e44be5560741b55..c32ae28c75aaeb29a764f7791b47cb5f
          if (this.keepAlivePending && packet.getId() == this.keepAliveChallenge) {
              int i = (int) (Util.getMillis() - this.keepAliveTime);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index bbe9d16183bba54d6b2869ab23a9683497d15b8a..7f0cc9d6187babc7a1cb78557208cebf373ee75c 100644
+index 80dee74274ba6a95029db8c812feeb2861ea9a36..cf13e83614d63aaedab1590d88ca4e92b45aa7ed 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -194,6 +194,11 @@ public class PurpurConfig {
+@@ -196,6 +196,11 @@ public class PurpurConfig {
          laggingThreshold = getDouble("settings.lagging-threshold", laggingThreshold);
      }
  

--- a/patches/server/0026-Logger-settings-suppressing-pointless-logs.patch
+++ b/patches/server/0026-Logger-settings-suppressing-pointless-logs.patch
@@ -53,10 +53,10 @@ index b2a15c986c7500a0ce227a54cb61ec3f5378f6f3..14600a7bc01bf61e8ffb736816d23df6
          if (MinecraftServer.getServer() != null && MinecraftServer.getServer().isDebugging()) {
              new Exception().printStackTrace();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 7f0cc9d6187babc7a1cb78557208cebf373ee75c..8e620bd5a3984a3cc3751a7bd1bc06b67fbda0f2 100644
+index cf13e83614d63aaedab1590d88ca4e92b45aa7ed..7570a38e31a49a02b7e7414ee001c1bf9afcb0e5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -233,4 +233,15 @@ public class PurpurConfig {
+@@ -235,4 +235,15 @@ public class PurpurConfig {
          org.bukkit.event.inventory.InventoryType.ENDER_CHEST.setDefaultSize(enderChestSixRows ? 54 : 27);
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
      }

--- a/patches/server/0052-Configurable-TPS-Catchup.patch
+++ b/patches/server/0052-Configurable-TPS-Catchup.patch
@@ -24,10 +24,10 @@ index c1719af753e4efa8fcbd49a801ee86b307d27779..963a1998f808061c7e7fcd0d15725e38
                  this.profiler.pop();
                  this.endMetricsRecordingTick();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 8e620bd5a3984a3cc3751a7bd1bc06b67fbda0f2..520e266a1aea7240a0e56a1350f23ec28622d11c 100644
+index 7570a38e31a49a02b7e7414ee001c1bf9afcb0e5..21582b20db2364f4dc6bd87d76b907c9451633d5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -244,4 +244,9 @@ public class PurpurConfig {
+@@ -246,4 +246,9 @@ public class PurpurConfig {
          loggerSuppressUnrecognizedRecipeErrors = getBoolean("settings.logger.suppress-unrecognized-recipe-errors", loggerSuppressUnrecognizedRecipeErrors);
          loggerSuppressSetBlockFarChunk = getBoolean("settings.logger.suppress-setblock-in-far-chunk-errors", loggerSuppressSetBlockFarChunk);
      }

--- a/patches/server/0068-Add-ping-command.patch
+++ b/patches/server/0068-Add-ping-command.patch
@@ -17,10 +17,10 @@ index 98664c95331cee4139711c402dfaf406ee672c22..be38b98894cc24c9af55ba470dc8a03a
  
          if (environment.includeIntegrated) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 520e266a1aea7240a0e56a1350f23ec28622d11c..497e7ab73dffbc62e90249d0b7d44ea9b6d7e2d6 100644
+index 21582b20db2364f4dc6bd87d76b907c9451633d5..fe0d39b261f079aeef46d2019ad8613ac3d759a1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -176,12 +176,14 @@ public class PurpurConfig {
+@@ -178,12 +178,14 @@ public class PurpurConfig {
      public static String afkBroadcastBack = "<yellow><italic>%s is no longer AFK";
      public static String afkTabListPrefix = "[AFK] ";
      public static String afkTabListSuffix = "";

--- a/patches/server/0069-Add-demo-command.patch
+++ b/patches/server/0069-Add-demo-command.patch
@@ -17,10 +17,10 @@ index be38b98894cc24c9af55ba470dc8a03a24737782..7ffe76f2054259c4e564184bf28be3fe
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 497e7ab73dffbc62e90249d0b7d44ea9b6d7e2d6..665b9f9eeb469a1dc0b103577a4d67c914ec9b93 100644
+index fe0d39b261f079aeef46d2019ad8613ac3d759a1..be3dc04bb1ceb63344bb40c71a0411838b5ea0ca 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -176,6 +176,7 @@ public class PurpurConfig {
+@@ -178,6 +178,7 @@ public class PurpurConfig {
      public static String afkBroadcastBack = "<yellow><italic>%s is no longer AFK";
      public static String afkTabListPrefix = "[AFK] ";
      public static String afkTabListSuffix = "";
@@ -28,7 +28,7 @@ index 497e7ab73dffbc62e90249d0b7d44ea9b6d7e2d6..665b9f9eeb469a1dc0b103577a4d67c9
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
-@@ -183,6 +184,7 @@ public class PurpurConfig {
+@@ -185,6 +186,7 @@ public class PurpurConfig {
          afkBroadcastBack = getString("settings.messages.afk-broadcast-back", afkBroadcastBack);
          afkTabListPrefix = getString("settings.messages.afk-tab-list-prefix", afkTabListPrefix);
          afkTabListSuffix = getString("settings.messages.afk-tab-list-suffix", afkTabListSuffix);

--- a/patches/server/0070-Add-credits-command.patch
+++ b/patches/server/0070-Add-credits-command.patch
@@ -17,10 +17,10 @@ index 7ffe76f2054259c4e564184bf28be3fede1e7298..ab0f00128f8c1b13c3eb5787df0c4e26
              org.purpurmc.purpur.command.PingCommand.register(this.dispatcher); // Purpur
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 665b9f9eeb469a1dc0b103577a4d67c914ec9b93..779b52f7d59acefc0e2018be3de32b5ede57e9da 100644
+index be3dc04bb1ceb63344bb40c71a0411838b5ea0ca..a9f26ac2a605e2abc00378c4620c789a5878b8d1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -176,6 +176,7 @@ public class PurpurConfig {
+@@ -178,6 +178,7 @@ public class PurpurConfig {
      public static String afkBroadcastBack = "<yellow><italic>%s is no longer AFK";
      public static String afkTabListPrefix = "[AFK] ";
      public static String afkTabListSuffix = "";
@@ -28,7 +28,7 @@ index 665b9f9eeb469a1dc0b103577a4d67c914ec9b93..779b52f7d59acefc0e2018be3de32b5e
      public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      private static void messages() {
-@@ -184,6 +185,7 @@ public class PurpurConfig {
+@@ -186,6 +187,7 @@ public class PurpurConfig {
          afkBroadcastBack = getString("settings.messages.afk-broadcast-back", afkBroadcastBack);
          afkTabListPrefix = getString("settings.messages.afk-tab-list-prefix", afkTabListPrefix);
          afkTabListSuffix = getString("settings.messages.afk-tab-list-suffix", afkTabListSuffix);

--- a/patches/server/0076-Add-allow-water-in-end-world-option.patch
+++ b/patches/server/0076-Add-allow-water-in-end-world-option.patch
@@ -68,10 +68,10 @@ index 0afadbc8515d448b0ef817f4f0f53b1bb0abde43..c9daa26ab987249f390c64c9e26cd9ce
          } else {
              world.setBlockAndUpdate(pos, Blocks.WATER.defaultBlockState());
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 779b52f7d59acefc0e2018be3de32b5ede57e9da..fd975b2deed53c9feaecfa49e90bae5cfd42a195 100644
+index a9f26ac2a605e2abc00378c4620c789a5878b8d1..6e13d4d3d56f6da9b752bce9ac008eda639ac510 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -240,6 +240,11 @@ public class PurpurConfig {
+@@ -242,6 +242,11 @@ public class PurpurConfig {
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
      }
  

--- a/patches/server/0086-Add-option-to-disable-certain-block-updates.patch
+++ b/patches/server/0086-Add-option-to-disable-certain-block-updates.patch
@@ -125,10 +125,10 @@ index c14eb4f7decdbcd6176d3bff95d595a947d4ec95..58e8905a4b98e2e1ee372b99bdc3de98
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index fd975b2deed53c9feaecfa49e90bae5cfd42a195..6bacd879eb67ff6c5387882c0f590a7a8bd48717 100644
+index 6e13d4d3d56f6da9b752bce9ac008eda639ac510..84cb76a714db476e786c33424d20657ab21c3e05 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -245,6 +245,15 @@ public class PurpurConfig {
+@@ -247,6 +247,15 @@ public class PurpurConfig {
          allowWaterPlacementInTheEnd = getBoolean("settings.allow-water-placement-in-the-end", allowWaterPlacementInTheEnd);
      }
  

--- a/patches/server/0090-Short-enderman-height.patch
+++ b/patches/server/0090-Short-enderman-height.patch
@@ -31,10 +31,10 @@ index ad47267eb6797e1591841cb7a576fb65f6e81382..9458cab33d4ff468d3d009cc1c3b3736
              Entity entity = source.getDirectEntity();
              boolean flag;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 6bacd879eb67ff6c5387882c0f590a7a8bd48717..58e3ed111a17f6b5c093affc0c597c0b9aa27e9e 100644
+index 84cb76a714db476e786c33424d20657ab21c3e05..3b10d9b4e7d3034ca43e6e05b3bccccfe0162a4b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -240,6 +240,12 @@ public class PurpurConfig {
+@@ -242,6 +242,12 @@ public class PurpurConfig {
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
      }
  

--- a/patches/server/0092-Crying-obsidian-valid-for-portal-frames.patch
+++ b/patches/server/0092-Crying-obsidian-valid-for-portal-frames.patch
@@ -18,10 +18,10 @@ index 3414f3190e1a760c602613e82e551e797c3aa575..5368376c126f3b629c0448f937c140ab
      private final LevelAccessor level;
      private final Direction.Axis axis;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 58e3ed111a17f6b5c093affc0c597c0b9aa27e9e..ce64d05f8a5c970e5fcdce8e134e661d2d1617c6 100644
+index 3b10d9b4e7d3034ca43e6e05b3bccccfe0162a4b..bc7acc8399f99a7167a03b76cc69f3c9fef1d470 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -208,6 +208,7 @@ public class PurpurConfig {
+@@ -210,6 +210,7 @@ public class PurpurConfig {
      public static int barrelRows = 3;
      public static boolean enderChestSixRows = false;
      public static boolean enderChestPermissionRows = false;
@@ -29,7 +29,7 @@ index 58e3ed111a17f6b5c093affc0c597c0b9aa27e9e..ce64d05f8a5c970e5fcdce8e134e661d
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -238,6 +239,7 @@ public class PurpurConfig {
+@@ -240,6 +241,7 @@ public class PurpurConfig {
          enderChestSixRows = getBoolean("settings.blocks.ender_chest.six-rows", enderChestSixRows);
          org.bukkit.event.inventory.InventoryType.ENDER_CHEST.setDefaultSize(enderChestSixRows ? 54 : 27);
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);

--- a/patches/server/0104-Allow-infinite-and-mending-enchantments-together.patch
+++ b/patches/server/0104-Allow-infinite-and-mending-enchantments-together.patch
@@ -17,10 +17,10 @@ index 3aece8245060dd1ba269c08d226c84247a6f0a83..5cebd7c16b82eea9dbf39c51c671bacb
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index ce64d05f8a5c970e5fcdce8e134e661d2d1617c6..1ae4a6773af14a804fb144eda138dd0dd25e6f6b 100644
+index bc7acc8399f99a7167a03b76cc69f3c9fef1d470..94d62b88dcb6b98f3ad2e10eafa4ef782c825f4f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -242,6 +242,16 @@ public class PurpurConfig {
+@@ -244,6 +244,16 @@ public class PurpurConfig {
          cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
      }
  

--- a/patches/server/0117-EMC-Configurable-disable-give-dropping.patch
+++ b/patches/server/0117-EMC-Configurable-disable-give-dropping.patch
@@ -20,10 +20,10 @@ index 06e3a868e922f1b7a586d0ca28f64a67ae463b68..32beb045f990d4da6112da4fea295333
                          itemstack.setCount(1);
                          entityitem = entityplayer.drop(itemstack, false, false, false); // SPIGOT-2942: Add boolean to call event
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 1ae4a6773af14a804fb144eda138dd0dd25e6f6b..6a18c21653bb2146734cdbc552a31ce0c70545c7 100644
+index 94d62b88dcb6b98f3ad2e10eafa4ef782c825f4f..c4bdb9f2aab98d8915f4079f4815c10f97334f71 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -205,6 +205,11 @@ public class PurpurConfig {
+@@ -207,6 +207,11 @@ public class PurpurConfig {
          useAlternateKeepAlive = getBoolean("settings.use-alternate-keepalive", useAlternateKeepAlive);
      }
  

--- a/patches/server/0125-Implement-TPSBar.patch
+++ b/patches/server/0125-Implement-TPSBar.patch
@@ -104,10 +104,10 @@ index d0db1623c8132eb4c9a51b6e452280c56f544bf5..8182e9d69083ade08ae0b9c0512b8b7b
  
          entityplayer.awardStat(Stats.LEAVE_GAME);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 6a18c21653bb2146734cdbc552a31ce0c70545c7..cbe4d2d692edf29f9f6587871058fc1b3c53a731 100644
+index c4bdb9f2aab98d8915f4079f4815c10f97334f71..0507a090fb9122fdda4111fbd2ad3c51e4ef5c36 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -179,6 +179,7 @@ public class PurpurConfig {
+@@ -181,6 +181,7 @@ public class PurpurConfig {
      public static String creditsCommandOutput = "<green>%s has been shown the end credits";
      public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
@@ -115,7 +115,7 @@ index 6a18c21653bb2146734cdbc552a31ce0c70545c7..cbe4d2d692edf29f9f6587871058fc1b
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -188,6 +189,7 @@ public class PurpurConfig {
+@@ -190,6 +191,7 @@ public class PurpurConfig {
          creditsCommandOutput = getString("settings.messages.credits-command-output", creditsCommandOutput);
          demoCommandOutput = getString("settings.messages.demo-command-output", demoCommandOutput);
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
@@ -123,7 +123,7 @@ index 6a18c21653bb2146734cdbc552a31ce0c70545c7..cbe4d2d692edf29f9f6587871058fc1b
      }
  
      public static String serverModName = "Purpur";
-@@ -210,6 +212,29 @@ public class PurpurConfig {
+@@ -212,6 +214,29 @@ public class PurpurConfig {
          disableGiveCommandDrops = getBoolean("settings.disable-give-dropping", disableGiveCommandDrops);
      }
  

--- a/patches/server/0140-Dont-run-with-scissors.patch
+++ b/patches/server/0140-Dont-run-with-scissors.patch
@@ -70,10 +70,10 @@ index cc0f6a51e10c77928fccf372a45a56aa6f2b298a..f4ca0a9481533befc78cb18c1f981082
  
          if (cause != null) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index cbe4d2d692edf29f9f6587871058fc1b3c53a731..bbc5d5af660b2aba16b02a9f8b33c8776f12ddba 100644
+index 0507a090fb9122fdda4111fbd2ad3c51e4ef5c36..0d40cd506342c006bddc769c57f11d34ccb00dc7 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -180,6 +180,7 @@ public class PurpurConfig {
+@@ -182,6 +182,7 @@ public class PurpurConfig {
      public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
@@ -81,7 +81,7 @@ index cbe4d2d692edf29f9f6587871058fc1b3c53a731..bbc5d5af660b2aba16b02a9f8b33c877
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -190,6 +191,12 @@ public class PurpurConfig {
+@@ -192,6 +193,12 @@ public class PurpurConfig {
          demoCommandOutput = getString("settings.messages.demo-command-output", demoCommandOutput);
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);

--- a/patches/server/0154-Allow-infinity-on-crossbows.patch
+++ b/patches/server/0154-Allow-infinity-on-crossbows.patch
@@ -77,10 +77,10 @@ index 873185fd4d4c994130f2e7c271b3e03cefb2278c..a371bbe337daf9abce320ce0d8c21fa3
              return null;
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index bbc5d5af660b2aba16b02a9f8b33c8776f12ddba..f1c2e2c05000ee80982c23e402f067feed0fcdca 100644
+index 0d40cd506342c006bddc769c57f11d34ccb00dc7..1659f76cfffab544b91cd1e6237047873ccfe256 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -280,6 +280,7 @@ public class PurpurConfig {
+@@ -282,6 +282,7 @@ public class PurpurConfig {
      }
  
      public static boolean allowInfinityMending = false;
@@ -88,7 +88,7 @@ index bbc5d5af660b2aba16b02a9f8b33c8776f12ddba..f1c2e2c05000ee80982c23e402f067fe
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -287,6 +288,7 @@ public class PurpurConfig {
+@@ -289,6 +290,7 @@ public class PurpurConfig {
              set("settings.enchantment.allow-infinite-and-mending-together", null);
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);

--- a/patches/server/0160-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0160-Config-to-allow-for-unsafe-enchants.patch
@@ -87,10 +87,10 @@ index 2b2115d218a279245f8be5e0c93a2b6200f81241..f7017c330ee2d8e17ab2be294865d7e3
          this.getOrCreateTag().put(key, element);
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index f1c2e2c05000ee80982c23e402f067feed0fcdca..24ec95be5f8bfe2a277ba74920063cc364972462 100644
+index 1659f76cfffab544b91cd1e6237047873ccfe256..09198dd9db8f39fadf95d58fddb70a9104b79e6c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -281,14 +281,32 @@ public class PurpurConfig {
+@@ -283,14 +283,32 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;

--- a/patches/server/0165-Config-to-change-max-number-of-bees.patch
+++ b/patches/server/0165-Config-to-change-max-number-of-bees.patch
@@ -18,10 +18,10 @@ index 41c9f074203915c31c1ae7a160ce509c13383f84..a16a1df28258d605cf5908dbe19bda5d
      public BeehiveBlockEntity(BlockPos pos, BlockState state) {
          super(BlockEntityType.BEEHIVE, pos, state);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 24ec95be5f8bfe2a277ba74920063cc364972462..00ea97ba3e62c73237eefb74c1e72b2eb1849843 100644
+index 09198dd9db8f39fadf95d58fddb70a9104b79e6c..fd9197f874bb67da3664a680347ca55329798afc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -246,6 +246,7 @@ public class PurpurConfig {
+@@ -248,6 +248,7 @@ public class PurpurConfig {
      public static boolean enderChestSixRows = false;
      public static boolean enderChestPermissionRows = false;
      public static boolean cryingObsidianValidForPortalFrame = false;
@@ -29,7 +29,7 @@ index 24ec95be5f8bfe2a277ba74920063cc364972462..00ea97ba3e62c73237eefb74c1e72b2e
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -277,6 +278,7 @@ public class PurpurConfig {
+@@ -279,6 +280,7 @@ public class PurpurConfig {
          org.bukkit.event.inventory.InventoryType.ENDER_CHEST.setDefaultSize(enderChestSixRows ? 54 : 27);
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
          cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);

--- a/patches/server/0167-Gamemode-extra-permissions.patch
+++ b/patches/server/0167-Gamemode-extra-permissions.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Gamemode extra permissions
 
 
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
-index 40f6d9845d2405c6e54c5213618e1b21016e3d3f..c2f32e65b44c60395661fb9f6eb8939ac7bea2ab 100644
+index ed64b78bc8510fbe8fda9a10b779e91d99313676..e7c51725d5c04cc9da1bd1d2e12392ca07264609 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
 +++ b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 @@ -213,6 +213,21 @@ public class CommandSourceStack implements SharedSuggestionProvider, com.destroy
@@ -75,10 +75,10 @@ index 0467419fc8a06c241a46216c8f8c32abeb9fbc26..bc178d7305f38b77393b827d7b71412d
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "defaultgamemode", "Allows the user to change the default gamemode of the server", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "seed", "Allows the user to view the seed of the world", PermissionDefault.OP, commands);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 00ea97ba3e62c73237eefb74c1e72b2eb1849843..52b9ee1c3a81986a591ab5c01a375ef7ca69973d 100644
+index fd9197f874bb67da3664a680347ca55329798afc..7aed631fca099bf5302bf705e0a20cf53d428350 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -229,6 +229,7 @@ public class PurpurConfig {
+@@ -231,6 +231,7 @@ public class PurpurConfig {
      public static String commandTPSBarTextColorMedium = "<gradient:#ffff55:#ffaa00><text></gradient>";
      public static String commandTPSBarTextColorLow = "<gradient:#ff5555:#aa0000><text></gradient>";
      public static int commandTPSBarTickInterval = 20;
@@ -86,7 +86,7 @@ index 00ea97ba3e62c73237eefb74c1e72b2eb1849843..52b9ee1c3a81986a591ab5c01a375ef7
      private static void commandSettings() {
          commandTPSBarTitle = getString("settings.command.tpsbar.title", commandTPSBarTitle);
          commandTPSBarProgressOverlay = BossBar.Overlay.valueOf(getString("settings.command.tpsbar.overlay", commandTPSBarProgressOverlay.name()));
-@@ -240,6 +241,7 @@ public class PurpurConfig {
+@@ -242,6 +243,7 @@ public class PurpurConfig {
          commandTPSBarTextColorMedium = getString("settings.command.tpsbar.text-color.medium", commandTPSBarTextColorMedium);
          commandTPSBarTextColorLow = getString("settings.command.tpsbar.text-color.low", commandTPSBarTextColorLow);
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);

--- a/patches/server/0170-Configurable-broadcast-settings.patch
+++ b/patches/server/0170-Configurable-broadcast-settings.patch
@@ -29,10 +29,10 @@ index 5d989ef08080bc6622b64b1eea8ae63ac59dfa4d..93afb1cb8c0980a2a66590a27de28fd7
                  if (scoreboardteambase.getDeathMessageVisibility() == Team.Visibility.HIDE_FOR_OTHER_TEAMS) {
                      this.server.getPlayerList().broadcastSystemToTeam(this, ichatbasecomponent);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 52b9ee1c3a81986a591ab5c01a375ef7ca69973d..676980f83b7b0ca109f7887096e682bbc50dfe56 100644
+index 7aed631fca099bf5302bf705e0a20cf53d428350..37e72dc1a0434b98a730183a0b5cb10aac612be4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -199,6 +199,18 @@ public class PurpurConfig {
+@@ -201,6 +201,18 @@ public class PurpurConfig {
          deathMsgRunWithScissors = getString("settings.messages.death-message.run-with-scissors", deathMsgRunWithScissors);
      }
  

--- a/patches/server/0172-Hide-hidden-players-from-entity-selector.patch
+++ b/patches/server/0172-Hide-hidden-players-from-entity-selector.patch
@@ -59,10 +59,10 @@ index 35cc3bba20afd4a47160cc674415ba6a3a0ec0ec..2cba35dcc479ed9ad3e698aa2e02b4aa
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 676980f83b7b0ca109f7887096e682bbc50dfe56..184928f0309877898d476c857761aa02897b2fab 100644
+index 37e72dc1a0434b98a730183a0b5cb10aac612be4..8ebc3d35973124928985beebea2ed581f0c5fc2e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -242,6 +242,7 @@ public class PurpurConfig {
+@@ -244,6 +244,7 @@ public class PurpurConfig {
      public static String commandTPSBarTextColorLow = "<gradient:#ff5555:#aa0000><text></gradient>";
      public static int commandTPSBarTickInterval = 20;
      public static boolean commandGamemodeRequiresPermission = false;
@@ -70,7 +70,7 @@ index 676980f83b7b0ca109f7887096e682bbc50dfe56..184928f0309877898d476c857761aa02
      private static void commandSettings() {
          commandTPSBarTitle = getString("settings.command.tpsbar.title", commandTPSBarTitle);
          commandTPSBarProgressOverlay = BossBar.Overlay.valueOf(getString("settings.command.tpsbar.overlay", commandTPSBarProgressOverlay.name()));
-@@ -254,6 +255,7 @@ public class PurpurConfig {
+@@ -256,6 +257,7 @@ public class PurpurConfig {
          commandTPSBarTextColorLow = getString("settings.command.tpsbar.text-color.low", commandTPSBarTextColorLow);
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);
          commandGamemodeRequiresPermission = getBoolean("settings.command.gamemode.requires-specific-permission", commandGamemodeRequiresPermission);

--- a/patches/server/0179-Config-for-unverified-username-message.patch
+++ b/patches/server/0179-Config-for-unverified-username-message.patch
@@ -18,10 +18,10 @@ index b607f5ccbce10570f827dd21eb38504f42781d2f..a0f34f6b4df45367a4bc740409eb7045
                      }
                  } catch (AuthenticationUnavailableException authenticationunavailableexception) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 184928f0309877898d476c857761aa02897b2fab..d40e2d86a689bd429f91ec57150f3cdea2aa98f5 100644
+index 8ebc3d35973124928985beebea2ed581f0c5fc2e..91183b9bb61e72ea229ea811924cef836741146f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -181,6 +181,7 @@ public class PurpurConfig {
+@@ -183,6 +183,7 @@ public class PurpurConfig {
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
@@ -29,7 +29,7 @@ index 184928f0309877898d476c857761aa02897b2fab..d40e2d86a689bd429f91ec57150f3cde
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -192,6 +193,7 @@ public class PurpurConfig {
+@@ -194,6 +195,7 @@ public class PurpurConfig {
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);

--- a/patches/server/0180-Make-anvil-cumulative-cost-configurable.patch
+++ b/patches/server/0180-Make-anvil-cumulative-cost-configurable.patch
@@ -18,10 +18,10 @@ index 33c33a953cdd47c30720225b10a5378f16daf225..0ecda463452a3f9205dfbd97f28ae7cf
  
      public void setItemName(String newItemName) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index d40e2d86a689bd429f91ec57150f3cdea2aa98f5..3146653b274b17ba73ec66b254e15bf7f4fb81d2 100644
+index 91183b9bb61e72ea229ea811924cef836741146f..6faac76d7874d890b92c1a3ce5d974e74bed2de0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -265,6 +265,7 @@ public class PurpurConfig {
+@@ -267,6 +267,7 @@ public class PurpurConfig {
      public static boolean enderChestPermissionRows = false;
      public static boolean cryingObsidianValidForPortalFrame = false;
      public static int beeInsideBeeHive = 3;
@@ -29,7 +29,7 @@ index d40e2d86a689bd429f91ec57150f3cdea2aa98f5..3146653b274b17ba73ec66b254e15bf7
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -297,6 +298,7 @@ public class PurpurConfig {
+@@ -299,6 +300,7 @@ public class PurpurConfig {
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
          cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);

--- a/patches/server/0189-Make-lightning-rod-range-configurable.patch
+++ b/patches/server/0189-Make-lightning-rod-range-configurable.patch
@@ -18,10 +18,10 @@ index 9dc317d471ce6eab24e0ebec729cea1dbed8b2ec..a7820becea1e46154975f4cd7b8e8d24
          return optional.map((blockposition1) -> {
              return blockposition1.above(1);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 3146653b274b17ba73ec66b254e15bf7f4fb81d2..9d6e1e62b4a2754826ab58c9eafe2d03e538a940 100644
+index 6faac76d7874d890b92c1a3ce5d974e74bed2de0..fb1de9b8f860cc1b7b63521ba48ee22db0a15699 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -266,6 +266,7 @@ public class PurpurConfig {
+@@ -268,6 +268,7 @@ public class PurpurConfig {
      public static boolean cryingObsidianValidForPortalFrame = false;
      public static int beeInsideBeeHive = 3;
      public static boolean anvilCumulativeCost = true;
@@ -29,7 +29,7 @@ index 3146653b274b17ba73ec66b254e15bf7f4fb81d2..9d6e1e62b4a2754826ab58c9eafe2d03
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -299,6 +300,7 @@ public class PurpurConfig {
+@@ -301,6 +302,7 @@ public class PurpurConfig {
          cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
          anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);

--- a/patches/server/0199-Add-uptime-command.patch
+++ b/patches/server/0199-Add-uptime-command.patch
@@ -29,10 +29,10 @@ index 03d0cc6c69164e196d5db2bf56a7136a9e4a5c79..fa2812d94045e5d49fdd9990eac91897
      public int autosavePeriod;
      public Commands vanillaCommandDispatcher;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 9d6e1e62b4a2754826ab58c9eafe2d03e538a940..c845ad46d8741f38ee88422aff26cb6cc98550a9 100644
+index fb1de9b8f860cc1b7b63521ba48ee22db0a15699..dfdbbb133b427cf005e76a28f85b041ee930a98c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -181,6 +181,7 @@ public class PurpurConfig {
+@@ -183,6 +183,7 @@ public class PurpurConfig {
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
@@ -40,7 +40,7 @@ index 9d6e1e62b4a2754826ab58c9eafe2d03e538a940..c845ad46d8741f38ee88422aff26cb6c
      public static String unverifiedUsername = "default";
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
-@@ -193,6 +194,7 @@ public class PurpurConfig {
+@@ -195,6 +196,7 @@ public class PurpurConfig {
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);
@@ -48,7 +48,7 @@ index 9d6e1e62b4a2754826ab58c9eafe2d03e538a940..c845ad46d8741f38ee88422aff26cb6c
          unverifiedUsername = getString("settings.messages.unverified-username", unverifiedUsername);
      }
  
-@@ -245,6 +247,15 @@ public class PurpurConfig {
+@@ -247,6 +249,15 @@ public class PurpurConfig {
      public static int commandTPSBarTickInterval = 20;
      public static boolean commandGamemodeRequiresPermission = false;
      public static boolean hideHiddenPlayersFromEntitySelector = false;
@@ -64,7 +64,7 @@ index 9d6e1e62b4a2754826ab58c9eafe2d03e538a940..c845ad46d8741f38ee88422aff26cb6c
      private static void commandSettings() {
          commandTPSBarTitle = getString("settings.command.tpsbar.title", commandTPSBarTitle);
          commandTPSBarProgressOverlay = BossBar.Overlay.valueOf(getString("settings.command.tpsbar.overlay", commandTPSBarProgressOverlay.name()));
-@@ -258,6 +269,15 @@ public class PurpurConfig {
+@@ -260,6 +271,15 @@ public class PurpurConfig {
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);
          commandGamemodeRequiresPermission = getBoolean("settings.command.gamemode.requires-specific-permission", commandGamemodeRequiresPermission);
          hideHiddenPlayersFromEntitySelector = getBoolean("settings.command.hide-hidden-players-from-entity-selector", hideHiddenPlayersFromEntitySelector);

--- a/patches/server/0200-Structure-seed-options.patch
+++ b/patches/server/0200-Structure-seed-options.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Structure seed options
 
 
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index c845ad46d8741f38ee88422aff26cb6cc98550a9..60d6fb8bea923026c8bda8b27bd5de4979270172 100644
+index dfdbbb133b427cf005e76a28f85b041ee930a98c..637a8ff846f0a90bee9789937ff21700af48a79b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -215,6 +215,23 @@ public class PurpurConfig {
+@@ -217,6 +217,23 @@ public class PurpurConfig {
          deathMessageOnlyBroadcastToAffectedPlayer = getBoolean("settings.broadcasts.death.only-broadcast-to-affected-player", deathMessageOnlyBroadcastToAffectedPlayer);
      }
  

--- a/patches/server/0204-Customizable-sleeping-actionbar-messages.patch
+++ b/patches/server/0204-Customizable-sleeping-actionbar-messages.patch
@@ -38,10 +38,10 @@ index a7820becea1e46154975f4cd7b8e8d24f9f0e4ad..66ab18b0654b1408fae1a5948290d44d
                  }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 60d6fb8bea923026c8bda8b27bd5de4979270172..d8de85a7b7d2b622401003c0a06f2ddc3848e8df 100644
+index 637a8ff846f0a90bee9789937ff21700af48a79b..695e6376fcf3306be49e593126576c1773b5792e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -183,6 +183,8 @@ public class PurpurConfig {
+@@ -185,6 +185,8 @@ public class PurpurConfig {
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
      public static String uptimeCommandOutput = "<green>Server uptime is <uptime>";
      public static String unverifiedUsername = "default";
@@ -50,7 +50,7 @@ index 60d6fb8bea923026c8bda8b27bd5de4979270172..d8de85a7b7d2b622401003c0a06f2ddc
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -196,6 +198,8 @@ public class PurpurConfig {
+@@ -198,6 +200,8 @@ public class PurpurConfig {
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);
          uptimeCommandOutput = getString("settings.messages.uptime-command-output", uptimeCommandOutput);
          unverifiedUsername = getString("settings.messages.unverified-username", unverifiedUsername);

--- a/patches/server/0210-Add-compass-command.patch
+++ b/patches/server/0210-Add-compass-command.patch
@@ -59,10 +59,10 @@ index 93afb1cb8c0980a2a66590a27de28fd79595635b..40dc37c7acabc8eb601035d5a61cf09e
      // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index d8de85a7b7d2b622401003c0a06f2ddc3848e8df..bd3bc984b885fe236927fb559bb05d9556edbe89 100644
+index 695e6376fcf3306be49e593126576c1773b5792e..bf3bbe2d26f5ce6e6b00b36d9ea269df7d19e92d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -266,6 +266,11 @@ public class PurpurConfig {
+@@ -268,6 +268,11 @@ public class PurpurConfig {
      public static String commandTPSBarTextColorMedium = "<gradient:#ffff55:#ffaa00><text></gradient>";
      public static String commandTPSBarTextColorLow = "<gradient:#ff5555:#aa0000><text></gradient>";
      public static int commandTPSBarTickInterval = 20;
@@ -74,7 +74,7 @@ index d8de85a7b7d2b622401003c0a06f2ddc3848e8df..bd3bc984b885fe236927fb559bb05d95
      public static boolean commandGamemodeRequiresPermission = false;
      public static boolean hideHiddenPlayersFromEntitySelector = false;
      public static String uptimeFormat = "<days><hours><minutes><seconds>";
-@@ -288,6 +293,13 @@ public class PurpurConfig {
+@@ -290,6 +295,13 @@ public class PurpurConfig {
          commandTPSBarTextColorMedium = getString("settings.command.tpsbar.text-color.medium", commandTPSBarTextColorMedium);
          commandTPSBarTextColorLow = getString("settings.command.tpsbar.text-color.low", commandTPSBarTextColorLow);
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);

--- a/patches/server/0232-Config-for-grindstones.patch
+++ b/patches/server/0232-Config-for-grindstones.patch
@@ -57,10 +57,10 @@ index 740b778ce14f241e509f17c3a84b9ed47cdeeebe..36a6db1752fbde0e071af0da8c212c5c
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index bd3bc984b885fe236927fb559bb05d9556edbe89..b2c68a0c9cc8e88a24dbaf01c90cec76eaaa4e9b 100644
+index bf3bbe2d26f5ce6e6b00b36d9ea269df7d19e92d..8322e9135188877471f78c3310cdbc3df758b67f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -320,6 +320,9 @@ public class PurpurConfig {
+@@ -322,6 +322,9 @@ public class PurpurConfig {
      public static int beeInsideBeeHive = 3;
      public static boolean anvilCumulativeCost = true;
      public static int lightningRodRange = 128;
@@ -70,7 +70,7 @@ index bd3bc984b885fe236927fb559bb05d9556edbe89..b2c68a0c9cc8e88a24dbaf01c90cec76
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -354,6 +357,19 @@ public class PurpurConfig {
+@@ -356,6 +359,19 @@ public class PurpurConfig {
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
          anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);
          lightningRodRange = getInt("settings.blocks.lightning_rod.range", lightningRodRange);

--- a/patches/server/0233-UPnP-Port-Forwarding.patch
+++ b/patches/server/0233-UPnP-Port-Forwarding.patch
@@ -67,10 +67,10 @@ index f69d1f11fffbca1ddd297e3793f1bcfe34f2a200..a9239a705fa7c9bd8d2fe7990cc456c5
          // CraftBukkit start
          // this.setPlayerList(new DedicatedPlayerList(this, this.registryHolder, this.playerDataStorage)); // Spigot - moved up
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index b2c68a0c9cc8e88a24dbaf01c90cec76eaaa4e9b..94c9c6717e5e397243a5b735d15210b928957827 100644
+index 8322e9135188877471f78c3310cdbc3df758b67f..d1d9f930374ce97690306e0b39a0be8798e2f76c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -437,4 +437,9 @@ public class PurpurConfig {
+@@ -439,4 +439,9 @@ public class PurpurConfig {
      private static void tpsCatchup() {
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }

--- a/patches/server/0239-Kelp-cave-weeping-and-twisting-vines-configurable-ma.patch
+++ b/patches/server/0239-Kelp-cave-weeping-and-twisting-vines-configurable-ma.patch
@@ -135,10 +135,10 @@ index e5c135ec059746b75fe58516809584221285cdbe..713c7e6e31a3e1097b612c77a4fce147
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 94c9c6717e5e397243a5b735d15210b928957827..0d73e8a06a8b7ce1db080396c8c8e6fc2b3c1c52 100644
+index d1d9f930374ce97690306e0b39a0be8798e2f76c..a20bdf37795a46324bbecfff51e7bd3e699e1fe0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -323,6 +323,10 @@ public class PurpurConfig {
+@@ -325,6 +325,10 @@ public class PurpurConfig {
      public static Set<Enchantment> grindstoneIgnoredEnchants = new HashSet<>();
      public static boolean grindstoneRemoveAttributes = false;
      public static boolean grindstoneRemoveDisplay = false;
@@ -149,7 +149,7 @@ index 94c9c6717e5e397243a5b735d15210b928957827..0d73e8a06a8b7ce1db080396c8c8e6fc
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -370,6 +374,30 @@ public class PurpurConfig {
+@@ -372,6 +376,30 @@ public class PurpurConfig {
          });
          grindstoneRemoveAttributes = getBoolean("settings.blocks.grindstone.remove-attributes", grindstoneRemoveAttributes);
          grindstoneRemoveDisplay = getBoolean("settings.blocks.grindstone.remove-name-and-lore", grindstoneRemoveDisplay);

--- a/patches/server/0248-Configurable-valid-characters-for-usernames.patch
+++ b/patches/server/0248-Configurable-valid-characters-for-usernames.patch
@@ -18,10 +18,10 @@ index a0f34f6b4df45367a4bc740409eb704531fe821a..68903862b8b9485f29d2e0da28250574
              char c = in.charAt(i);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 0d73e8a06a8b7ce1db080396c8c8e6fc2b3c1c52..fd529c1cecb63fb9de855d6cd35835112bb5cd42 100644
+index a20bdf37795a46324bbecfff51e7bd3e699e1fe0..0afd94f41863e4edf39e31bb9ba15a1695ab26d5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -470,4 +470,11 @@ public class PurpurConfig {
+@@ -472,4 +472,11 @@ public class PurpurConfig {
      private static void networkSettings() {
          useUPnP = getBoolean("settings.network.upnp-port-forwarding", useUPnP);
      }

--- a/patches/server/0249-Shears-can-have-looting-enchantment.patch
+++ b/patches/server/0249-Shears-can-have-looting-enchantment.patch
@@ -158,10 +158,10 @@ index 6b8a1535086aae7e4e3229d05615fb903188f507..60af917083de1b790b1d93d61835a669
      public int getMinCost(int level) {
          return 15 + (level - 1) * 9;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index fd529c1cecb63fb9de855d6cd35835112bb5cd42..aa01a500483daf175054f90def45a45cdacc856f 100644
+index 0afd94f41863e4edf39e31bb9ba15a1695ab26d5..73c2ae25ec8b556a1fdac9a30a3863d6ebaccac8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -402,6 +402,7 @@ public class PurpurConfig {
+@@ -404,6 +404,7 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
@@ -169,7 +169,7 @@ index fd529c1cecb63fb9de855d6cd35835112bb5cd42..aa01a500483daf175054f90def45a45c
      public static boolean allowUnsafeEnchants = false;
      public static boolean allowInapplicableEnchants = true;
      public static boolean allowIncompatibleEnchants = true;
-@@ -423,6 +424,7 @@ public class PurpurConfig {
+@@ -425,6 +426,7 @@ public class PurpurConfig {
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);

--- a/patches/server/0257-Configurable-food-attributes.patch
+++ b/patches/server/0257-Configurable-food-attributes.patch
@@ -69,10 +69,10 @@ index fcdd30f38bc57cc382a47d99e3c31f9348ca12c3..e0b5af2d83a0ee5a04e10dd54936a173
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index aa01a500483daf175054f90def45a45cdacc856f..668066e2298eed6de118ff059ea469fa240e9ba9 100644
+index 73c2ae25ec8b556a1fdac9a30a3863d6ebaccac8..44d710e0710afbd99bb9569e40e21e1ffe3d2ece 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -479,4 +479,56 @@ public class PurpurConfig {
+@@ -481,4 +481,56 @@ public class PurpurConfig {
          String setPattern = getString("settings.username-valid-characters", defaultPattern);
          usernameValidCharactersPattern = java.util.regex.Pattern.compile(setPattern == null || setPattern.isBlank() ? defaultPattern : setPattern);
      }

--- a/patches/server/0258-Max-joins-per-second.patch
+++ b/patches/server/0258-Max-joins-per-second.patch
@@ -31,10 +31,10 @@ index 6967c90c50ea75fb9dd5da808b2c8c8ea046ecec..e1563410e0711de5cf9363978125e637
          }
          // Paper end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 668066e2298eed6de118ff059ea469fa240e9ba9..48cdfb5e6b63bdcaeebeef87a25e3331d45a62cc 100644
+index 44d710e0710afbd99bb9569e40e21e1ffe3d2ece..6cb9acea12fdc75ea540096dc84f91e8ba9c6236 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -469,8 +469,10 @@ public class PurpurConfig {
+@@ -471,8 +471,10 @@ public class PurpurConfig {
      }
  
      public static boolean useUPnP = false;

--- a/patches/server/0262-Fill-command-max-area-option.patch
+++ b/patches/server/0262-Fill-command-max-area-option.patch
@@ -22,10 +22,10 @@ index 99fbb24dabe867ed4956a2996543107f58a57193..5c81c64540579fbacc335a3fadf4bf59
              List<BlockPos> list = Lists.newArrayList();
              ServerLevel serverLevel = source.getLevel();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 48cdfb5e6b63bdcaeebeef87a25e3331d45a62cc..4e80eca63546a8bb7bee9564e068b29cf13146db 100644
+index 6cb9acea12fdc75ea540096dc84f91e8ba9c6236..65f2c37e667f78c4f2bb59e5db7f870d2534513a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -272,6 +272,7 @@ public class PurpurConfig {
+@@ -274,6 +274,7 @@ public class PurpurConfig {
      public static float commandCompassBarProgressPercent = 1.0F;
      public static int commandCompassBarTickInterval = 5;
      public static boolean commandGamemodeRequiresPermission = false;
@@ -33,7 +33,7 @@ index 48cdfb5e6b63bdcaeebeef87a25e3331d45a62cc..4e80eca63546a8bb7bee9564e068b29c
      public static boolean hideHiddenPlayersFromEntitySelector = false;
      public static String uptimeFormat = "<days><hours><minutes><seconds>";
      public static String uptimeDay = "%02d day, ";
-@@ -301,6 +302,7 @@ public class PurpurConfig {
+@@ -303,6 +304,7 @@ public class PurpurConfig {
          commandCompassBarTickInterval = getInt("settings.command.compass.tick-interval", commandCompassBarTickInterval);
  
          commandGamemodeRequiresPermission = getBoolean("settings.command.gamemode.requires-specific-permission", commandGamemodeRequiresPermission);

--- a/patches/server/0268-Add-toggle-for-enchant-level-clamping.patch
+++ b/patches/server/0268-Add-toggle-for-enchant-level-clamping.patch
@@ -31,10 +31,10 @@ index 4afa30753a90d9bbd3c71b21cb4a8deadf9ccb3b..1d79da7f8405f7dff3b2e10022a564a9
  
      @Nullable
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 4e80eca63546a8bb7bee9564e068b29cf13146db..46b6a8d0e833f6e92076752f7af8f8dc597292bf 100644
+index 65f2c37e667f78c4f2bb59e5db7f870d2534513a..6ae12d6684620a0e524294b28a5abcbc53392089 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -410,6 +410,7 @@ public class PurpurConfig {
+@@ -412,6 +412,7 @@ public class PurpurConfig {
      public static boolean allowIncompatibleEnchants = true;
      public static boolean allowHigherEnchantsLevels = true;
      public static boolean allowUnsafeEnchantCommand = false;
@@ -42,7 +42,7 @@ index 4e80eca63546a8bb7bee9564e068b29cf13146db..46b6a8d0e833f6e92076752f7af8f8dc
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -432,6 +433,7 @@ public class PurpurConfig {
+@@ -434,6 +435,7 @@ public class PurpurConfig {
          allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);
          allowHigherEnchantsLevels = getBoolean("settings.enchantment.anvil.allow-higher-enchants-levels", allowHigherEnchantsLevels);
          allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability

--- a/patches/server/0272-Stonecutter-damage.patch
+++ b/patches/server/0272-Stonecutter-damage.patch
@@ -80,10 +80,10 @@ index f4ca0a9481533befc78cb18c1f9810826f57562c..902e420d19288df124da2292a60f95e9
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager, source.msgId));
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 46b6a8d0e833f6e92076752f7af8f8dc597292bf..a682e1852ec6ae82e15ed62ae19172e477e94ca6 100644
+index 6ae12d6684620a0e524294b28a5abcbc53392089..fec6308aeb99826040fdf5424362b99e07b42838 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -203,8 +203,10 @@ public class PurpurConfig {
+@@ -205,8 +205,10 @@ public class PurpurConfig {
      }
  
      public static String deathMsgRunWithScissors = "<player> slipped and fell on their shears";

--- a/patches/server/0275-Add-log-suppression-for-sent-expired-chat.patch
+++ b/patches/server/0275-Add-log-suppression-for-sent-expired-chat.patch
@@ -18,10 +18,10 @@ index 597ea30c360a0cc44ef83cfff118d477fa3d0b0a..628a3788c60c9644043ee78736e03570
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index a682e1852ec6ae82e15ed62ae19172e477e94ca6..0b3bc6e8e13ebdbdb568bc6a222c32e470113560 100644
+index fec6308aeb99826040fdf5424362b99e07b42838..a0ea28386a12973fcff0c7c2462205ff9e451b35 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -462,11 +462,13 @@ public class PurpurConfig {
+@@ -464,11 +464,13 @@ public class PurpurConfig {
      public static boolean loggerSuppressIgnoredAdvancementWarnings = false;
      public static boolean loggerSuppressUnrecognizedRecipeErrors = false;
      public static boolean loggerSuppressSetBlockFarChunk = false;

--- a/patches/server/0279-Option-to-disable-kick-for-out-of-order-chat.patch
+++ b/patches/server/0279-Option-to-disable-kick-for-out-of-order-chat.patch
@@ -18,10 +18,10 @@ index 628a3788c60c9644043ee78736e035707a9d4044..9519e11fef244eb1b286b43b857d3f41
          } while (!this.lastChatTimeStamp.compareAndSet(instant1, timestamp));
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 0b3bc6e8e13ebdbdb568bc6a222c32e470113560..3e1a8de7d2f23a8e9218bf56e3fd18c48ffe14df 100644
+index a0ea28386a12973fcff0c7c2462205ff9e451b35..d75604b369b44e493da22a5408530b644c6dc1d6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -478,9 +478,11 @@ public class PurpurConfig {
+@@ -480,9 +480,11 @@ public class PurpurConfig {
  
      public static boolean useUPnP = false;
      public static boolean maxJoinsPerSecond = false;

--- a/patches/server/0300-Implement-ram-and-rambar-commands.patch
+++ b/patches/server/0300-Implement-ram-and-rambar-commands.patch
@@ -61,10 +61,10 @@ index 6979305279996be59756d0424e5bc16a19fde6b0..12637019da44019475042e4cf88d3e0e
          return this.tpsBar;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 3e1a8de7d2f23a8e9218bf56e3fd18c48ffe14df..8d12ba33da62b58f6390a812fd025ede6032ed88 100644
+index d75604b369b44e493da22a5408530b644c6dc1d6..697367da89959abc7145c76d49f6d801d9ab0b23 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -179,6 +179,8 @@ public class PurpurConfig {
+@@ -181,6 +181,8 @@ public class PurpurConfig {
      public static String creditsCommandOutput = "<green>%s has been shown the end credits";
      public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
@@ -73,7 +73,7 @@ index 3e1a8de7d2f23a8e9218bf56e3fd18c48ffe14df..8d12ba33da62b58f6390a812fd025ede
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
      public static String uptimeCommandOutput = "<green>Server uptime is <uptime>";
-@@ -194,6 +196,8 @@ public class PurpurConfig {
+@@ -196,6 +198,8 @@ public class PurpurConfig {
          creditsCommandOutput = getString("settings.messages.credits-command-output", creditsCommandOutput);
          demoCommandOutput = getString("settings.messages.demo-command-output", demoCommandOutput);
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
@@ -82,7 +82,7 @@ index 3e1a8de7d2f23a8e9218bf56e3fd18c48ffe14df..8d12ba33da62b58f6390a812fd025ede
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);
          uptimeCommandOutput = getString("settings.messages.uptime-command-output", uptimeCommandOutput);
-@@ -258,6 +262,15 @@ public class PurpurConfig {
+@@ -260,6 +264,15 @@ public class PurpurConfig {
          disableGiveCommandDrops = getBoolean("settings.disable-give-dropping", disableGiveCommandDrops);
      }
  
@@ -98,7 +98,7 @@ index 3e1a8de7d2f23a8e9218bf56e3fd18c48ffe14df..8d12ba33da62b58f6390a812fd025ede
      public static String commandTPSBarTitle = "<gray>TPS<yellow>:</yellow> <tps> MSPT<yellow>:</yellow> <mspt> Ping<yellow>:</yellow> <ping>ms";
      public static BossBar.Overlay commandTPSBarProgressOverlay = BossBar.Overlay.NOTCHED_20;
      public static TPSBarTask.FillMode commandTPSBarProgressFillMode = TPSBarTask.FillMode.MSPT;
-@@ -286,6 +299,16 @@ public class PurpurConfig {
+@@ -288,6 +301,16 @@ public class PurpurConfig {
      public static String uptimeSecond = "%02d second";
      public static String uptimeSeconds = "%02d seconds";
      private static void commandSettings() {

--- a/patches/server/0303-Configurable-block-blast-resistance.patch
+++ b/patches/server/0303-Configurable-block-blast-resistance.patch
@@ -18,7 +18,7 @@ index 304f0f372d669e3da2e8131c50f2f1246185a56b..bcc4c1af0fe153ed87e55706a1a6a5c6
      protected final SoundType soundType;
      protected final float friction;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 8d12ba33da62b58f6390a812fd025ede6032ed88..ed2e893e122828f6d1c9bc9b05ab2bf7daa989f8 100644
+index 8d12ba33da62b58f6390a812fd025ede6032ed88..69390eb3731c24dbc0e82a95d45a96b4e398078f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -15,6 +15,7 @@ import net.minecraft.world.entity.EntityType;
@@ -29,7 +29,15 @@ index 8d12ba33da62b58f6390a812fd025ede6032ed88..ed2e893e122828f6d1c9bc9b05ab2bf7
  import net.minecraft.world.level.block.Blocks;
  import org.bukkit.Bukkit;
  import org.bukkit.command.Command;
-@@ -566,4 +567,19 @@ public class PurpurConfig {
+@@ -30,6 +31,7 @@ import java.lang.reflect.InvocationTargetException;
+ import java.lang.reflect.Method;
+ import java.lang.reflect.Modifier;
+ import java.util.ArrayList;
++import java.util.Collections;
+ import java.util.HashMap;
+ import java.util.HashSet;
+ import java.util.List;
+@@ -566,4 +568,19 @@ public class PurpurConfig {
              }
          });
      }

--- a/patches/server/0303-Configurable-block-blast-resistance.patch
+++ b/patches/server/0303-Configurable-block-blast-resistance.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Sat, 1 Oct 2022 13:29:17 -0700
+Subject: [PATCH] Configurable block blast resistance
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
+index 304f0f372d669e3da2e8131c50f2f1246185a56b..bcc4c1af0fe153ed87e55706a1a6a5c6e945fec8 100644
+--- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
++++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
+@@ -75,7 +75,7 @@ public abstract class BlockBehaviour {
+     protected static final Direction[] UPDATE_SHAPE_ORDER = new Direction[]{Direction.WEST, Direction.EAST, Direction.NORTH, Direction.SOUTH, Direction.DOWN, Direction.UP};
+     public final Material material; // Purpur - protected -> public
+     public final boolean hasCollision;
+-    protected final float explosionResistance;
++    public float explosionResistance; // Purpur - protected final -> public
+     protected final boolean isRandomlyTicking;
+     protected final SoundType soundType;
+     protected final float friction;
+diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+index 8d12ba33da62b58f6390a812fd025ede6032ed88..ed2e893e122828f6d1c9bc9b05ab2bf7daa989f8 100644
+--- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
++++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+@@ -15,6 +15,7 @@ import net.minecraft.world.entity.EntityType;
+ import net.minecraft.world.food.FoodProperties;
+ import net.minecraft.world.food.Foods;
+ import net.minecraft.world.item.enchantment.Enchantment;
++import net.minecraft.world.level.block.Block;
+ import net.minecraft.world.level.block.Blocks;
+ import org.bukkit.Bukkit;
+ import org.bukkit.command.Command;
+@@ -566,4 +567,19 @@ public class PurpurConfig {
+             }
+         });
+     }
++
++    private static void blastResistanceSettings() {
++        getMap("settings.blast-resistance-overrides", Collections.emptyMap()).forEach((blockId, value) -> {
++            Block block = Registry.BLOCK.get(new ResourceLocation(blockId));
++            if (block == Blocks.AIR) {
++                log(Level.SEVERE, "Invalid block for `settings.blast-resistance-overrides`: " + blockId);
++                return;
++            }
++            if (!(value instanceof Number blastResistance)) {
++                log(Level.SEVERE, "Invalid blast resistance for `settings.blast-resistance-overrides." + blockId + "`: " + value);
++                return;
++            }
++            block.explosionResistance = blastResistance.floatValue();
++        });
++    }
+ }

--- a/patches/server/0304-Add-an-option-to-fix-MC-3304-projectile-looting.patch
+++ b/patches/server/0304-Add-an-option-to-fix-MC-3304-projectile-looting.patch
@@ -104,10 +104,10 @@ index 31918fa2eb38e42a5ea5366e559f25ea9d7d59ae..15d8e9261a89da30529ac347462c5209
              if (context.hasParam(LootContextParams.LOOTING_MOD)) {
                  i = context.getParamOrNull(LootContextParams.LOOTING_MOD);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 8d12ba33da62b58f6390a812fd025ede6032ed88..7efdb3d71c065435dc365207bfc42a82ec36a8b1 100644
+index 697367da89959abc7145c76d49f6d801d9ab0b23..01fe3af88214ec7d73f307d5209955bd925ccc96 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -566,4 +566,9 @@ public class PurpurConfig {
+@@ -568,4 +568,9 @@ public class PurpurConfig {
              }
          });
      }

--- a/patches/server/0305-Configurable-block-blast-resistance.patch
+++ b/patches/server/0305-Configurable-block-blast-resistance.patch
@@ -18,7 +18,7 @@ index 304f0f372d669e3da2e8131c50f2f1246185a56b..bcc4c1af0fe153ed87e55706a1a6a5c6
      protected final SoundType soundType;
      protected final float friction;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 8d12ba33da62b58f6390a812fd025ede6032ed88..69390eb3731c24dbc0e82a95d45a96b4e398078f 100644
+index 7efdb3d71c065435dc365207bfc42a82ec36a8b1..14844cb8a402ac987f44a91b95d5ebdac73c6dfe 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -15,6 +15,7 @@ import net.minecraft.world.entity.EntityType;
@@ -37,9 +37,9 @@ index 8d12ba33da62b58f6390a812fd025ede6032ed88..69390eb3731c24dbc0e82a95d45a96b4
  import java.util.HashMap;
  import java.util.HashSet;
  import java.util.List;
-@@ -566,4 +568,19 @@ public class PurpurConfig {
-             }
-         });
+@@ -571,4 +573,19 @@ public class PurpurConfig {
+     private static void fixProjectileLootingTransfer() {
+         fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
      }
 +
 +    private static void blastResistanceSettings() {

--- a/patches/server/0305-Configurable-block-blast-resistance.patch
+++ b/patches/server/0305-Configurable-block-blast-resistance.patch
@@ -18,26 +18,10 @@ index 304f0f372d669e3da2e8131c50f2f1246185a56b..bcc4c1af0fe153ed87e55706a1a6a5c6
      protected final SoundType soundType;
      protected final float friction;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 7efdb3d71c065435dc365207bfc42a82ec36a8b1..14844cb8a402ac987f44a91b95d5ebdac73c6dfe 100644
+index 01fe3af88214ec7d73f307d5209955bd925ccc96..14844cb8a402ac987f44a91b95d5ebdac73c6dfe 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -15,6 +15,7 @@ import net.minecraft.world.entity.EntityType;
- import net.minecraft.world.food.FoodProperties;
- import net.minecraft.world.food.Foods;
- import net.minecraft.world.item.enchantment.Enchantment;
-+import net.minecraft.world.level.block.Block;
- import net.minecraft.world.level.block.Blocks;
- import org.bukkit.Bukkit;
- import org.bukkit.command.Command;
-@@ -30,6 +31,7 @@ import java.lang.reflect.InvocationTargetException;
- import java.lang.reflect.Method;
- import java.lang.reflect.Modifier;
- import java.util.ArrayList;
-+import java.util.Collections;
- import java.util.HashMap;
- import java.util.HashSet;
- import java.util.List;
-@@ -571,4 +573,19 @@ public class PurpurConfig {
+@@ -573,4 +573,19 @@ public class PurpurConfig {
      private static void fixProjectileLootingTransfer() {
          fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
      }


### PR DESCRIPTION
This pull request adds a setting for changing the blast resistance of blocks. This is useful if you want to change the blast resistance of blocks for balancing explosives, or to make certain blocks have a higher blast resistance.
The `blast-resistance-overrides` setting takes a map with block ids as keys, and floats as values for the blast resistance.

Example configuration:
```yaml
  blast-resistance-overrides:
    minecraft:oak_leaves: 55
    minecraft:obsidian: 1.5
```