### PR TITLE
Allow mini message in anvil

### DIFF
--- a/patches/server/0088-Allow-anvil-colors.patch
+++ b/patches/server/0088-Allow-anvil-colors.patch
@@ -5,17 +5,19 @@ Subject: [PATCH] Allow anvil colors
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 0363d2263b2d6bd6166fa21d7849297e95eddd77..800df3b7c04ce7ed52f265d681e7752f63ae4ec7 100644
+index 0363d2263b2d6bd6166fa21d7849297e95eddd77..4b706a22859c5be41abeb6255680e1f085f050a2 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-@@ -280,6 +280,17 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -280,6 +280,19 @@ public class AnvilMenu extends ItemCombinerMenu {
              } else if (!this.itemName.equals(itemstack.getHoverName().getString())) {
                  b1 = 1;
                  i += b1;
 +                // Purpur start
 +                if (player != null && player.level.purpurConfig.anvilAllowColors && player.getBukkitEntity().hasPermission("purpur.anvil.color")) {
 +                    final net.kyori.adventure.text.Component renameTextComponent;
-+                    if (itemName.startsWith("&r") && player.getBukkitEntity().hasPermission("purpur.anvil.remove_italics")) {
++                    if (player.level.purpurConfig.anvilColorsUseMiniMessage && player.getBukkitEntity().hasPermission("purpur.anvil.minimessage")) {
++                        renameTextComponent = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(itemName);
++                    } else if (itemName.startsWith("&r") && player.getBukkitEntity().hasPermission("purpur.anvil.remove_italics")) {
 +                        renameTextComponent = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize(itemName.substring(2)).decoration(net.kyori.adventure.text.format.TextDecoration.ITALIC, false);
 +                    } else {
 +                        renameTextComponent = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacyAmpersand().deserialize(itemName);
@@ -27,16 +29,18 @@ index 0363d2263b2d6bd6166fa21d7849297e95eddd77..800df3b7c04ce7ed52f265d681e7752f
              }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 2421b9d2c41a878ff01c81753d140c50f30ef4c2..f9d778ea201c5a0ff552d05edf5701fcb55120bd 100644
+index 2421b9d2c41a878ff01c81753d140c50f30ef4c2..a7b763a1d86c98128a4c5f600ae89ab79fd7e22d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -300,6 +300,11 @@ public class PurpurWorldConfig {
+@@ -300,6 +300,13 @@ public class PurpurWorldConfig {
          });
      }
  
 +    public boolean anvilAllowColors = false;
++    public boolean anvilColorsUseMiniMessage;
 +    private void anvilSettings() {
 +        anvilAllowColors = getBoolean("blocks.anvil.allow-colors", anvilAllowColors);
++        anvilColorsUseMiniMessage = getBoolean("blocks.anvil.use-mini-message", anvilColorsUseMiniMessage);
 +    }
 +
      public boolean bedExplode = true;

--- a/patches/server/0089-Add-option-to-disable-dolphin-treasure-searching.patch
+++ b/patches/server/0089-Add-option-to-disable-dolphin-treasure-searching.patch
@@ -17,10 +17,10 @@ index 1ca3ffe212da2c3914c290172e729ba8017f631c..a8ca2d120a545d423fc00aef5299b66b
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f9d778ea201c5a0ff552d05edf5701fcb55120bd..6aee3448c08210a2f87de6759d364179c5bf8a1e 100644
+index a7b763a1d86c98128a4c5f600ae89ab79fd7e22d..08eca6afc59d1011e2e3ba184c5d8d5e2f31f094 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -588,6 +588,7 @@ public class PurpurWorldConfig {
+@@ -590,6 +590,7 @@ public class PurpurWorldConfig {
      public float dolphinSpitSpeed = 1.0F;
      public float dolphinSpitDamage = 2.0F;
      public double dolphinMaxHealth = 10.0D;
@@ -28,7 +28,7 @@ index f9d778ea201c5a0ff552d05edf5701fcb55120bd..6aee3448c08210a2f87de6759d364179
      private void dolphinSettings() {
          dolphinRidable = getBoolean("mobs.dolphin.ridable", dolphinRidable);
          dolphinControllable = getBoolean("mobs.dolphin.controllable", dolphinControllable);
-@@ -600,6 +601,7 @@ public class PurpurWorldConfig {
+@@ -602,6 +603,7 @@ public class PurpurWorldConfig {
              set("mobs.dolphin.attributes.max_health", oldValue);
          }
          dolphinMaxHealth = getDouble("mobs.dolphin.attributes.max_health", dolphinMaxHealth);

--- a/patches/server/0091-Stop-squids-floating-on-top-of-water.patch
+++ b/patches/server/0091-Stop-squids-floating-on-top-of-water.patch
@@ -54,10 +54,10 @@ index 68cc6f2a78a06293a29317fda72ab3ee79b3533a..cfb2e46b34b2982d6724f18214557fc8
 +    // Purpur
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6aee3448c08210a2f87de6759d364179c5bf8a1e..94984558798bb4571a30a54bc4fdd43087dcbcd5 100644
+index 08eca6afc59d1011e2e3ba184c5d8d5e2f31f094..022d8c904ce5df6c0b1906c99770aa17344bd351 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1457,6 +1457,7 @@ public class PurpurWorldConfig {
+@@ -1459,6 +1459,7 @@ public class PurpurWorldConfig {
      public boolean squidControllable = true;
      public double squidMaxHealth = 10.0D;
      public boolean squidImmuneToEAR = true;
@@ -65,7 +65,7 @@ index 6aee3448c08210a2f87de6759d364179c5bf8a1e..94984558798bb4571a30a54bc4fdd430
      private void squidSettings() {
          squidRidable = getBoolean("mobs.squid.ridable", squidRidable);
          squidControllable = getBoolean("mobs.squid.controllable", squidControllable);
-@@ -1467,6 +1468,7 @@ public class PurpurWorldConfig {
+@@ -1469,6 +1470,7 @@ public class PurpurWorldConfig {
          }
          squidMaxHealth = getDouble("mobs.squid.attributes.max_health", squidMaxHealth);
          squidImmuneToEAR = getBoolean("mobs.squid.immune-to-EAR", squidImmuneToEAR);

--- a/patches/server/0095-Customizable-wither-health-and-healing.patch
+++ b/patches/server/0095-Customizable-wither-health-and-healing.patch
@@ -23,10 +23,10 @@ index 80674ee4882d2d1c67f78c6bc627e34a78d0c4b0..9cf7cd70492c8769cd3dad1ed57eeff1
  
              this.bossEvent.setProgress(this.getHealth() / this.getMaxHealth());
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1ff5a05f5b3c5caf804fd67ff857e9d776e08677..3261f6ca362b199b472570ab7a089215a30960b7 100644
+index 3f3dc194f2b11a4fddab9b178db248e8154f693d..f5f2bf775390ac019c811e4c26d817749a2f6645 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1700,6 +1700,8 @@ public class PurpurWorldConfig {
+@@ -1702,6 +1702,8 @@ public class PurpurWorldConfig {
      public boolean witherControllable = true;
      public double witherMaxY = 320D;
      public double witherMaxHealth = 300.0D;
@@ -35,7 +35,7 @@ index 1ff5a05f5b3c5caf804fd67ff857e9d776e08677..3261f6ca362b199b472570ab7a089215
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -1715,6 +1717,8 @@ public class PurpurWorldConfig {
+@@ -1717,6 +1719,8 @@ public class PurpurWorldConfig {
              set("mobs.wither.attributes.max_health", oldValue);
          }
          witherMaxHealth = getDouble("mobs.wither.attributes.max_health", witherMaxHealth);

--- a/patches/server/0099-Add-option-to-disable-zombie-aggressiveness-towards-.patch
+++ b/patches/server/0099-Add-option-to-disable-zombie-aggressiveness-towards-.patch
@@ -71,10 +71,10 @@ index eeb01e54125cab3d0803341f21d135068924d786..66b69f9c6cc5cbf235dce888623b6cea
          this.targetSelector.addGoal(5, new NearestAttackableTargetGoal<>(this, Turtle.class, 10, true, false, Turtle.BABY_ON_LAND_SELECTOR));
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 69d31556151df6fc6e2c0a57bc8345b0433b56be..bf4afe1895f679a32d70cafbef717b1d37de0aa7 100644
+index 6f4f71c9a27fa1c0ab354b9b410fba744787a51a..aab75be19fe6d9364c3214b6760ccddd253d3b1e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1833,6 +1833,7 @@ public class PurpurWorldConfig {
+@@ -1835,6 +1835,7 @@ public class PurpurWorldConfig {
      public boolean zombieJockeyOnlyBaby = true;
      public double zombieJockeyChance = 0.05D;
      public boolean zombieJockeyTryExistingChickens = true;
@@ -82,7 +82,7 @@ index 69d31556151df6fc6e2c0a57bc8345b0433b56be..bf4afe1895f679a32d70cafbef717b1d
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -1847,6 +1848,7 @@ public class PurpurWorldConfig {
+@@ -1849,6 +1850,7 @@ public class PurpurWorldConfig {
          zombieJockeyOnlyBaby = getBoolean("mobs.zombie.jockey.only-babies", zombieJockeyOnlyBaby);
          zombieJockeyChance = getDouble("mobs.zombie.jockey.chance", zombieJockeyChance);
          zombieJockeyTryExistingChickens = getBoolean("mobs.zombie.jockey.try-existing-chickens", zombieJockeyTryExistingChickens);

--- a/patches/server/0101-Flying-squids-Oh-my.patch
+++ b/patches/server/0101-Flying-squids-Oh-my.patch
@@ -58,10 +58,10 @@ index 709aaa9dc834d91219ce1087d8f89ef5bf3d915c..4850960c7c4f38c7d81b8945f8c87504
                  float f1 = Mth.cos(f) * 0.2F;
                  float f2 = -0.1F + this.squid.getRandom().nextFloat() * 0.2F;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index bf4afe1895f679a32d70cafbef717b1d37de0aa7..8905ba0297d1e5294faeafbd425bd35c202ee025 100644
+index aab75be19fe6d9364c3214b6760ccddd253d3b1e..7b2a16c2d474b3931ff629ba58f6987f69fadfec 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -880,10 +880,12 @@ public class PurpurWorldConfig {
+@@ -882,10 +882,12 @@ public class PurpurWorldConfig {
      public boolean glowSquidRidable = false;
      public boolean glowSquidControllable = true;
      public double glowSquidMaxHealth = 10.0D;
@@ -74,7 +74,7 @@ index bf4afe1895f679a32d70cafbef717b1d37de0aa7..8905ba0297d1e5294faeafbd425bd35c
      }
  
      public boolean goatRidable = false;
-@@ -1516,6 +1518,7 @@ public class PurpurWorldConfig {
+@@ -1518,6 +1520,7 @@ public class PurpurWorldConfig {
      public double squidMaxHealth = 10.0D;
      public boolean squidImmuneToEAR = true;
      public double squidOffsetWaterCheck = 0.0D;
@@ -82,7 +82,7 @@ index bf4afe1895f679a32d70cafbef717b1d37de0aa7..8905ba0297d1e5294faeafbd425bd35c
      private void squidSettings() {
          squidRidable = getBoolean("mobs.squid.ridable", squidRidable);
          squidControllable = getBoolean("mobs.squid.controllable", squidControllable);
-@@ -1527,6 +1530,7 @@ public class PurpurWorldConfig {
+@@ -1529,6 +1532,7 @@ public class PurpurWorldConfig {
          squidMaxHealth = getDouble("mobs.squid.attributes.max_health", squidMaxHealth);
          squidImmuneToEAR = getBoolean("mobs.squid.immune-to-EAR", squidImmuneToEAR);
          squidOffsetWaterCheck = getDouble("mobs.squid.water-offset-check", squidOffsetWaterCheck);

--- a/patches/server/0105-Furnace-uses-lava-from-underneath.patch
+++ b/patches/server/0105-Furnace-uses-lava-from-underneath.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Furnace uses lava from underneath
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index 4977f3fad3bfc12fd4c5f9fbe8beea2895247c57..c617a8aacbbefb37d53d0e005e822469d29aa642 100644
+index c6aeda6497cb59673b469588142f5f15a338389d..36759f7905eea8c1a5b9d4cb32967ad04dd62e15 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 @@ -43,6 +43,7 @@ import net.minecraft.world.level.Level;
@@ -47,10 +47,10 @@ index 4977f3fad3bfc12fd4c5f9fbe8beea2895247c57..c617a8aacbbefb37d53d0e005e822469
  
      private static boolean canBurn(@Nullable Recipe<?> recipe, NonNullList<ItemStack> slots, int count) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e95c39c76f71d1434f874c56e22b2470c3f543c1..239cf141be60074cda41e262571f22c96f5dad34 100644
+index 0a8f9082470b3b70fb21ea620d6dce23120cb65b..624f7ed6054091c89644f3c8bc7cbf23075a52c4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -409,6 +409,17 @@ public class PurpurWorldConfig {
+@@ -411,6 +411,17 @@ public class PurpurWorldConfig {
          farmlandGetsMoistFromBelow = getBoolean("blocks.farmland.gets-moist-from-below", farmlandGetsMoistFromBelow);
      }
  

--- a/patches/server/0107-Ability-to-re-add-farmland-mechanics-from-Alpha.patch
+++ b/patches/server/0107-Ability-to-re-add-farmland-mechanics-from-Alpha.patch
@@ -24,10 +24,10 @@ index 4208833252a5b5c74d294dc3435869d71d774e37..a3ff99c461dd862733816d9d1204cf8b
                  return;
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4535d7dddc65084bd058ec966dc5db628497047c..94e69bee785a4da44ead68d451eac2dd8ce719fa 100644
+index 4c1e434f92a2754eb2bfc8ef11aa5ee7ff142762..e0e32c8f7b5ee4a33c9246bb4b521131b89db875 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -410,8 +410,10 @@ public class PurpurWorldConfig {
+@@ -412,8 +412,10 @@ public class PurpurWorldConfig {
      }
  
      public boolean farmlandGetsMoistFromBelow = false;

--- a/patches/server/0109-Make-entity-breeding-times-configurable.patch
+++ b/patches/server/0109-Make-entity-breeding-times-configurable.patch
@@ -331,7 +331,7 @@ index 6a6613f70f9c4cc950882191b00048d4c47bd84f..e739416fa58b182d7bd311be094d6aab
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
-index 77be0c6f6e6061ceee1daa467c20c8d7ece7590e..59caabbe84a24ea47796ae71130961dff146a76f 100644
+index c1cdef2eaa2bb969ddecc8c3bbdb0fdd33fa9c82..af6bc24065f0db7b12962b5b718b5fb82cf5fa22 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
 @@ -109,6 +109,11 @@ public class Goat extends Animal {
@@ -491,10 +491,10 @@ index e99ffbf30652e188e88f8e17ed41d39ff25c9f73..c335a32832c6eef95658fbf632b943bb
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910395f3442 100644
+index d351b955427c00c4fea4157ac2d0eec3c4688b70..da8d0c3b68f0d41a0925b983f0214724764740e1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -503,10 +503,12 @@ public class PurpurWorldConfig {
+@@ -505,10 +505,12 @@ public class PurpurWorldConfig {
      public boolean axolotlRidable = false;
      public boolean axolotlControllable = true;
      public double axolotlMaxHealth = 14.0D;
@@ -507,7 +507,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean batRidable = false;
-@@ -539,6 +541,7 @@ public class PurpurWorldConfig {
+@@ -541,6 +543,7 @@ public class PurpurWorldConfig {
      public boolean beeControllable = true;
      public double beeMaxY = 320D;
      public double beeMaxHealth = 10.0D;
@@ -515,7 +515,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -550,6 +553,7 @@ public class PurpurWorldConfig {
+@@ -552,6 +555,7 @@ public class PurpurWorldConfig {
              set("mobs.bee.attributes.max_health", oldValue);
          }
          beeMaxHealth = getDouble("mobs.bee.attributes.max_health", beeMaxHealth);
@@ -523,7 +523,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean blazeRidable = false;
-@@ -577,6 +581,7 @@ public class PurpurWorldConfig {
+@@ -579,6 +583,7 @@ public class PurpurWorldConfig {
      public int catSpawnDelay = 1200;
      public int catSpawnSwampHutScanRange = 16;
      public int catSpawnVillageScanRange = 48;
@@ -531,7 +531,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void catSettings() {
          catRidable = getBoolean("mobs.cat.ridable", catRidable);
          catRidableInWater = getBoolean("mobs.cat.ridable-in-water", catRidableInWater);
-@@ -590,6 +595,7 @@ public class PurpurWorldConfig {
+@@ -592,6 +597,7 @@ public class PurpurWorldConfig {
          catSpawnDelay = getInt("mobs.cat.spawn-delay", catSpawnDelay);
          catSpawnSwampHutScanRange = getInt("mobs.cat.scan-range-for-other-cats.swamp-hut", catSpawnSwampHutScanRange);
          catSpawnVillageScanRange = getInt("mobs.cat.scan-range-for-other-cats.village", catSpawnVillageScanRange);
@@ -539,7 +539,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean caveSpiderRidable = false;
-@@ -613,6 +619,7 @@ public class PurpurWorldConfig {
+@@ -615,6 +621,7 @@ public class PurpurWorldConfig {
      public boolean chickenControllable = true;
      public double chickenMaxHealth = 4.0D;
      public boolean chickenRetaliate = false;
@@ -547,7 +547,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void chickenSettings() {
          chickenRidable = getBoolean("mobs.chicken.ridable", chickenRidable);
          chickenRidableInWater = getBoolean("mobs.chicken.ridable-in-water", chickenRidableInWater);
-@@ -624,6 +631,7 @@ public class PurpurWorldConfig {
+@@ -626,6 +633,7 @@ public class PurpurWorldConfig {
          }
          chickenMaxHealth = getDouble("mobs.chicken.attributes.max_health", chickenMaxHealth);
          chickenRetaliate = getBoolean("mobs.chicken.retaliate", chickenRetaliate);
@@ -555,7 +555,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean codRidable = false;
-@@ -645,6 +653,7 @@ public class PurpurWorldConfig {
+@@ -647,6 +655,7 @@ public class PurpurWorldConfig {
      public boolean cowControllable = true;
      public double cowMaxHealth = 10.0D;
      public int cowFeedMushrooms = 0;
@@ -563,7 +563,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void cowSettings() {
          cowRidable = getBoolean("mobs.cow.ridable", cowRidable);
          cowRidableInWater = getBoolean("mobs.cow.ridable-in-water", cowRidableInWater);
-@@ -656,6 +665,7 @@ public class PurpurWorldConfig {
+@@ -658,6 +667,7 @@ public class PurpurWorldConfig {
          }
          cowMaxHealth = getDouble("mobs.cow.attributes.max_health", cowMaxHealth);
          cowFeedMushrooms = getInt("mobs.cow.feed-mushrooms-for-mooshroom", cowFeedMushrooms);
@@ -571,7 +571,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean creeperRidable = false;
-@@ -707,6 +717,7 @@ public class PurpurWorldConfig {
+@@ -709,6 +719,7 @@ public class PurpurWorldConfig {
      public double donkeyJumpStrengthMax = 0.5D;
      public double donkeyMovementSpeedMin = 0.175D;
      public double donkeyMovementSpeedMax = 0.175D;
@@ -579,7 +579,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void donkeySettings() {
          donkeyRidableInWater = getBoolean("mobs.donkey.ridable-in-water", donkeyRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -722,6 +733,7 @@ public class PurpurWorldConfig {
+@@ -724,6 +735,7 @@ public class PurpurWorldConfig {
          donkeyJumpStrengthMax = getDouble("mobs.donkey.attributes.jump_strength.max", donkeyJumpStrengthMax);
          donkeyMovementSpeedMin = getDouble("mobs.donkey.attributes.movement_speed.min", donkeyMovementSpeedMin);
          donkeyMovementSpeedMax = getDouble("mobs.donkey.attributes.movement_speed.max", donkeyMovementSpeedMax);
@@ -587,7 +587,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean drownedRidable = false;
-@@ -841,6 +853,7 @@ public class PurpurWorldConfig {
+@@ -843,6 +855,7 @@ public class PurpurWorldConfig {
      public boolean foxControllable = true;
      public double foxMaxHealth = 10.0D;
      public boolean foxTypeChangesWithTulips = false;
@@ -595,7 +595,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void foxSettings() {
          foxRidable = getBoolean("mobs.fox.ridable", foxRidable);
          foxRidableInWater = getBoolean("mobs.fox.ridable-in-water", foxRidableInWater);
-@@ -852,17 +865,20 @@ public class PurpurWorldConfig {
+@@ -854,17 +867,20 @@ public class PurpurWorldConfig {
          }
          foxMaxHealth = getDouble("mobs.fox.attributes.max_health", foxMaxHealth);
          foxTypeChangesWithTulips = getBoolean("mobs.fox.tulips-change-type", foxTypeChangesWithTulips);
@@ -616,7 +616,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean ghastRidable = false;
-@@ -930,11 +946,13 @@ public class PurpurWorldConfig {
+@@ -932,11 +948,13 @@ public class PurpurWorldConfig {
      public boolean goatRidableInWater = false;
      public boolean goatControllable = true;
      public double goatMaxHealth = 10.0D;
@@ -630,7 +630,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean guardianRidable = false;
-@@ -955,6 +973,7 @@ public class PurpurWorldConfig {
+@@ -957,6 +975,7 @@ public class PurpurWorldConfig {
      public boolean hoglinRidableInWater = false;
      public boolean hoglinControllable = true;
      public double hoglinMaxHealth = 40.0D;
@@ -638,7 +638,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void hoglinSettings() {
          hoglinRidable = getBoolean("mobs.hoglin.ridable", hoglinRidable);
          hoglinRidableInWater = getBoolean("mobs.hoglin.ridable-in-water", hoglinRidableInWater);
-@@ -965,6 +984,7 @@ public class PurpurWorldConfig {
+@@ -967,6 +986,7 @@ public class PurpurWorldConfig {
              set("mobs.hoglin.attributes.max_health", oldValue);
          }
          hoglinMaxHealth = getDouble("mobs.hoglin.attributes.max_health", hoglinMaxHealth);
@@ -646,7 +646,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean horseRidableInWater = false;
-@@ -974,6 +994,7 @@ public class PurpurWorldConfig {
+@@ -976,6 +996,7 @@ public class PurpurWorldConfig {
      public double horseJumpStrengthMax = 1.0D;
      public double horseMovementSpeedMin = 0.1125D;
      public double horseMovementSpeedMax = 0.3375D;
@@ -654,7 +654,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void horseSettings() {
          horseRidableInWater = getBoolean("mobs.horse.ridable-in-water", horseRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -989,6 +1010,7 @@ public class PurpurWorldConfig {
+@@ -991,6 +1012,7 @@ public class PurpurWorldConfig {
          horseJumpStrengthMax = getDouble("mobs.horse.attributes.jump_strength.max", horseJumpStrengthMax);
          horseMovementSpeedMin = getDouble("mobs.horse.attributes.movement_speed.min", horseMovementSpeedMin);
          horseMovementSpeedMax = getDouble("mobs.horse.attributes.movement_speed.max", horseMovementSpeedMax);
@@ -662,7 +662,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean huskRidable = false;
-@@ -1066,6 +1088,7 @@ public class PurpurWorldConfig {
+@@ -1068,6 +1090,7 @@ public class PurpurWorldConfig {
      public double llamaJumpStrengthMax = 0.5D;
      public double llamaMovementSpeedMin = 0.175D;
      public double llamaMovementSpeedMax = 0.175D;
@@ -670,7 +670,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void llamaSettings() {
          llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
          llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
-@@ -1083,6 +1106,7 @@ public class PurpurWorldConfig {
+@@ -1085,6 +1108,7 @@ public class PurpurWorldConfig {
          llamaJumpStrengthMax = getDouble("mobs.llama.attributes.jump_strength.max", llamaJumpStrengthMax);
          llamaMovementSpeedMin = getDouble("mobs.llama.attributes.movement_speed.min", llamaMovementSpeedMin);
          llamaMovementSpeedMax = getDouble("mobs.llama.attributes.movement_speed.max", llamaMovementSpeedMax);
@@ -678,7 +678,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean magmaCubeRidable = false;
-@@ -1111,6 +1135,7 @@ public class PurpurWorldConfig {
+@@ -1113,6 +1137,7 @@ public class PurpurWorldConfig {
      public boolean mooshroomRidableInWater = false;
      public boolean mooshroomControllable = true;
      public double mooshroomMaxHealth = 10.0D;
@@ -686,7 +686,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void mooshroomSettings() {
          mooshroomRidable = getBoolean("mobs.mooshroom.ridable", mooshroomRidable);
          mooshroomRidableInWater = getBoolean("mobs.mooshroom.ridable-in-water", mooshroomRidableInWater);
-@@ -1121,6 +1146,7 @@ public class PurpurWorldConfig {
+@@ -1123,6 +1148,7 @@ public class PurpurWorldConfig {
              set("mobs.mooshroom.attributes.max_health", oldValue);
          }
          mooshroomMaxHealth = getDouble("mobs.mooshroom.attributes.max_health", mooshroomMaxHealth);
@@ -694,7 +694,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean muleRidableInWater = false;
-@@ -1130,6 +1156,7 @@ public class PurpurWorldConfig {
+@@ -1132,6 +1158,7 @@ public class PurpurWorldConfig {
      public double muleJumpStrengthMax = 0.5D;
      public double muleMovementSpeedMin = 0.175D;
      public double muleMovementSpeedMax = 0.175D;
@@ -702,7 +702,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void muleSettings() {
          muleRidableInWater = getBoolean("mobs.mule.ridable-in-water", muleRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1145,12 +1172,14 @@ public class PurpurWorldConfig {
+@@ -1147,12 +1174,14 @@ public class PurpurWorldConfig {
          muleJumpStrengthMax = getDouble("mobs.mule.attributes.jump_strength.max", muleJumpStrengthMax);
          muleMovementSpeedMin = getDouble("mobs.mule.attributes.movement_speed.min", muleMovementSpeedMin);
          muleMovementSpeedMax = getDouble("mobs.mule.attributes.movement_speed.max", muleMovementSpeedMax);
@@ -717,7 +717,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void ocelotSettings() {
          ocelotRidable = getBoolean("mobs.ocelot.ridable", ocelotRidable);
          ocelotRidableInWater = getBoolean("mobs.ocelot.ridable-in-water", ocelotRidableInWater);
-@@ -1161,12 +1190,14 @@ public class PurpurWorldConfig {
+@@ -1163,12 +1192,14 @@ public class PurpurWorldConfig {
              set("mobs.ocelot.attributes.max_health", oldValue);
          }
          ocelotMaxHealth = getDouble("mobs.ocelot.attributes.max_health", ocelotMaxHealth);
@@ -732,7 +732,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void pandaSettings() {
          pandaRidable = getBoolean("mobs.panda.ridable", pandaRidable);
          pandaRidableInWater = getBoolean("mobs.panda.ridable-in-water", pandaRidableInWater);
-@@ -1177,6 +1208,7 @@ public class PurpurWorldConfig {
+@@ -1179,6 +1210,7 @@ public class PurpurWorldConfig {
              set("mobs.panda.attributes.max_health", oldValue);
          }
          pandaMaxHealth = getDouble("mobs.panda.attributes.max_health", pandaMaxHealth);
@@ -740,7 +740,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean parrotRidable = false;
-@@ -1272,6 +1304,7 @@ public class PurpurWorldConfig {
+@@ -1274,6 +1306,7 @@ public class PurpurWorldConfig {
      public boolean pigControllable = true;
      public double pigMaxHealth = 10.0D;
      public boolean pigGiveSaddleBack = false;
@@ -748,7 +748,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void pigSettings() {
          pigRidable = getBoolean("mobs.pig.ridable", pigRidable);
          pigRidableInWater = getBoolean("mobs.pig.ridable-in-water", pigRidableInWater);
-@@ -1283,6 +1316,7 @@ public class PurpurWorldConfig {
+@@ -1285,6 +1318,7 @@ public class PurpurWorldConfig {
          }
          pigMaxHealth = getDouble("mobs.pig.attributes.max_health", pigMaxHealth);
          pigGiveSaddleBack = getBoolean("mobs.pig.give-saddle-back", pigGiveSaddleBack);
@@ -756,7 +756,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean piglinRidable = false;
-@@ -1339,6 +1373,7 @@ public class PurpurWorldConfig {
+@@ -1341,6 +1375,7 @@ public class PurpurWorldConfig {
      public double polarBearMaxHealth = 30.0D;
      public String polarBearBreedableItemString = "";
      public Item polarBearBreedableItem = null;
@@ -764,7 +764,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void polarBearSettings() {
          polarBearRidable = getBoolean("mobs.polar_bear.ridable", polarBearRidable);
          polarBearRidableInWater = getBoolean("mobs.polar_bear.ridable-in-water", polarBearRidableInWater);
-@@ -1352,6 +1387,7 @@ public class PurpurWorldConfig {
+@@ -1354,6 +1389,7 @@ public class PurpurWorldConfig {
          polarBearBreedableItemString = getString("mobs.polar_bear.breedable-item", polarBearBreedableItemString);
          Item item = Registry.ITEM.get(new ResourceLocation(polarBearBreedableItemString));
          if (item != Items.AIR) polarBearBreedableItem = item;
@@ -772,7 +772,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean pufferfishRidable = false;
-@@ -1374,6 +1410,7 @@ public class PurpurWorldConfig {
+@@ -1376,6 +1412,7 @@ public class PurpurWorldConfig {
      public double rabbitMaxHealth = 3.0D;
      public double rabbitNaturalToast = 0.0D;
      public double rabbitNaturalKiller = 0.0D;
@@ -780,7 +780,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void rabbitSettings() {
          rabbitRidable = getBoolean("mobs.rabbit.ridable", rabbitRidable);
          rabbitRidableInWater = getBoolean("mobs.rabbit.ridable-in-water", rabbitRidableInWater);
-@@ -1386,6 +1423,7 @@ public class PurpurWorldConfig {
+@@ -1388,6 +1425,7 @@ public class PurpurWorldConfig {
          rabbitMaxHealth = getDouble("mobs.rabbit.attributes.max_health", rabbitMaxHealth);
          rabbitNaturalToast = getDouble("mobs.rabbit.spawn-toast-chance", rabbitNaturalToast);
          rabbitNaturalKiller = getDouble("mobs.rabbit.spawn-killer-rabbit-chance", rabbitNaturalKiller);
@@ -788,7 +788,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean ravagerRidable = false;
-@@ -1422,6 +1460,7 @@ public class PurpurWorldConfig {
+@@ -1424,6 +1462,7 @@ public class PurpurWorldConfig {
      public boolean sheepRidableInWater = false;
      public boolean sheepControllable = true;
      public double sheepMaxHealth = 8.0D;
@@ -796,7 +796,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -1432,6 +1471,7 @@ public class PurpurWorldConfig {
+@@ -1434,6 +1473,7 @@ public class PurpurWorldConfig {
              set("mobs.sheep.attributes.max_health", oldValue);
          }
          sheepMaxHealth = getDouble("mobs.sheep.attributes.max_health", sheepMaxHealth);
@@ -804,7 +804,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean shulkerRidable = false;
-@@ -1607,6 +1647,7 @@ public class PurpurWorldConfig {
+@@ -1609,6 +1649,7 @@ public class PurpurWorldConfig {
      public boolean striderRidableInWater = false;
      public boolean striderControllable = true;
      public double striderMaxHealth = 20.0D;
@@ -812,7 +812,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void striderSettings() {
          striderRidable = getBoolean("mobs.strider.ridable", striderRidable);
          striderRidableInWater = getBoolean("mobs.strider.ridable-in-water", striderRidableInWater);
-@@ -1617,6 +1658,7 @@ public class PurpurWorldConfig {
+@@ -1619,6 +1660,7 @@ public class PurpurWorldConfig {
              set("mobs.strider.attributes.max_health", oldValue);
          }
          striderMaxHealth = getDouble("mobs.strider.attributes.max_health", striderMaxHealth);
@@ -820,7 +820,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean tadpoleRidable = false;
-@@ -1637,6 +1679,7 @@ public class PurpurWorldConfig {
+@@ -1639,6 +1681,7 @@ public class PurpurWorldConfig {
      public double traderLlamaJumpStrengthMax = 0.5D;
      public double traderLlamaMovementSpeedMin = 0.175D;
      public double traderLlamaMovementSpeedMax = 0.175D;
@@ -828,7 +828,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void traderLlamaSettings() {
          traderLlamaRidable = getBoolean("mobs.trader_llama.ridable", traderLlamaRidable);
          traderLlamaRidableInWater = getBoolean("mobs.trader_llama.ridable-in-water", traderLlamaRidableInWater);
-@@ -1654,6 +1697,7 @@ public class PurpurWorldConfig {
+@@ -1656,6 +1699,7 @@ public class PurpurWorldConfig {
          traderLlamaJumpStrengthMax = getDouble("mobs.trader_llama.attributes.jump_strength.max", traderLlamaJumpStrengthMax);
          traderLlamaMovementSpeedMin = getDouble("mobs.trader_llama.attributes.movement_speed.min", traderLlamaMovementSpeedMin);
          traderLlamaMovementSpeedMax = getDouble("mobs.trader_llama.attributes.movement_speed.max", traderLlamaMovementSpeedMax);
@@ -836,7 +836,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean tropicalFishRidable = false;
-@@ -1674,6 +1718,7 @@ public class PurpurWorldConfig {
+@@ -1676,6 +1720,7 @@ public class PurpurWorldConfig {
      public boolean turtleRidableInWater = false;
      public boolean turtleControllable = true;
      public double turtleMaxHealth = 30.0D;
@@ -844,7 +844,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void turtleSettings() {
          turtleRidable = getBoolean("mobs.turtle.ridable", turtleRidable);
          turtleRidableInWater = getBoolean("mobs.turtle.ridable-in-water", turtleRidableInWater);
-@@ -1684,6 +1729,7 @@ public class PurpurWorldConfig {
+@@ -1686,6 +1731,7 @@ public class PurpurWorldConfig {
              set("mobs.turtle.attributes.max_health", oldValue);
          }
          turtleMaxHealth = getDouble("mobs.turtle.attributes.max_health", turtleMaxHealth);
@@ -852,7 +852,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean vexRidable = false;
-@@ -1713,6 +1759,7 @@ public class PurpurWorldConfig {
+@@ -1715,6 +1761,7 @@ public class PurpurWorldConfig {
      public boolean villagerFollowEmeraldBlock = false;
      public boolean villagerCanBeLeashed = false;
      public boolean villagerCanBreed = true;
@@ -860,7 +860,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -1728,6 +1775,7 @@ public class PurpurWorldConfig {
+@@ -1730,6 +1777,7 @@ public class PurpurWorldConfig {
          villagerFollowEmeraldBlock = getBoolean("mobs.villager.follow-emerald-blocks", villagerFollowEmeraldBlock);
          villagerCanBeLeashed = getBoolean("mobs.villager.can-be-leashed", villagerCanBeLeashed);
          villagerCanBreed = getBoolean("mobs.villager.can-breed", villagerCanBreed);
@@ -868,7 +868,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      }
  
      public boolean vindicatorRidable = false;
-@@ -1839,6 +1887,7 @@ public class PurpurWorldConfig {
+@@ -1841,6 +1889,7 @@ public class PurpurWorldConfig {
      public boolean wolfRidableInWater = false;
      public boolean wolfControllable = true;
      public double wolfMaxHealth = 8.0D;
@@ -876,7 +876,7 @@ index ec65383579b629b6ba3009001c654ae45b434f7b..2902ff168400063c3a6a37427fe37910
      private void wolfSettings() {
          wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
          wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
-@@ -1849,6 +1898,7 @@ public class PurpurWorldConfig {
+@@ -1851,6 +1900,7 @@ public class PurpurWorldConfig {
              set("mobs.wolf.attributes.max_health", oldValue);
          }
          wolfMaxHealth = getDouble("mobs.wolf.attributes.max_health", wolfMaxHealth);

--- a/patches/server/0112-Add-config-for-allowing-Endermen-to-despawn-even-whi.patch
+++ b/patches/server/0112-Add-config-for-allowing-Endermen-to-despawn-even-whi.patch
@@ -21,10 +21,10 @@ index 9458cab33d4ff468d3d009cc1c3b3736f21f649b..4443a4a300d17e8568a81bcb9af89251
  
      private static class EndermanFreezeWhenLookedAt extends Goal {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f58adcc7a4c739a28825ec63c96728231a6b6565..cfd7173d287ca17b923c57dbe17ace5d40192980 100644
+index b9f7eff06f71e7f60ad478b8ddfbaa225678dda2..a7549c81217ebe11d7f1b9d605b55597200363f3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -809,6 +809,7 @@ public class PurpurWorldConfig {
+@@ -811,6 +811,7 @@ public class PurpurWorldConfig {
      public boolean endermanControllable = true;
      public double endermanMaxHealth = 40.0D;
      public boolean endermanAllowGriefing = true;
@@ -32,7 +32,7 @@ index f58adcc7a4c739a28825ec63c96728231a6b6565..cfd7173d287ca17b923c57dbe17ace5d
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -820,6 +821,7 @@ public class PurpurWorldConfig {
+@@ -822,6 +823,7 @@ public class PurpurWorldConfig {
          }
          endermanMaxHealth = getDouble("mobs.enderman.attributes.max_health", endermanMaxHealth);
          endermanAllowGriefing = getBoolean("mobs.enderman.allow-griefing", endermanAllowGriefing);

--- a/patches/server/0116-Snow-Golem-rate-of-fire-config.patch
+++ b/patches/server/0116-Snow-Golem-rate-of-fire-config.patch
@@ -23,10 +23,10 @@ index b4459d68397cc5bac4f7ef79a2dfb18f3eb24f77..b9025929fcc89e72aa820953b91a6542
          this.goalSelector.addGoal(3, new LookAtPlayerGoal(this, Player.class, 6.0F));
          this.goalSelector.addGoal(4, new RandomLookAroundGoal(this));
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4bf80aba46dee82cbbd1243f5f3357039f1d9835..59981e32f601e03f8891fc2c05179e2155587b66 100644
+index 0671853ed91ad046ad02cbb09188766e7afbaa9d..b031d456c6360ca0ff2900a2d8a56f1c6d5b4421 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1593,6 +1593,10 @@ public class PurpurWorldConfig {
+@@ -1595,6 +1595,10 @@ public class PurpurWorldConfig {
      public double snowGolemMaxHealth = 4.0D;
      public boolean snowGolemDropsPumpkin = true;
      public boolean snowGolemPutPumpkinBack = false;
@@ -37,7 +37,7 @@ index 4bf80aba46dee82cbbd1243f5f3357039f1d9835..59981e32f601e03f8891fc2c05179e21
      private void snowGolemSettings() {
          snowGolemRidable = getBoolean("mobs.snow_golem.ridable", snowGolemRidable);
          snowGolemRidableInWater = getBoolean("mobs.snow_golem.ridable-in-water", snowGolemRidableInWater);
-@@ -1606,6 +1610,10 @@ public class PurpurWorldConfig {
+@@ -1608,6 +1612,10 @@ public class PurpurWorldConfig {
          snowGolemMaxHealth = getDouble("mobs.snow_golem.attributes.max_health", snowGolemMaxHealth);
          snowGolemDropsPumpkin = getBoolean("mobs.snow_golem.drop-pumpkin-when-sheared", snowGolemDropsPumpkin);
          snowGolemPutPumpkinBack = getBoolean("mobs.snow_golem.pumpkin-can-be-added-back", snowGolemPutPumpkinBack);

--- a/patches/server/0118-Option-for-Villager-Clerics-to-farm-Nether-Wart.patch
+++ b/patches/server/0118-Option-for-Villager-Clerics-to-farm-Nether-Wart.patch
@@ -181,10 +181,10 @@ index b1f20cb356e6b4e89fdddf4e48f2fd932bdb5170..352a7df156c638684a12a864eb5a9d06
      public static final VillagerProfession FISHERMAN = register("fisherman", PoiTypes.FISHERMAN, SoundEvents.VILLAGER_WORK_FISHERMAN);
      public static final VillagerProfession FLETCHER = register("fletcher", PoiTypes.FLETCHER, SoundEvents.VILLAGER_WORK_FLETCHER);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 59981e32f601e03f8891fc2c05179e2155587b66..b00a8458655fc101f42f772487c4f0c6edc1f444 100644
+index b031d456c6360ca0ff2900a2d8a56f1c6d5b4421..1a575a511b94808399e8b368a1628a52f66abef7 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1785,6 +1785,8 @@ public class PurpurWorldConfig {
+@@ -1787,6 +1787,8 @@ public class PurpurWorldConfig {
      public boolean villagerCanBeLeashed = false;
      public boolean villagerCanBreed = true;
      public int villagerBreedingTicks = 6000;
@@ -193,7 +193,7 @@ index 59981e32f601e03f8891fc2c05179e2155587b66..b00a8458655fc101f42f772487c4f0c6
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -1801,6 +1803,8 @@ public class PurpurWorldConfig {
+@@ -1803,6 +1805,8 @@ public class PurpurWorldConfig {
          villagerCanBeLeashed = getBoolean("mobs.villager.can-be-leashed", villagerCanBeLeashed);
          villagerCanBreed = getBoolean("mobs.villager.can-breed", villagerCanBreed);
          villagerBreedingTicks = getInt("mobs.villager.breeding-delay-ticks", villagerBreedingTicks);

--- a/patches/server/0119-Toggle-for-Zombified-Piglin-death-always-counting-as.patch
+++ b/patches/server/0119-Toggle-for-Zombified-Piglin-death-always-counting-as.patch
@@ -35,10 +35,10 @@ index 6c1dd723373f9b1b920548de85aeb6cef0120fa7..1f0003fb08a45af02e6d38e28fa548ab
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b00a8458655fc101f42f772487c4f0c6edc1f444..de4dde048cfe5320a885752f1bfd4886d19d8688 100644
+index 1a575a511b94808399e8b368a1628a52f66abef7..ceadfbae389c77a106c5647ce1703fb731139f40 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2031,6 +2031,7 @@ public class PurpurWorldConfig {
+@@ -2033,6 +2033,7 @@ public class PurpurWorldConfig {
      public boolean zombifiedPiglinJockeyOnlyBaby = true;
      public double zombifiedPiglinJockeyChance = 0.05D;
      public boolean zombifiedPiglinJockeyTryExistingChickens = true;
@@ -46,7 +46,7 @@ index b00a8458655fc101f42f772487c4f0c6edc1f444..de4dde048cfe5320a885752f1bfd4886
      private void zombifiedPiglinSettings() {
          zombifiedPiglinRidable = getBoolean("mobs.zombified_piglin.ridable", zombifiedPiglinRidable);
          zombifiedPiglinRidableInWater = getBoolean("mobs.zombified_piglin.ridable-in-water", zombifiedPiglinRidableInWater);
-@@ -2045,5 +2046,6 @@ public class PurpurWorldConfig {
+@@ -2047,5 +2048,6 @@ public class PurpurWorldConfig {
          zombifiedPiglinJockeyOnlyBaby = getBoolean("mobs.zombified_piglin.jockey.only-babies", zombifiedPiglinJockeyOnlyBaby);
          zombifiedPiglinJockeyChance = getDouble("mobs.zombified_piglin.jockey.chance", zombifiedPiglinJockeyChance);
          zombifiedPiglinJockeyTryExistingChickens = getBoolean("mobs.zombified_piglin.jockey.try-existing-chickens", zombifiedPiglinJockeyTryExistingChickens);

--- a/patches/server/0121-Configurable-chance-for-wolves-to-spawn-rabid.patch
+++ b/patches/server/0121-Configurable-chance-for-wolves-to-spawn-rabid.patch
@@ -222,10 +222,10 @@ index e43fd3e59fd8c74828ae65965fade27f56beef65..b2f133c8baabba1cffa6e92ea0f85453
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index de4dde048cfe5320a885752f1bfd4886d19d8688..8832680891a10afb12aa29370ac66f344b1482e9 100644
+index ceadfbae389c77a106c5647ce1703fb731139f40..b567dff45e17a988179d8b07ef1bd04f1db0fd1a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1916,6 +1916,8 @@ public class PurpurWorldConfig {
+@@ -1918,6 +1918,8 @@ public class PurpurWorldConfig {
      public boolean wolfRidableInWater = false;
      public boolean wolfControllable = true;
      public double wolfMaxHealth = 8.0D;
@@ -234,7 +234,7 @@ index de4dde048cfe5320a885752f1bfd4886d19d8688..8832680891a10afb12aa29370ac66f34
      public int wolfBreedingTicks = 6000;
      private void wolfSettings() {
          wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
-@@ -1927,6 +1929,8 @@ public class PurpurWorldConfig {
+@@ -1929,6 +1931,8 @@ public class PurpurWorldConfig {
              set("mobs.wolf.attributes.max_health", oldValue);
          }
          wolfMaxHealth = getDouble("mobs.wolf.attributes.max_health", wolfMaxHealth);

--- a/patches/server/0122-Configurable-default-collar-color.patch
+++ b/patches/server/0122-Configurable-default-collar-color.patch
@@ -43,10 +43,10 @@ index f862d83db6127804b9254a33a73e6f186a1d1327..ffe8f80cfe3bec8fe79415015f529074
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 8832680891a10afb12aa29370ac66f344b1482e9..44aad04a796ed8d9de5e8f23244a6b7911994910 100644
+index b567dff45e17a988179d8b07ef1bd04f1db0fd1a..dc91c3594e462c0ae80f82fd50fad68a58d1d604 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -597,6 +597,7 @@ public class PurpurWorldConfig {
+@@ -599,6 +599,7 @@ public class PurpurWorldConfig {
      public int catSpawnSwampHutScanRange = 16;
      public int catSpawnVillageScanRange = 48;
      public int catBreedingTicks = 6000;
@@ -54,7 +54,7 @@ index 8832680891a10afb12aa29370ac66f344b1482e9..44aad04a796ed8d9de5e8f23244a6b79
      private void catSettings() {
          catRidable = getBoolean("mobs.cat.ridable", catRidable);
          catRidableInWater = getBoolean("mobs.cat.ridable-in-water", catRidableInWater);
-@@ -611,6 +612,11 @@ public class PurpurWorldConfig {
+@@ -613,6 +614,11 @@ public class PurpurWorldConfig {
          catSpawnSwampHutScanRange = getInt("mobs.cat.scan-range-for-other-cats.swamp-hut", catSpawnSwampHutScanRange);
          catSpawnVillageScanRange = getInt("mobs.cat.scan-range-for-other-cats.village", catSpawnVillageScanRange);
          catBreedingTicks = getInt("mobs.cat.breeding-delay-ticks", catBreedingTicks);
@@ -66,7 +66,7 @@ index 8832680891a10afb12aa29370ac66f344b1482e9..44aad04a796ed8d9de5e8f23244a6b79
      }
  
      public boolean caveSpiderRidable = false;
-@@ -1916,6 +1922,7 @@ public class PurpurWorldConfig {
+@@ -1918,6 +1924,7 @@ public class PurpurWorldConfig {
      public boolean wolfRidableInWater = false;
      public boolean wolfControllable = true;
      public double wolfMaxHealth = 8.0D;
@@ -74,7 +74,7 @@ index 8832680891a10afb12aa29370ac66f344b1482e9..44aad04a796ed8d9de5e8f23244a6b79
      public boolean wolfMilkCuresRabies = true;
      public double wolfNaturalRabid = 0.0D;
      public int wolfBreedingTicks = 6000;
-@@ -1929,6 +1936,11 @@ public class PurpurWorldConfig {
+@@ -1931,6 +1938,11 @@ public class PurpurWorldConfig {
              set("mobs.wolf.attributes.max_health", oldValue);
          }
          wolfMaxHealth = getDouble("mobs.wolf.attributes.max_health", wolfMaxHealth);

--- a/patches/server/0123-Phantom-flames-on-swoop.patch
+++ b/patches/server/0123-Phantom-flames-on-swoop.patch
@@ -17,10 +17,10 @@ index 77716d29aa50887bfa704ebafe2a304faddcc5c2..9858361d4dd5407b5d24bd5ac656c2ea
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 44aad04a796ed8d9de5e8f23244a6b7911994910..fadf5c1c65c3c7bd240d281f3bc1c0cf28499dca 100644
+index dc91c3594e462c0ae80f82fd50fad68a58d1d604..4cf965cc6ffaef8b5c655a17faa79fde45a0ff15 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1281,6 +1281,7 @@ public class PurpurWorldConfig {
+@@ -1283,6 +1283,7 @@ public class PurpurWorldConfig {
      public int phantomBurnInLight = 0;
      public boolean phantomIgnorePlayersWithTorch = false;
      public boolean phantomBurnInDaylight = true;
@@ -28,7 +28,7 @@ index 44aad04a796ed8d9de5e8f23244a6b7911994910..fadf5c1c65c3c7bd240d281f3bc1c0cf
      private void phantomSettings() {
          phantomRidable = getBoolean("mobs.phantom.ridable", phantomRidable);
          phantomRidableInWater = getBoolean("mobs.phantom.ridable-in-water", phantomRidableInWater);
-@@ -1320,6 +1321,7 @@ public class PurpurWorldConfig {
+@@ -1322,6 +1323,7 @@ public class PurpurWorldConfig {
          phantomBurnInLight = getInt("mobs.phantom.burn-in-light", phantomBurnInLight);
          phantomBurnInDaylight = getBoolean("mobs.phantom.burn-in-daylight", phantomBurnInDaylight);
          phantomIgnorePlayersWithTorch = getBoolean("mobs.phantom.ignore-players-with-torch", phantomIgnorePlayersWithTorch);

--- a/patches/server/0124-Option-for-chests-to-open-even-with-a-solid-block-on.patch
+++ b/patches/server/0124-Option-for-chests-to-open-even-with-a-solid-block-on.patch
@@ -17,10 +17,10 @@ index c6b57d45383441aa35510e759ce3cb82bc98f305..330ff3bc5fd8625e37b79e1204eddbe8
  
          return world.getBlockState(blockposition1).isRedstoneConductor(world, blockposition1);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index fadf5c1c65c3c7bd240d281f3bc1c0cf28499dca..7662645e5b836383b2f859a01c560d6357462629 100644
+index 4cf965cc6ffaef8b5c655a17faa79fde45a0ff15..3155dbf8ba8871d32cbe13400bbd5d01a5d47a8f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -419,6 +419,11 @@ public class PurpurWorldConfig {
+@@ -421,6 +421,11 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0126-Striders-give-saddle-back.patch
+++ b/patches/server/0126-Striders-give-saddle-back.patch
@@ -29,10 +29,10 @@ index eb2083d67f9486a24d2f0aa4bf1f5ba8a00e23a3..df9d16a6493a57b6034cd56bf8dbe38f
              if (!this.level.isClientSide) {
                  player.startRiding(this);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7662645e5b836383b2f859a01c560d6357462629..fcef95f95698bdb939b4372ad56a907a85b5d06f 100644
+index 3155dbf8ba8871d32cbe13400bbd5d01a5d47a8f..20099e9f2abac2a34a3ac86d17dd0860fe0d864a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1686,6 +1686,7 @@ public class PurpurWorldConfig {
+@@ -1688,6 +1688,7 @@ public class PurpurWorldConfig {
      public boolean striderControllable = true;
      public double striderMaxHealth = 20.0D;
      public int striderBreedingTicks = 6000;
@@ -40,7 +40,7 @@ index 7662645e5b836383b2f859a01c560d6357462629..fcef95f95698bdb939b4372ad56a907a
      private void striderSettings() {
          striderRidable = getBoolean("mobs.strider.ridable", striderRidable);
          striderRidableInWater = getBoolean("mobs.strider.ridable-in-water", striderRidableInWater);
-@@ -1697,6 +1698,7 @@ public class PurpurWorldConfig {
+@@ -1699,6 +1700,7 @@ public class PurpurWorldConfig {
          }
          striderMaxHealth = getDouble("mobs.strider.attributes.max_health", striderMaxHealth);
          striderBreedingTicks = getInt("mobs.strider.breeding-delay-ticks", striderBreedingTicks);

--- a/patches/server/0130-Add-mobGriefing-bypass-to-everything-affected.patch
+++ b/patches/server/0130-Add-mobGriefing-bypass-to-everything-affected.patch
@@ -409,7 +409,7 @@ index 1a12fee99a8b69fc6c01e1e217575c7c19e13155..4907e0acb7d01b7f57b75579e58ce743
          return true;
          // Purpur end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349ed29bda43 100644
+index d0176655802d082a946cf84d06824ff1505ba1bb..48a798236bf46ef076cdd5efa5a6cb5d28b7a1ea 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -118,8 +118,11 @@ public class PurpurWorldConfig {
@@ -436,7 +436,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
          tridentLoyaltyVoidReturnHeight = getDouble("gameplay-mechanics.trident-loyalty-void-return-height", tridentLoyaltyVoidReturnHeight);
          voidDamageHeight = getDouble("gameplay-mechanics.void-damage-height", voidDamageHeight);
          voidDamageDealt = getDouble("gameplay-mechanics.void-damage-dealt", voidDamageDealt);
-@@ -444,9 +450,11 @@ public class PurpurWorldConfig {
+@@ -446,9 +452,11 @@ public class PurpurWorldConfig {
          dispenserPlaceAnvils = getBoolean("blocks.dispenser.place-anvils", dispenserPlaceAnvils);
      }
  
@@ -448,7 +448,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
          farmlandGetsMoistFromBelow = getBoolean("blocks.farmland.gets-moist-from-below", farmlandGetsMoistFromBelow);
          farmlandAlpha = getBoolean("blocks.farmland.use-alpha-farmland", farmlandAlpha);
      }
-@@ -473,6 +481,11 @@ public class PurpurWorldConfig {
+@@ -475,6 +483,11 @@ public class PurpurWorldConfig {
          lavaSpeedNotNether = getInt("blocks.lava.speed.not-nether", lavaSpeedNotNether);
      }
  
@@ -460,7 +460,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      public boolean respawnAnchorExplode = true;
      public double respawnAnchorExplosionPower = 5.0D;
      public boolean respawnAnchorExplosionFire = true;
-@@ -502,10 +515,12 @@ public class PurpurWorldConfig {
+@@ -504,10 +517,12 @@ public class PurpurWorldConfig {
      public boolean turtleEggsBreakFromExpOrbs = true;
      public boolean turtleEggsBreakFromItems = true;
      public boolean turtleEggsBreakFromMinecarts = true;
@@ -473,7 +473,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean waterInfinite = true;
-@@ -713,6 +728,7 @@ public class PurpurWorldConfig {
+@@ -715,6 +730,7 @@ public class PurpurWorldConfig {
      public double creeperMaxHealth = 20.0D;
      public double creeperChargedChance = 0.0D;
      public boolean creeperAllowGriefing = true;
@@ -481,7 +481,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -725,6 +741,7 @@ public class PurpurWorldConfig {
+@@ -727,6 +743,7 @@ public class PurpurWorldConfig {
          creeperMaxHealth = getDouble("mobs.creeper.attributes.max_health", creeperMaxHealth);
          creeperChargedChance = getDouble("mobs.creeper.naturally-charged-chance", creeperChargedChance);
          creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
@@ -489,7 +489,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean dolphinRidable = false;
-@@ -819,6 +836,7 @@ public class PurpurWorldConfig {
+@@ -821,6 +838,7 @@ public class PurpurWorldConfig {
      public double enderDragonMaxY = 320D;
      public double enderDragonMaxHealth = 200.0D;
      public boolean enderDragonAlwaysDropsFullExp = false;
@@ -497,7 +497,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void enderDragonSettings() {
          enderDragonRidable = getBoolean("mobs.ender_dragon.ridable", enderDragonRidable);
          enderDragonRidableInWater = getBoolean("mobs.ender_dragon.ridable-in-water", enderDragonRidableInWater);
-@@ -835,6 +853,7 @@ public class PurpurWorldConfig {
+@@ -837,6 +855,7 @@ public class PurpurWorldConfig {
          }
          enderDragonMaxHealth = getDouble("mobs.ender_dragon.attributes.max_health", enderDragonMaxHealth);
          enderDragonAlwaysDropsFullExp = getBoolean("mobs.ender_dragon.always-drop-full-exp", enderDragonAlwaysDropsFullExp);
@@ -505,7 +505,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean endermanRidable = false;
-@@ -843,6 +862,7 @@ public class PurpurWorldConfig {
+@@ -845,6 +864,7 @@ public class PurpurWorldConfig {
      public double endermanMaxHealth = 40.0D;
      public boolean endermanAllowGriefing = true;
      public boolean endermanDespawnEvenWithBlock = false;
@@ -513,7 +513,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -855,6 +875,7 @@ public class PurpurWorldConfig {
+@@ -857,6 +877,7 @@ public class PurpurWorldConfig {
          endermanMaxHealth = getDouble("mobs.enderman.attributes.max_health", endermanMaxHealth);
          endermanAllowGriefing = getBoolean("mobs.enderman.allow-griefing", endermanAllowGriefing);
          endermanDespawnEvenWithBlock = getBoolean("mobs.enderman.can-despawn-with-held-block", endermanDespawnEvenWithBlock);
@@ -521,7 +521,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean endermiteRidable = false;
-@@ -877,6 +898,7 @@ public class PurpurWorldConfig {
+@@ -879,6 +900,7 @@ public class PurpurWorldConfig {
      public boolean evokerRidableInWater = false;
      public boolean evokerControllable = true;
      public double evokerMaxHealth = 24.0D;
@@ -529,7 +529,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void evokerSettings() {
          evokerRidable = getBoolean("mobs.evoker.ridable", evokerRidable);
          evokerRidableInWater = getBoolean("mobs.evoker.ridable-in-water", evokerRidableInWater);
-@@ -887,6 +909,7 @@ public class PurpurWorldConfig {
+@@ -889,6 +911,7 @@ public class PurpurWorldConfig {
              set("mobs.evoker.attributes.max_health", oldValue);
          }
          evokerMaxHealth = getDouble("mobs.evoker.attributes.max_health", evokerMaxHealth);
@@ -537,7 +537,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean foxRidable = false;
-@@ -895,6 +918,7 @@ public class PurpurWorldConfig {
+@@ -897,6 +920,7 @@ public class PurpurWorldConfig {
      public double foxMaxHealth = 10.0D;
      public boolean foxTypeChangesWithTulips = false;
      public int foxBreedingTicks = 6000;
@@ -545,7 +545,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void foxSettings() {
          foxRidable = getBoolean("mobs.fox.ridable", foxRidable);
          foxRidableInWater = getBoolean("mobs.fox.ridable-in-water", foxRidableInWater);
-@@ -907,6 +931,7 @@ public class PurpurWorldConfig {
+@@ -909,6 +933,7 @@ public class PurpurWorldConfig {
          foxMaxHealth = getDouble("mobs.fox.attributes.max_health", foxMaxHealth);
          foxTypeChangesWithTulips = getBoolean("mobs.fox.tulips-change-type", foxTypeChangesWithTulips);
          foxBreedingTicks = getInt("mobs.fox.breeding-delay-ticks", foxBreedingTicks);
@@ -553,7 +553,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean frogRidable = false;
-@@ -1366,6 +1391,7 @@ public class PurpurWorldConfig {
+@@ -1368,6 +1393,7 @@ public class PurpurWorldConfig {
      public boolean piglinRidableInWater = false;
      public boolean piglinControllable = true;
      public double piglinMaxHealth = 16.0D;
@@ -561,7 +561,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -1376,6 +1402,7 @@ public class PurpurWorldConfig {
+@@ -1378,6 +1404,7 @@ public class PurpurWorldConfig {
              set("mobs.piglin.attributes.max_health", oldValue);
          }
          piglinMaxHealth = getDouble("mobs.piglin.attributes.max_health", piglinMaxHealth);
@@ -569,7 +569,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean piglinBruteRidable = false;
-@@ -1398,6 +1425,7 @@ public class PurpurWorldConfig {
+@@ -1400,6 +1427,7 @@ public class PurpurWorldConfig {
      public boolean pillagerRidableInWater = false;
      public boolean pillagerControllable = true;
      public double pillagerMaxHealth = 24.0D;
@@ -577,7 +577,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void pillagerSettings() {
          pillagerRidable = getBoolean("mobs.pillager.ridable", pillagerRidable);
          pillagerRidableInWater = getBoolean("mobs.pillager.ridable-in-water", pillagerRidableInWater);
-@@ -1408,6 +1436,7 @@ public class PurpurWorldConfig {
+@@ -1410,6 +1438,7 @@ public class PurpurWorldConfig {
              set("mobs.pillager.attributes.max_health", oldValue);
          }
          pillagerMaxHealth = getDouble("mobs.pillager.attributes.max_health", pillagerMaxHealth);
@@ -585,7 +585,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean polarBearRidable = false;
-@@ -1454,6 +1483,7 @@ public class PurpurWorldConfig {
+@@ -1456,6 +1485,7 @@ public class PurpurWorldConfig {
      public double rabbitNaturalToast = 0.0D;
      public double rabbitNaturalKiller = 0.0D;
      public int rabbitBreedingTicks = 6000;
@@ -593,7 +593,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void rabbitSettings() {
          rabbitRidable = getBoolean("mobs.rabbit.ridable", rabbitRidable);
          rabbitRidableInWater = getBoolean("mobs.rabbit.ridable-in-water", rabbitRidableInWater);
-@@ -1467,12 +1497,14 @@ public class PurpurWorldConfig {
+@@ -1469,12 +1499,14 @@ public class PurpurWorldConfig {
          rabbitNaturalToast = getDouble("mobs.rabbit.spawn-toast-chance", rabbitNaturalToast);
          rabbitNaturalKiller = getDouble("mobs.rabbit.spawn-killer-rabbit-chance", rabbitNaturalKiller);
          rabbitBreedingTicks = getInt("mobs.rabbit.breeding-delay-ticks", rabbitBreedingTicks);
@@ -608,7 +608,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void ravagerSettings() {
          ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
          ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
-@@ -1483,6 +1515,7 @@ public class PurpurWorldConfig {
+@@ -1485,6 +1517,7 @@ public class PurpurWorldConfig {
              set("mobs.ravager.attributes.max_health", oldValue);
          }
          ravagerMaxHealth = getDouble("mobs.ravager.attributes.max_health", ravagerMaxHealth);
@@ -616,7 +616,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean salmonRidable = false;
-@@ -1504,6 +1537,7 @@ public class PurpurWorldConfig {
+@@ -1506,6 +1539,7 @@ public class PurpurWorldConfig {
      public boolean sheepControllable = true;
      public double sheepMaxHealth = 8.0D;
      public int sheepBreedingTicks = 6000;
@@ -624,7 +624,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -1515,6 +1549,7 @@ public class PurpurWorldConfig {
+@@ -1517,6 +1551,7 @@ public class PurpurWorldConfig {
          }
          sheepMaxHealth = getDouble("mobs.sheep.attributes.max_health", sheepMaxHealth);
          sheepBreedingTicks = getInt("mobs.sheep.breeding-delay-ticks", sheepBreedingTicks);
@@ -632,7 +632,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean shulkerRidable = false;
-@@ -1537,6 +1572,7 @@ public class PurpurWorldConfig {
+@@ -1539,6 +1574,7 @@ public class PurpurWorldConfig {
      public boolean silverfishRidableInWater = false;
      public boolean silverfishControllable = true;
      public double silverfishMaxHealth = 8.0D;
@@ -640,7 +640,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void silverfishSettings() {
          silverfishRidable = getBoolean("mobs.silverfish.ridable", silverfishRidable);
          silverfishRidableInWater = getBoolean("mobs.silverfish.ridable-in-water", silverfishRidableInWater);
-@@ -1547,6 +1583,7 @@ public class PurpurWorldConfig {
+@@ -1549,6 +1585,7 @@ public class PurpurWorldConfig {
              set("mobs.silverfish.attributes.max_health", oldValue);
          }
          silverfishMaxHealth = getDouble("mobs.silverfish.attributes.max_health", silverfishMaxHealth);
@@ -648,7 +648,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean skeletonRidable = false;
-@@ -1623,6 +1660,7 @@ public class PurpurWorldConfig {
+@@ -1625,6 +1662,7 @@ public class PurpurWorldConfig {
      public int snowGolemSnowBallMax = 20;
      public float snowGolemSnowBallModifier = 10.0F;
      public double snowGolemAttackDistance = 1.25D;
@@ -656,7 +656,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void snowGolemSettings() {
          snowGolemRidable = getBoolean("mobs.snow_golem.ridable", snowGolemRidable);
          snowGolemRidableInWater = getBoolean("mobs.snow_golem.ridable-in-water", snowGolemRidableInWater);
-@@ -1640,6 +1678,7 @@ public class PurpurWorldConfig {
+@@ -1642,6 +1680,7 @@ public class PurpurWorldConfig {
          snowGolemSnowBallMax = getInt("mobs.snow_golem.max-shoot-interval-ticks", snowGolemSnowBallMax);
          snowGolemSnowBallModifier = (float) getDouble("mobs.snow_golem.snow-ball-modifier", snowGolemSnowBallModifier);
          snowGolemAttackDistance = getDouble("mobs.snow_golem.attack-distance", snowGolemAttackDistance);
@@ -664,7 +664,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean squidRidable = false;
-@@ -1815,6 +1854,7 @@ public class PurpurWorldConfig {
+@@ -1817,6 +1856,7 @@ public class PurpurWorldConfig {
      public int villagerBreedingTicks = 6000;
      public boolean villagerClericsFarmWarts = false;
      public boolean villagerClericFarmersThrowWarts = true;
@@ -672,7 +672,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -1833,6 +1873,7 @@ public class PurpurWorldConfig {
+@@ -1835,6 +1875,7 @@ public class PurpurWorldConfig {
          villagerBreedingTicks = getInt("mobs.villager.breeding-delay-ticks", villagerBreedingTicks);
          villagerClericsFarmWarts = getBoolean("mobs.villager.clerics-farm-warts", villagerClericsFarmWarts);
          villagerClericFarmersThrowWarts = getBoolean("mobs.villager.cleric-wart-farmers-throw-warts-at-villagers", villagerClericFarmersThrowWarts);
@@ -680,7 +680,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean vindicatorRidable = false;
-@@ -1905,6 +1946,7 @@ public class PurpurWorldConfig {
+@@ -1907,6 +1948,7 @@ public class PurpurWorldConfig {
      public double witherMaxHealth = 300.0D;
      public float witherHealthRegenAmount = 1.0f;
      public int witherHealthRegenDelay = 20;
@@ -688,7 +688,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -1922,6 +1964,7 @@ public class PurpurWorldConfig {
+@@ -1924,6 +1966,7 @@ public class PurpurWorldConfig {
          witherMaxHealth = getDouble("mobs.wither.attributes.max_health", witherMaxHealth);
          witherHealthRegenAmount = (float) getDouble("mobs.wither.health-regen-amount", witherHealthRegenAmount);
          witherHealthRegenDelay = getInt("mobs.wither.health-regen-delay", witherHealthRegenDelay);
@@ -696,7 +696,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      }
  
      public boolean witherSkeletonRidable = false;
-@@ -1993,6 +2036,7 @@ public class PurpurWorldConfig {
+@@ -1995,6 +2038,7 @@ public class PurpurWorldConfig {
      public double zombieJockeyChance = 0.05D;
      public boolean zombieJockeyTryExistingChickens = true;
      public boolean zombieAggressiveTowardsVillagerWhenLagging = true;
@@ -704,7 +704,7 @@ index 91d625799d51ac590eb73fd44e3373a8d5a0d762..c7ea267c63a30ba8d2d65c5fe55c349e
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -2008,6 +2052,7 @@ public class PurpurWorldConfig {
+@@ -2010,6 +2054,7 @@ public class PurpurWorldConfig {
          zombieJockeyChance = getDouble("mobs.zombie.jockey.chance", zombieJockeyChance);
          zombieJockeyTryExistingChickens = getBoolean("mobs.zombie.jockey.try-existing-chickens", zombieJockeyTryExistingChickens);
          zombieAggressiveTowardsVillagerWhenLagging = getBoolean("mobs.zombie.aggressive-towards-villager-when-lagging", zombieAggressiveTowardsVillagerWhenLagging);

--- a/patches/server/0133-Farmland-trampling-changes.patch
+++ b/patches/server/0133-Farmland-trampling-changes.patch
@@ -37,10 +37,10 @@ index d92ea9f29b9d919871662977d3e3eb41ddf2eb35..e5a3e3a4367dfb924624a913b816b3fd
              if (CraftEventFactory.callEntityChangeBlockEvent(entity, pos, Blocks.DIRT.defaultBlockState()).isCancelled()) {
                  return;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ea6af61304f6384009a2a661c042854a29c3f50b..603145af0c61788c7ae268a763f3df7c6c0686dc 100644
+index 88588ca9af08f255e099733c6c0692cde7115394..efdb38bb6cb70176460514cb63e5bf5c984f7911 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -457,10 +457,16 @@ public class PurpurWorldConfig {
+@@ -459,10 +459,16 @@ public class PurpurWorldConfig {
      public boolean farmlandBypassMobGriefing = false;
      public boolean farmlandGetsMoistFromBelow = false;
      public boolean farmlandAlpha = false;

--- a/patches/server/0136-Toggle-for-water-sensitive-mob-damage.patch
+++ b/patches/server/0136-Toggle-for-water-sensitive-mob-damage.patch
@@ -427,7 +427,7 @@ index e68a40ec759925317a0db2087339cd29351dbeb4..858a5beea8b038822789e6daec956163
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
-index 59caabbe84a24ea47796ae71130961dff146a76f..ae50bb7e86cddd95a0b49a89682083994ddf14ef 100644
+index af6bc24065f0db7b12962b5b718b5fb82cf5fa22..c95126870665d3c456940a9d1d9f54d30d8d6cd4 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
 @@ -114,6 +114,11 @@ public class Goat extends Animal {
@@ -1197,10 +1197,10 @@ index 8756e0d8d0077308f5fb74bf45fe093d0f043c99..6dd8856816bebb2766203589048cc68b
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddfb55ef555 100644
+index 4e996becabad942aaaa5ccb097707b0e2fd83adb..7862f9ff2b5179751949a0efedc03087611a7219 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -570,11 +570,13 @@ public class PurpurWorldConfig {
+@@ -572,11 +572,13 @@ public class PurpurWorldConfig {
      public boolean axolotlControllable = true;
      public double axolotlMaxHealth = 14.0D;
      public int axolotlBreedingTicks = 6000;
@@ -1214,7 +1214,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean batRidable = false;
-@@ -589,6 +591,7 @@ public class PurpurWorldConfig {
+@@ -591,6 +593,7 @@ public class PurpurWorldConfig {
      public double batArmor = 0.0D;
      public double batArmorToughness = 0.0D;
      public double batAttackKnockback = 0.0D;
@@ -1222,7 +1222,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void batSettings() {
          batRidable = getBoolean("mobs.bat.ridable", batRidable);
          batRidableInWater = getBoolean("mobs.bat.ridable-in-water", batRidableInWater);
-@@ -600,6 +603,7 @@ public class PurpurWorldConfig {
+@@ -602,6 +605,7 @@ public class PurpurWorldConfig {
              set("mobs.bat.attributes.max_health", oldValue);
          }
          batMaxHealth = getDouble("mobs.bat.attributes.max_health", batMaxHealth);
@@ -1230,7 +1230,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean beeRidable = false;
-@@ -608,6 +612,7 @@ public class PurpurWorldConfig {
+@@ -610,6 +614,7 @@ public class PurpurWorldConfig {
      public double beeMaxY = 320D;
      public double beeMaxHealth = 10.0D;
      public int beeBreedingTicks = 6000;
@@ -1238,7 +1238,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -620,6 +625,7 @@ public class PurpurWorldConfig {
+@@ -622,6 +627,7 @@ public class PurpurWorldConfig {
          }
          beeMaxHealth = getDouble("mobs.bee.attributes.max_health", beeMaxHealth);
          beeBreedingTicks = getInt("mobs.bee.breeding-delay-ticks", beeBreedingTicks);
@@ -1246,7 +1246,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean blazeRidable = false;
-@@ -627,6 +633,7 @@ public class PurpurWorldConfig {
+@@ -629,6 +635,7 @@ public class PurpurWorldConfig {
      public boolean blazeControllable = true;
      public double blazeMaxY = 320D;
      public double blazeMaxHealth = 20.0D;
@@ -1254,7 +1254,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void blazeSettings() {
          blazeRidable = getBoolean("mobs.blaze.ridable", blazeRidable);
          blazeRidableInWater = getBoolean("mobs.blaze.ridable-in-water", blazeRidableInWater);
-@@ -638,6 +645,7 @@ public class PurpurWorldConfig {
+@@ -640,6 +647,7 @@ public class PurpurWorldConfig {
              set("mobs.blaze.attributes.max_health", oldValue);
          }
          blazeMaxHealth = getDouble("mobs.blaze.attributes.max_health", blazeMaxHealth);
@@ -1262,7 +1262,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean catRidable = false;
-@@ -649,6 +657,7 @@ public class PurpurWorldConfig {
+@@ -651,6 +659,7 @@ public class PurpurWorldConfig {
      public int catSpawnVillageScanRange = 48;
      public int catBreedingTicks = 6000;
      public DyeColor catDefaultCollarColor = DyeColor.RED;
@@ -1270,7 +1270,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void catSettings() {
          catRidable = getBoolean("mobs.cat.ridable", catRidable);
          catRidableInWater = getBoolean("mobs.cat.ridable-in-water", catRidableInWater);
-@@ -668,12 +677,14 @@ public class PurpurWorldConfig {
+@@ -670,12 +679,14 @@ public class PurpurWorldConfig {
          } catch (IllegalArgumentException ignore) {
              catDefaultCollarColor = DyeColor.RED;
          }
@@ -1285,7 +1285,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void caveSpiderSettings() {
          caveSpiderRidable = getBoolean("mobs.cave_spider.ridable", caveSpiderRidable);
          caveSpiderRidableInWater = getBoolean("mobs.cave_spider.ridable-in-water", caveSpiderRidableInWater);
-@@ -684,6 +695,7 @@ public class PurpurWorldConfig {
+@@ -686,6 +697,7 @@ public class PurpurWorldConfig {
              set("mobs.cave_spider.attributes.max_health", oldValue);
          }
          caveSpiderMaxHealth = getDouble("mobs.cave_spider.attributes.max_health", caveSpiderMaxHealth);
@@ -1293,7 +1293,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean chickenRidable = false;
-@@ -692,6 +704,7 @@ public class PurpurWorldConfig {
+@@ -694,6 +706,7 @@ public class PurpurWorldConfig {
      public double chickenMaxHealth = 4.0D;
      public boolean chickenRetaliate = false;
      public int chickenBreedingTicks = 6000;
@@ -1301,7 +1301,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void chickenSettings() {
          chickenRidable = getBoolean("mobs.chicken.ridable", chickenRidable);
          chickenRidableInWater = getBoolean("mobs.chicken.ridable-in-water", chickenRidableInWater);
-@@ -704,11 +717,13 @@ public class PurpurWorldConfig {
+@@ -706,11 +719,13 @@ public class PurpurWorldConfig {
          chickenMaxHealth = getDouble("mobs.chicken.attributes.max_health", chickenMaxHealth);
          chickenRetaliate = getBoolean("mobs.chicken.retaliate", chickenRetaliate);
          chickenBreedingTicks = getInt("mobs.chicken.breeding-delay-ticks", chickenBreedingTicks);
@@ -1315,7 +1315,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void codSettings() {
          codRidable = getBoolean("mobs.cod.ridable", codRidable);
          codControllable = getBoolean("mobs.cod.controllable", codControllable);
-@@ -718,6 +733,7 @@ public class PurpurWorldConfig {
+@@ -720,6 +735,7 @@ public class PurpurWorldConfig {
              set("mobs.cod.attributes.max_health", oldValue);
          }
          codMaxHealth = getDouble("mobs.cod.attributes.max_health", codMaxHealth);
@@ -1323,7 +1323,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean cowRidable = false;
-@@ -726,6 +742,7 @@ public class PurpurWorldConfig {
+@@ -728,6 +744,7 @@ public class PurpurWorldConfig {
      public double cowMaxHealth = 10.0D;
      public int cowFeedMushrooms = 0;
      public int cowBreedingTicks = 6000;
@@ -1331,7 +1331,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void cowSettings() {
          cowRidable = getBoolean("mobs.cow.ridable", cowRidable);
          cowRidableInWater = getBoolean("mobs.cow.ridable-in-water", cowRidableInWater);
-@@ -738,6 +755,7 @@ public class PurpurWorldConfig {
+@@ -740,6 +757,7 @@ public class PurpurWorldConfig {
          cowMaxHealth = getDouble("mobs.cow.attributes.max_health", cowMaxHealth);
          cowFeedMushrooms = getInt("mobs.cow.feed-mushrooms-for-mooshroom", cowFeedMushrooms);
          cowBreedingTicks = getInt("mobs.cow.breeding-delay-ticks", cowBreedingTicks);
@@ -1339,7 +1339,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean creeperRidable = false;
-@@ -747,6 +765,7 @@ public class PurpurWorldConfig {
+@@ -749,6 +767,7 @@ public class PurpurWorldConfig {
      public double creeperChargedChance = 0.0D;
      public boolean creeperAllowGriefing = true;
      public boolean creeperBypassMobGriefing = false;
@@ -1347,7 +1347,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -760,6 +779,7 @@ public class PurpurWorldConfig {
+@@ -762,6 +781,7 @@ public class PurpurWorldConfig {
          creeperChargedChance = getDouble("mobs.creeper.naturally-charged-chance", creeperChargedChance);
          creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
          creeperBypassMobGriefing = getBoolean("mobs.creeper.bypass-mob-griefing", creeperBypassMobGriefing);
@@ -1355,7 +1355,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean dolphinRidable = false;
-@@ -769,6 +789,7 @@ public class PurpurWorldConfig {
+@@ -771,6 +791,7 @@ public class PurpurWorldConfig {
      public float dolphinSpitDamage = 2.0F;
      public double dolphinMaxHealth = 10.0D;
      public boolean dolphinDisableTreasureSearching = false;
@@ -1363,7 +1363,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void dolphinSettings() {
          dolphinRidable = getBoolean("mobs.dolphin.ridable", dolphinRidable);
          dolphinControllable = getBoolean("mobs.dolphin.controllable", dolphinControllable);
-@@ -782,6 +803,7 @@ public class PurpurWorldConfig {
+@@ -784,6 +805,7 @@ public class PurpurWorldConfig {
          }
          dolphinMaxHealth = getDouble("mobs.dolphin.attributes.max_health", dolphinMaxHealth);
          dolphinDisableTreasureSearching = getBoolean("mobs.dolphin.disable-treasure-searching", dolphinDisableTreasureSearching);
@@ -1371,7 +1371,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean donkeyRidableInWater = false;
-@@ -792,6 +814,7 @@ public class PurpurWorldConfig {
+@@ -794,6 +816,7 @@ public class PurpurWorldConfig {
      public double donkeyMovementSpeedMin = 0.175D;
      public double donkeyMovementSpeedMax = 0.175D;
      public int donkeyBreedingTicks = 6000;
@@ -1379,7 +1379,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void donkeySettings() {
          donkeyRidableInWater = getBoolean("mobs.donkey.ridable-in-water", donkeyRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -808,6 +831,7 @@ public class PurpurWorldConfig {
+@@ -810,6 +833,7 @@ public class PurpurWorldConfig {
          donkeyMovementSpeedMin = getDouble("mobs.donkey.attributes.movement_speed.min", donkeyMovementSpeedMin);
          donkeyMovementSpeedMax = getDouble("mobs.donkey.attributes.movement_speed.max", donkeyMovementSpeedMax);
          donkeyBreedingTicks = getInt("mobs.donkey.breeding-delay-ticks", donkeyBreedingTicks);
@@ -1387,7 +1387,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean drownedRidable = false;
-@@ -818,6 +842,7 @@ public class PurpurWorldConfig {
+@@ -820,6 +844,7 @@ public class PurpurWorldConfig {
      public boolean drownedJockeyOnlyBaby = true;
      public double drownedJockeyChance = 0.05D;
      public boolean drownedJockeyTryExistingChickens = true;
@@ -1395,7 +1395,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void drownedSettings() {
          drownedRidable = getBoolean("mobs.drowned.ridable", drownedRidable);
          drownedRidableInWater = getBoolean("mobs.drowned.ridable-in-water", drownedRidableInWater);
-@@ -832,11 +857,13 @@ public class PurpurWorldConfig {
+@@ -834,11 +859,13 @@ public class PurpurWorldConfig {
          drownedJockeyOnlyBaby = getBoolean("mobs.drowned.jockey.only-babies", drownedJockeyOnlyBaby);
          drownedJockeyChance = getDouble("mobs.drowned.jockey.chance", drownedJockeyChance);
          drownedJockeyTryExistingChickens = getBoolean("mobs.drowned.jockey.try-existing-chickens", drownedJockeyTryExistingChickens);
@@ -1409,7 +1409,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void elderGuardianSettings() {
          elderGuardianRidable = getBoolean("mobs.elder_guardian.ridable", elderGuardianRidable);
          elderGuardianControllable = getBoolean("mobs.elder_guardian.controllable", elderGuardianControllable);
-@@ -846,6 +873,7 @@ public class PurpurWorldConfig {
+@@ -848,6 +875,7 @@ public class PurpurWorldConfig {
              set("mobs.elder_guardian.attributes.max_health", oldValue);
          }
          elderGuardianMaxHealth = getDouble("mobs.elder_guardian.attributes.max_health", elderGuardianMaxHealth);
@@ -1417,7 +1417,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean enderDragonRidable = false;
-@@ -855,6 +883,7 @@ public class PurpurWorldConfig {
+@@ -857,6 +885,7 @@ public class PurpurWorldConfig {
      public double enderDragonMaxHealth = 200.0D;
      public boolean enderDragonAlwaysDropsFullExp = false;
      public boolean enderDragonBypassMobGriefing = false;
@@ -1425,7 +1425,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void enderDragonSettings() {
          enderDragonRidable = getBoolean("mobs.ender_dragon.ridable", enderDragonRidable);
          enderDragonRidableInWater = getBoolean("mobs.ender_dragon.ridable-in-water", enderDragonRidableInWater);
-@@ -872,6 +901,7 @@ public class PurpurWorldConfig {
+@@ -874,6 +903,7 @@ public class PurpurWorldConfig {
          enderDragonMaxHealth = getDouble("mobs.ender_dragon.attributes.max_health", enderDragonMaxHealth);
          enderDragonAlwaysDropsFullExp = getBoolean("mobs.ender_dragon.always-drop-full-exp", enderDragonAlwaysDropsFullExp);
          enderDragonBypassMobGriefing = getBoolean("mobs.ender_dragon.bypass-mob-griefing", enderDragonBypassMobGriefing);
@@ -1433,7 +1433,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean endermanRidable = false;
-@@ -881,6 +911,7 @@ public class PurpurWorldConfig {
+@@ -883,6 +913,7 @@ public class PurpurWorldConfig {
      public boolean endermanAllowGriefing = true;
      public boolean endermanDespawnEvenWithBlock = false;
      public boolean endermanBypassMobGriefing = false;
@@ -1441,7 +1441,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -894,12 +925,14 @@ public class PurpurWorldConfig {
+@@ -896,12 +927,14 @@ public class PurpurWorldConfig {
          endermanAllowGriefing = getBoolean("mobs.enderman.allow-griefing", endermanAllowGriefing);
          endermanDespawnEvenWithBlock = getBoolean("mobs.enderman.can-despawn-with-held-block", endermanDespawnEvenWithBlock);
          endermanBypassMobGriefing = getBoolean("mobs.enderman.bypass-mob-griefing", endermanBypassMobGriefing);
@@ -1456,7 +1456,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void endermiteSettings() {
          endermiteRidable = getBoolean("mobs.endermite.ridable", endermiteRidable);
          endermiteRidableInWater = getBoolean("mobs.endermite.ridable-in-water", endermiteRidableInWater);
-@@ -910,6 +943,7 @@ public class PurpurWorldConfig {
+@@ -912,6 +945,7 @@ public class PurpurWorldConfig {
              set("mobs.endermite.attributes.max_health", oldValue);
          }
          endermiteMaxHealth = getDouble("mobs.endermite.attributes.max_health", endermiteMaxHealth);
@@ -1464,7 +1464,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean evokerRidable = false;
-@@ -917,6 +951,7 @@ public class PurpurWorldConfig {
+@@ -919,6 +953,7 @@ public class PurpurWorldConfig {
      public boolean evokerControllable = true;
      public double evokerMaxHealth = 24.0D;
      public boolean evokerBypassMobGriefing = false;
@@ -1472,7 +1472,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void evokerSettings() {
          evokerRidable = getBoolean("mobs.evoker.ridable", evokerRidable);
          evokerRidableInWater = getBoolean("mobs.evoker.ridable-in-water", evokerRidableInWater);
-@@ -928,6 +963,7 @@ public class PurpurWorldConfig {
+@@ -930,6 +965,7 @@ public class PurpurWorldConfig {
          }
          evokerMaxHealth = getDouble("mobs.evoker.attributes.max_health", evokerMaxHealth);
          evokerBypassMobGriefing = getBoolean("mobs.evoker.bypass-mob-griefing", evokerBypassMobGriefing);
@@ -1480,7 +1480,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean foxRidable = false;
-@@ -937,6 +973,7 @@ public class PurpurWorldConfig {
+@@ -939,6 +975,7 @@ public class PurpurWorldConfig {
      public boolean foxTypeChangesWithTulips = false;
      public int foxBreedingTicks = 6000;
      public boolean foxBypassMobGriefing = false;
@@ -1488,7 +1488,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void foxSettings() {
          foxRidable = getBoolean("mobs.fox.ridable", foxRidable);
          foxRidableInWater = getBoolean("mobs.fox.ridable-in-water", foxRidableInWater);
-@@ -950,6 +987,7 @@ public class PurpurWorldConfig {
+@@ -952,6 +989,7 @@ public class PurpurWorldConfig {
          foxTypeChangesWithTulips = getBoolean("mobs.fox.tulips-change-type", foxTypeChangesWithTulips);
          foxBreedingTicks = getInt("mobs.fox.breeding-delay-ticks", foxBreedingTicks);
          foxBypassMobGriefing = getBoolean("mobs.fox.bypass-mob-griefing", foxBypassMobGriefing);
@@ -1496,7 +1496,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean frogRidable = false;
-@@ -970,6 +1008,7 @@ public class PurpurWorldConfig {
+@@ -972,6 +1010,7 @@ public class PurpurWorldConfig {
      public boolean ghastControllable = true;
      public double ghastMaxY = 320D;
      public double ghastMaxHealth = 10.0D;
@@ -1504,7 +1504,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void ghastSettings() {
          ghastRidable = getBoolean("mobs.ghast.ridable", ghastRidable);
          ghastRidableInWater = getBoolean("mobs.ghast.ridable-in-water", ghastRidableInWater);
-@@ -981,6 +1020,7 @@ public class PurpurWorldConfig {
+@@ -983,6 +1022,7 @@ public class PurpurWorldConfig {
              set("mobs.ghast.attributes.max_health", oldValue);
          }
          ghastMaxHealth = getDouble("mobs.ghast.attributes.max_health", ghastMaxHealth);
@@ -1512,7 +1512,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean giantRidable = false;
-@@ -993,6 +1033,7 @@ public class PurpurWorldConfig {
+@@ -995,6 +1035,7 @@ public class PurpurWorldConfig {
      public float giantJumpHeight = 1.0F;
      public boolean giantHaveAI = false;
      public boolean giantHaveHostileAI = false;
@@ -1520,7 +1520,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void giantSettings() {
          giantRidable = getBoolean("mobs.giant.ridable", giantRidable);
          giantRidableInWater = getBoolean("mobs.giant.ridable-in-water", giantRidableInWater);
-@@ -1013,17 +1054,20 @@ public class PurpurWorldConfig {
+@@ -1015,17 +1056,20 @@ public class PurpurWorldConfig {
          giantJumpHeight = (float) getDouble("mobs.giant.jump-height", giantJumpHeight);
          giantHaveAI = getBoolean("mobs.giant.have-ai", giantHaveAI);
          giantHaveHostileAI = getBoolean("mobs.giant.have-hostile-ai", giantHaveHostileAI);
@@ -1541,7 +1541,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean goatRidable = false;
-@@ -1031,17 +1075,20 @@ public class PurpurWorldConfig {
+@@ -1033,17 +1077,20 @@ public class PurpurWorldConfig {
      public boolean goatControllable = true;
      public double goatMaxHealth = 10.0D;
      public int goatBreedingTicks = 6000;
@@ -1562,7 +1562,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void guardianSettings() {
          guardianRidable = getBoolean("mobs.guardian.ridable", guardianRidable);
          guardianControllable = getBoolean("mobs.guardian.controllable", guardianControllable);
-@@ -1051,6 +1098,7 @@ public class PurpurWorldConfig {
+@@ -1053,6 +1100,7 @@ public class PurpurWorldConfig {
              set("mobs.guardian.attributes.max_health", oldValue);
          }
          guardianMaxHealth = getDouble("mobs.guardian.attributes.max_health", guardianMaxHealth);
@@ -1570,7 +1570,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean hoglinRidable = false;
-@@ -1058,6 +1106,7 @@ public class PurpurWorldConfig {
+@@ -1060,6 +1108,7 @@ public class PurpurWorldConfig {
      public boolean hoglinControllable = true;
      public double hoglinMaxHealth = 40.0D;
      public int hoglinBreedingTicks = 6000;
@@ -1578,7 +1578,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void hoglinSettings() {
          hoglinRidable = getBoolean("mobs.hoglin.ridable", hoglinRidable);
          hoglinRidableInWater = getBoolean("mobs.hoglin.ridable-in-water", hoglinRidableInWater);
-@@ -1069,6 +1118,7 @@ public class PurpurWorldConfig {
+@@ -1071,6 +1120,7 @@ public class PurpurWorldConfig {
          }
          hoglinMaxHealth = getDouble("mobs.hoglin.attributes.max_health", hoglinMaxHealth);
          hoglinBreedingTicks = getInt("mobs.hoglin.breeding-delay-ticks", hoglinBreedingTicks);
@@ -1586,7 +1586,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean horseRidableInWater = false;
-@@ -1079,6 +1129,7 @@ public class PurpurWorldConfig {
+@@ -1081,6 +1131,7 @@ public class PurpurWorldConfig {
      public double horseMovementSpeedMin = 0.1125D;
      public double horseMovementSpeedMax = 0.3375D;
      public int horseBreedingTicks = 6000;
@@ -1594,7 +1594,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void horseSettings() {
          horseRidableInWater = getBoolean("mobs.horse.ridable-in-water", horseRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1095,6 +1146,7 @@ public class PurpurWorldConfig {
+@@ -1097,6 +1148,7 @@ public class PurpurWorldConfig {
          horseMovementSpeedMin = getDouble("mobs.horse.attributes.movement_speed.min", horseMovementSpeedMin);
          horseMovementSpeedMax = getDouble("mobs.horse.attributes.movement_speed.max", horseMovementSpeedMax);
          horseBreedingTicks = getInt("mobs.horse.breeding-delay-ticks", horseBreedingTicks);
@@ -1602,7 +1602,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean huskRidable = false;
-@@ -1105,6 +1157,7 @@ public class PurpurWorldConfig {
+@@ -1107,6 +1159,7 @@ public class PurpurWorldConfig {
      public boolean huskJockeyOnlyBaby = true;
      public double huskJockeyChance = 0.05D;
      public boolean huskJockeyTryExistingChickens = true;
@@ -1610,7 +1610,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void huskSettings() {
          huskRidable = getBoolean("mobs.husk.ridable", huskRidable);
          huskRidableInWater = getBoolean("mobs.husk.ridable-in-water", huskRidableInWater);
-@@ -1119,6 +1172,7 @@ public class PurpurWorldConfig {
+@@ -1121,6 +1174,7 @@ public class PurpurWorldConfig {
          huskJockeyOnlyBaby = getBoolean("mobs.husk.jockey.only-babies", huskJockeyOnlyBaby);
          huskJockeyChance = getDouble("mobs.husk.jockey.chance", huskJockeyChance);
          huskJockeyTryExistingChickens = getBoolean("mobs.husk.jockey.try-existing-chickens", huskJockeyTryExistingChickens);
@@ -1618,7 +1618,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean illusionerRidable = false;
-@@ -1127,6 +1181,7 @@ public class PurpurWorldConfig {
+@@ -1129,6 +1183,7 @@ public class PurpurWorldConfig {
      public double illusionerMovementSpeed = 0.5D;
      public double illusionerFollowRange = 18.0D;
      public double illusionerMaxHealth = 32.0D;
@@ -1626,7 +1626,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void illusionerSettings() {
          illusionerRidable = getBoolean("mobs.illusioner.ridable", illusionerRidable);
          illusionerRidableInWater = getBoolean("mobs.illusioner.ridable-in-water", illusionerRidableInWater);
-@@ -1143,6 +1198,7 @@ public class PurpurWorldConfig {
+@@ -1145,6 +1200,7 @@ public class PurpurWorldConfig {
              set("mobs.illusioner.attributes.max_health", oldValue);
          }
          illusionerMaxHealth = getDouble("mobs.illusioner.attributes.max_health", illusionerMaxHealth);
@@ -1634,7 +1634,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean ironGolemRidable = false;
-@@ -1150,6 +1206,7 @@ public class PurpurWorldConfig {
+@@ -1152,6 +1208,7 @@ public class PurpurWorldConfig {
      public boolean ironGolemControllable = true;
      public boolean ironGolemCanSwim = false;
      public double ironGolemMaxHealth = 100.0D;
@@ -1642,7 +1642,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void ironGolemSettings() {
          ironGolemRidable = getBoolean("mobs.iron_golem.ridable", ironGolemRidable);
          ironGolemRidableInWater = getBoolean("mobs.iron_golem.ridable-in-water", ironGolemRidableInWater);
-@@ -1161,6 +1218,7 @@ public class PurpurWorldConfig {
+@@ -1163,6 +1220,7 @@ public class PurpurWorldConfig {
              set("mobs.iron_golem.attributes.max_health", oldValue);
          }
          ironGolemMaxHealth = getDouble("mobs.iron_golem.attributes.max_health", ironGolemMaxHealth);
@@ -1650,7 +1650,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean llamaRidable = false;
-@@ -1173,6 +1231,7 @@ public class PurpurWorldConfig {
+@@ -1175,6 +1233,7 @@ public class PurpurWorldConfig {
      public double llamaMovementSpeedMin = 0.175D;
      public double llamaMovementSpeedMax = 0.175D;
      public int llamaBreedingTicks = 6000;
@@ -1658,7 +1658,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void llamaSettings() {
          llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
          llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
-@@ -1191,6 +1250,7 @@ public class PurpurWorldConfig {
+@@ -1193,6 +1252,7 @@ public class PurpurWorldConfig {
          llamaMovementSpeedMin = getDouble("mobs.llama.attributes.movement_speed.min", llamaMovementSpeedMin);
          llamaMovementSpeedMax = getDouble("mobs.llama.attributes.movement_speed.max", llamaMovementSpeedMax);
          llamaBreedingTicks = getInt("mobs.llama.breeding-delay-ticks", llamaBreedingTicks);
@@ -1666,7 +1666,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean magmaCubeRidable = false;
-@@ -1200,6 +1260,7 @@ public class PurpurWorldConfig {
+@@ -1202,6 +1262,7 @@ public class PurpurWorldConfig {
      public String magmaCubeAttackDamage = "size";
      public Map<Integer, Double> magmaCubeMaxHealthCache = new HashMap<>();
      public Map<Integer, Double> magmaCubeAttackDamageCache = new HashMap<>();
@@ -1674,7 +1674,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void magmaCubeSettings() {
          magmaCubeRidable = getBoolean("mobs.magma_cube.ridable", magmaCubeRidable);
          magmaCubeRidableInWater = getBoolean("mobs.magma_cube.ridable-in-water", magmaCubeRidableInWater);
-@@ -1213,6 +1274,7 @@ public class PurpurWorldConfig {
+@@ -1215,6 +1276,7 @@ public class PurpurWorldConfig {
          magmaCubeAttackDamage = getString("mobs.magma_cube.attributes.attack_damage", magmaCubeAttackDamage);
          magmaCubeMaxHealthCache.clear();
          magmaCubeAttackDamageCache.clear();
@@ -1682,7 +1682,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean mooshroomRidable = false;
-@@ -1220,6 +1282,7 @@ public class PurpurWorldConfig {
+@@ -1222,6 +1284,7 @@ public class PurpurWorldConfig {
      public boolean mooshroomControllable = true;
      public double mooshroomMaxHealth = 10.0D;
      public int mooshroomBreedingTicks = 6000;
@@ -1690,7 +1690,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void mooshroomSettings() {
          mooshroomRidable = getBoolean("mobs.mooshroom.ridable", mooshroomRidable);
          mooshroomRidableInWater = getBoolean("mobs.mooshroom.ridable-in-water", mooshroomRidableInWater);
-@@ -1231,6 +1294,7 @@ public class PurpurWorldConfig {
+@@ -1233,6 +1296,7 @@ public class PurpurWorldConfig {
          }
          mooshroomMaxHealth = getDouble("mobs.mooshroom.attributes.max_health", mooshroomMaxHealth);
          mooshroomBreedingTicks = getInt("mobs.mooshroom.breeding-delay-ticks", mooshroomBreedingTicks);
@@ -1698,7 +1698,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean muleRidableInWater = false;
-@@ -1241,6 +1305,7 @@ public class PurpurWorldConfig {
+@@ -1243,6 +1307,7 @@ public class PurpurWorldConfig {
      public double muleMovementSpeedMin = 0.175D;
      public double muleMovementSpeedMax = 0.175D;
      public int muleBreedingTicks = 6000;
@@ -1706,7 +1706,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void muleSettings() {
          muleRidableInWater = getBoolean("mobs.mule.ridable-in-water", muleRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1257,6 +1322,7 @@ public class PurpurWorldConfig {
+@@ -1259,6 +1324,7 @@ public class PurpurWorldConfig {
          muleMovementSpeedMin = getDouble("mobs.mule.attributes.movement_speed.min", muleMovementSpeedMin);
          muleMovementSpeedMax = getDouble("mobs.mule.attributes.movement_speed.max", muleMovementSpeedMax);
          muleBreedingTicks = getInt("mobs.mule.breeding-delay-ticks", muleBreedingTicks);
@@ -1714,7 +1714,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean ocelotRidable = false;
-@@ -1264,6 +1330,7 @@ public class PurpurWorldConfig {
+@@ -1266,6 +1332,7 @@ public class PurpurWorldConfig {
      public boolean ocelotControllable = true;
      public double ocelotMaxHealth = 10.0D;
      public int ocelotBreedingTicks = 6000;
@@ -1722,7 +1722,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void ocelotSettings() {
          ocelotRidable = getBoolean("mobs.ocelot.ridable", ocelotRidable);
          ocelotRidableInWater = getBoolean("mobs.ocelot.ridable-in-water", ocelotRidableInWater);
-@@ -1275,6 +1342,7 @@ public class PurpurWorldConfig {
+@@ -1277,6 +1344,7 @@ public class PurpurWorldConfig {
          }
          ocelotMaxHealth = getDouble("mobs.ocelot.attributes.max_health", ocelotMaxHealth);
          ocelotBreedingTicks = getInt("mobs.ocelot.breeding-delay-ticks", ocelotBreedingTicks);
@@ -1730,7 +1730,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean pandaRidable = false;
-@@ -1282,6 +1350,7 @@ public class PurpurWorldConfig {
+@@ -1284,6 +1352,7 @@ public class PurpurWorldConfig {
      public boolean pandaControllable = true;
      public double pandaMaxHealth = 20.0D;
      public int pandaBreedingTicks = 6000;
@@ -1738,7 +1738,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void pandaSettings() {
          pandaRidable = getBoolean("mobs.panda.ridable", pandaRidable);
          pandaRidableInWater = getBoolean("mobs.panda.ridable-in-water", pandaRidableInWater);
-@@ -1293,6 +1362,7 @@ public class PurpurWorldConfig {
+@@ -1295,6 +1364,7 @@ public class PurpurWorldConfig {
          }
          pandaMaxHealth = getDouble("mobs.panda.attributes.max_health", pandaMaxHealth);
          pandaBreedingTicks = getInt("mobs.panda.breeding-delay-ticks", pandaBreedingTicks);
@@ -1746,7 +1746,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean parrotRidable = false;
-@@ -1300,6 +1370,7 @@ public class PurpurWorldConfig {
+@@ -1302,6 +1372,7 @@ public class PurpurWorldConfig {
      public boolean parrotControllable = true;
      public double parrotMaxY = 320D;
      public double parrotMaxHealth = 6.0D;
@@ -1754,7 +1754,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void parrotSettings() {
          parrotRidable = getBoolean("mobs.parrot.ridable", parrotRidable);
          parrotRidableInWater = getBoolean("mobs.parrot.ridable-in-water", parrotRidableInWater);
-@@ -1311,6 +1382,7 @@ public class PurpurWorldConfig {
+@@ -1313,6 +1384,7 @@ public class PurpurWorldConfig {
              set("mobs.parrot.attributes.max_health", oldValue);
          }
          parrotMaxHealth = getDouble("mobs.parrot.attributes.max_health", parrotMaxHealth);
@@ -1762,7 +1762,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean phantomRidable = false;
-@@ -1343,6 +1415,7 @@ public class PurpurWorldConfig {
+@@ -1345,6 +1417,7 @@ public class PurpurWorldConfig {
      public boolean phantomIgnorePlayersWithTorch = false;
      public boolean phantomBurnInDaylight = true;
      public boolean phantomFlamesOnSwoop = false;
@@ -1770,7 +1770,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void phantomSettings() {
          phantomRidable = getBoolean("mobs.phantom.ridable", phantomRidable);
          phantomRidableInWater = getBoolean("mobs.phantom.ridable-in-water", phantomRidableInWater);
-@@ -1383,6 +1456,7 @@ public class PurpurWorldConfig {
+@@ -1385,6 +1458,7 @@ public class PurpurWorldConfig {
          phantomBurnInDaylight = getBoolean("mobs.phantom.burn-in-daylight", phantomBurnInDaylight);
          phantomIgnorePlayersWithTorch = getBoolean("mobs.phantom.ignore-players-with-torch", phantomIgnorePlayersWithTorch);
          phantomFlamesOnSwoop = getBoolean("mobs.phantom.flames-on-swoop", phantomFlamesOnSwoop);
@@ -1778,7 +1778,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean pigRidable = false;
-@@ -1391,6 +1465,7 @@ public class PurpurWorldConfig {
+@@ -1393,6 +1467,7 @@ public class PurpurWorldConfig {
      public double pigMaxHealth = 10.0D;
      public boolean pigGiveSaddleBack = false;
      public int pigBreedingTicks = 6000;
@@ -1786,7 +1786,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void pigSettings() {
          pigRidable = getBoolean("mobs.pig.ridable", pigRidable);
          pigRidableInWater = getBoolean("mobs.pig.ridable-in-water", pigRidableInWater);
-@@ -1403,6 +1478,7 @@ public class PurpurWorldConfig {
+@@ -1405,6 +1480,7 @@ public class PurpurWorldConfig {
          pigMaxHealth = getDouble("mobs.pig.attributes.max_health", pigMaxHealth);
          pigGiveSaddleBack = getBoolean("mobs.pig.give-saddle-back", pigGiveSaddleBack);
          pigBreedingTicks = getInt("mobs.pig.breeding-delay-ticks", pigBreedingTicks);
@@ -1794,7 +1794,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean piglinRidable = false;
-@@ -1410,6 +1486,7 @@ public class PurpurWorldConfig {
+@@ -1412,6 +1488,7 @@ public class PurpurWorldConfig {
      public boolean piglinControllable = true;
      public double piglinMaxHealth = 16.0D;
      public boolean piglinBypassMobGriefing = false;
@@ -1802,7 +1802,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -1421,12 +1498,14 @@ public class PurpurWorldConfig {
+@@ -1423,12 +1500,14 @@ public class PurpurWorldConfig {
          }
          piglinMaxHealth = getDouble("mobs.piglin.attributes.max_health", piglinMaxHealth);
          piglinBypassMobGriefing = getBoolean("mobs.piglin.bypass-mob-griefing", piglinBypassMobGriefing);
@@ -1817,7 +1817,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void piglinBruteSettings() {
          piglinBruteRidable = getBoolean("mobs.piglin_brute.ridable", piglinBruteRidable);
          piglinBruteRidableInWater = getBoolean("mobs.piglin_brute.ridable-in-water", piglinBruteRidableInWater);
-@@ -1437,6 +1516,7 @@ public class PurpurWorldConfig {
+@@ -1439,6 +1518,7 @@ public class PurpurWorldConfig {
              set("mobs.piglin_brute.attributes.max_health", oldValue);
          }
          piglinBruteMaxHealth = getDouble("mobs.piglin_brute.attributes.max_health", piglinBruteMaxHealth);
@@ -1825,7 +1825,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean pillagerRidable = false;
-@@ -1444,6 +1524,7 @@ public class PurpurWorldConfig {
+@@ -1446,6 +1526,7 @@ public class PurpurWorldConfig {
      public boolean pillagerControllable = true;
      public double pillagerMaxHealth = 24.0D;
      public boolean pillagerBypassMobGriefing = false;
@@ -1833,7 +1833,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void pillagerSettings() {
          pillagerRidable = getBoolean("mobs.pillager.ridable", pillagerRidable);
          pillagerRidableInWater = getBoolean("mobs.pillager.ridable-in-water", pillagerRidableInWater);
-@@ -1455,6 +1536,7 @@ public class PurpurWorldConfig {
+@@ -1457,6 +1538,7 @@ public class PurpurWorldConfig {
          }
          pillagerMaxHealth = getDouble("mobs.pillager.attributes.max_health", pillagerMaxHealth);
          pillagerBypassMobGriefing = getBoolean("mobs.pillager.bypass-mob-griefing", pillagerBypassMobGriefing);
@@ -1841,7 +1841,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean polarBearRidable = false;
-@@ -1464,6 +1546,7 @@ public class PurpurWorldConfig {
+@@ -1466,6 +1548,7 @@ public class PurpurWorldConfig {
      public String polarBearBreedableItemString = "";
      public Item polarBearBreedableItem = null;
      public int polarBearBreedingTicks = 6000;
@@ -1849,7 +1849,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void polarBearSettings() {
          polarBearRidable = getBoolean("mobs.polar_bear.ridable", polarBearRidable);
          polarBearRidableInWater = getBoolean("mobs.polar_bear.ridable-in-water", polarBearRidableInWater);
-@@ -1478,11 +1561,13 @@ public class PurpurWorldConfig {
+@@ -1480,11 +1563,13 @@ public class PurpurWorldConfig {
          Item item = Registry.ITEM.get(new ResourceLocation(polarBearBreedableItemString));
          if (item != Items.AIR) polarBearBreedableItem = item;
          polarBearBreedingTicks = getInt("mobs.polar_bear.breeding-delay-ticks", polarBearBreedingTicks);
@@ -1863,7 +1863,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void pufferfishSettings() {
          pufferfishRidable = getBoolean("mobs.pufferfish.ridable", pufferfishRidable);
          pufferfishControllable = getBoolean("mobs.pufferfish.controllable", pufferfishControllable);
-@@ -1492,6 +1577,7 @@ public class PurpurWorldConfig {
+@@ -1494,6 +1579,7 @@ public class PurpurWorldConfig {
              set("mobs.pufferfish.attributes.max_health", oldValue);
          }
          pufferfishMaxHealth = getDouble("mobs.pufferfish.attributes.max_health", pufferfishMaxHealth);
@@ -1871,7 +1871,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean rabbitRidable = false;
-@@ -1502,6 +1588,7 @@ public class PurpurWorldConfig {
+@@ -1504,6 +1590,7 @@ public class PurpurWorldConfig {
      public double rabbitNaturalKiller = 0.0D;
      public int rabbitBreedingTicks = 6000;
      public boolean rabbitBypassMobGriefing = false;
@@ -1879,7 +1879,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void rabbitSettings() {
          rabbitRidable = getBoolean("mobs.rabbit.ridable", rabbitRidable);
          rabbitRidableInWater = getBoolean("mobs.rabbit.ridable-in-water", rabbitRidableInWater);
-@@ -1516,6 +1603,7 @@ public class PurpurWorldConfig {
+@@ -1518,6 +1605,7 @@ public class PurpurWorldConfig {
          rabbitNaturalKiller = getDouble("mobs.rabbit.spawn-killer-rabbit-chance", rabbitNaturalKiller);
          rabbitBreedingTicks = getInt("mobs.rabbit.breeding-delay-ticks", rabbitBreedingTicks);
          rabbitBypassMobGriefing = getBoolean("mobs.rabbit.bypass-mob-griefing", rabbitBypassMobGriefing);
@@ -1887,7 +1887,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean ravagerRidable = false;
-@@ -1523,6 +1611,7 @@ public class PurpurWorldConfig {
+@@ -1525,6 +1613,7 @@ public class PurpurWorldConfig {
      public boolean ravagerControllable = true;
      public double ravagerMaxHealth = 100.0D;
      public boolean ravagerBypassMobGriefing = false;
@@ -1895,7 +1895,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void ravagerSettings() {
          ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
          ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
-@@ -1534,11 +1623,13 @@ public class PurpurWorldConfig {
+@@ -1536,11 +1625,13 @@ public class PurpurWorldConfig {
          }
          ravagerMaxHealth = getDouble("mobs.ravager.attributes.max_health", ravagerMaxHealth);
          ravagerBypassMobGriefing = getBoolean("mobs.ravager.bypass-mob-griefing", ravagerBypassMobGriefing);
@@ -1909,7 +1909,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void salmonSettings() {
          salmonRidable = getBoolean("mobs.salmon.ridable", salmonRidable);
          salmonControllable = getBoolean("mobs.salmon.controllable", salmonControllable);
-@@ -1548,6 +1639,7 @@ public class PurpurWorldConfig {
+@@ -1550,6 +1641,7 @@ public class PurpurWorldConfig {
              set("mobs.salmon.attributes.max_health", oldValue);
          }
          salmonMaxHealth = getDouble("mobs.salmon.attributes.max_health", salmonMaxHealth);
@@ -1917,7 +1917,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean sheepRidable = false;
-@@ -1556,6 +1648,7 @@ public class PurpurWorldConfig {
+@@ -1558,6 +1650,7 @@ public class PurpurWorldConfig {
      public double sheepMaxHealth = 8.0D;
      public int sheepBreedingTicks = 6000;
      public boolean sheepBypassMobGriefing = false;
@@ -1925,7 +1925,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -1568,12 +1661,14 @@ public class PurpurWorldConfig {
+@@ -1570,12 +1663,14 @@ public class PurpurWorldConfig {
          sheepMaxHealth = getDouble("mobs.sheep.attributes.max_health", sheepMaxHealth);
          sheepBreedingTicks = getInt("mobs.sheep.breeding-delay-ticks", sheepBreedingTicks);
          sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
@@ -1940,7 +1940,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -1584,6 +1679,7 @@ public class PurpurWorldConfig {
+@@ -1586,6 +1681,7 @@ public class PurpurWorldConfig {
              set("mobs.shulker.attributes.max_health", oldValue);
          }
          shulkerMaxHealth = getDouble("mobs.shulker.attributes.max_health", shulkerMaxHealth);
@@ -1948,7 +1948,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean silverfishRidable = false;
-@@ -1591,6 +1687,7 @@ public class PurpurWorldConfig {
+@@ -1593,6 +1689,7 @@ public class PurpurWorldConfig {
      public boolean silverfishControllable = true;
      public double silverfishMaxHealth = 8.0D;
      public boolean silverfishBypassMobGriefing = false;
@@ -1956,7 +1956,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void silverfishSettings() {
          silverfishRidable = getBoolean("mobs.silverfish.ridable", silverfishRidable);
          silverfishRidableInWater = getBoolean("mobs.silverfish.ridable-in-water", silverfishRidableInWater);
-@@ -1602,12 +1699,14 @@ public class PurpurWorldConfig {
+@@ -1604,12 +1701,14 @@ public class PurpurWorldConfig {
          }
          silverfishMaxHealth = getDouble("mobs.silverfish.attributes.max_health", silverfishMaxHealth);
          silverfishBypassMobGriefing = getBoolean("mobs.silverfish.bypass-mob-griefing", silverfishBypassMobGriefing);
@@ -1971,7 +1971,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -1618,6 +1717,7 @@ public class PurpurWorldConfig {
+@@ -1620,6 +1719,7 @@ public class PurpurWorldConfig {
              set("mobs.skeleton.attributes.max_health", oldValue);
          }
          skeletonMaxHealth = getDouble("mobs.skeleton.attributes.max_health", skeletonMaxHealth);
@@ -1979,7 +1979,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean skeletonHorseRidableInWater = true;
-@@ -1628,6 +1728,7 @@ public class PurpurWorldConfig {
+@@ -1630,6 +1730,7 @@ public class PurpurWorldConfig {
      public double skeletonHorseJumpStrengthMax = 1.0D;
      public double skeletonHorseMovementSpeedMin = 0.2D;
      public double skeletonHorseMovementSpeedMax = 0.2D;
@@ -1987,7 +1987,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void skeletonHorseSettings() {
          skeletonHorseRidableInWater = getBoolean("mobs.skeleton_horse.ridable-in-water", skeletonHorseRidableInWater);
          skeletonHorseCanSwim = getBoolean("mobs.skeleton_horse.can-swim", skeletonHorseCanSwim);
-@@ -1643,6 +1744,7 @@ public class PurpurWorldConfig {
+@@ -1645,6 +1746,7 @@ public class PurpurWorldConfig {
          skeletonHorseJumpStrengthMax = getDouble("mobs.skeleton_horse.attributes.jump_strength.max", skeletonHorseJumpStrengthMax);
          skeletonHorseMovementSpeedMin = getDouble("mobs.skeleton_horse.attributes.movement_speed.min", skeletonHorseMovementSpeedMin);
          skeletonHorseMovementSpeedMax = getDouble("mobs.skeleton_horse.attributes.movement_speed.max", skeletonHorseMovementSpeedMax);
@@ -1995,7 +1995,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean slimeRidable = false;
-@@ -1652,6 +1754,7 @@ public class PurpurWorldConfig {
+@@ -1654,6 +1756,7 @@ public class PurpurWorldConfig {
      public String slimeAttackDamage = "size";
      public Map<Integer, Double> slimeMaxHealthCache = new HashMap<>();
      public Map<Integer, Double> slimeAttackDamageCache = new HashMap<>();
@@ -2003,7 +2003,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void slimeSettings() {
          slimeRidable = getBoolean("mobs.slime.ridable", slimeRidable);
          slimeRidableInWater = getBoolean("mobs.slime.ridable-in-water", slimeRidableInWater);
-@@ -1665,6 +1768,7 @@ public class PurpurWorldConfig {
+@@ -1667,6 +1770,7 @@ public class PurpurWorldConfig {
          slimeAttackDamage = getString("mobs.slime.attributes.attack_damage", slimeAttackDamage);
          slimeMaxHealthCache.clear();
          slimeAttackDamageCache.clear();
@@ -2011,7 +2011,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean snowGolemRidable = false;
-@@ -1679,6 +1783,7 @@ public class PurpurWorldConfig {
+@@ -1681,6 +1785,7 @@ public class PurpurWorldConfig {
      public float snowGolemSnowBallModifier = 10.0F;
      public double snowGolemAttackDistance = 1.25D;
      public boolean snowGolemBypassMobGriefing = false;
@@ -2019,7 +2019,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void snowGolemSettings() {
          snowGolemRidable = getBoolean("mobs.snow_golem.ridable", snowGolemRidable);
          snowGolemRidableInWater = getBoolean("mobs.snow_golem.ridable-in-water", snowGolemRidableInWater);
-@@ -1697,6 +1802,7 @@ public class PurpurWorldConfig {
+@@ -1699,6 +1804,7 @@ public class PurpurWorldConfig {
          snowGolemSnowBallModifier = (float) getDouble("mobs.snow_golem.snow-ball-modifier", snowGolemSnowBallModifier);
          snowGolemAttackDistance = getDouble("mobs.snow_golem.attack-distance", snowGolemAttackDistance);
          snowGolemBypassMobGriefing = getBoolean("mobs.snow_golem.bypass-mob-griefing", snowGolemBypassMobGriefing);
@@ -2027,7 +2027,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean squidRidable = false;
-@@ -1705,6 +1811,7 @@ public class PurpurWorldConfig {
+@@ -1707,6 +1813,7 @@ public class PurpurWorldConfig {
      public boolean squidImmuneToEAR = true;
      public double squidOffsetWaterCheck = 0.0D;
      public boolean squidsCanFly = false;
@@ -2035,7 +2035,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void squidSettings() {
          squidRidable = getBoolean("mobs.squid.ridable", squidRidable);
          squidControllable = getBoolean("mobs.squid.controllable", squidControllable);
-@@ -1717,12 +1824,14 @@ public class PurpurWorldConfig {
+@@ -1719,12 +1826,14 @@ public class PurpurWorldConfig {
          squidImmuneToEAR = getBoolean("mobs.squid.immune-to-EAR", squidImmuneToEAR);
          squidOffsetWaterCheck = getDouble("mobs.squid.water-offset-check", squidOffsetWaterCheck);
          squidsCanFly = getBoolean("mobs.squid.can-fly", squidsCanFly);
@@ -2050,7 +2050,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void spiderSettings() {
          spiderRidable = getBoolean("mobs.spider.ridable", spiderRidable);
          spiderRidableInWater = getBoolean("mobs.spider.ridable-in-water", spiderRidableInWater);
-@@ -1733,12 +1842,14 @@ public class PurpurWorldConfig {
+@@ -1735,12 +1844,14 @@ public class PurpurWorldConfig {
              set("mobs.spider.attributes.max_health", oldValue);
          }
          spiderMaxHealth = getDouble("mobs.spider.attributes.max_health", spiderMaxHealth);
@@ -2065,7 +2065,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void straySettings() {
          strayRidable = getBoolean("mobs.stray.ridable", strayRidable);
          strayRidableInWater = getBoolean("mobs.stray.ridable-in-water", strayRidableInWater);
-@@ -1749,6 +1860,7 @@ public class PurpurWorldConfig {
+@@ -1751,6 +1862,7 @@ public class PurpurWorldConfig {
              set("mobs.stray.attributes.max_health", oldValue);
          }
          strayMaxHealth = getDouble("mobs.stray.attributes.max_health", strayMaxHealth);
@@ -2073,7 +2073,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean striderRidable = false;
-@@ -1757,6 +1869,7 @@ public class PurpurWorldConfig {
+@@ -1759,6 +1871,7 @@ public class PurpurWorldConfig {
      public double striderMaxHealth = 20.0D;
      public int striderBreedingTicks = 6000;
      public boolean striderGiveSaddleBack = false;
@@ -2081,7 +2081,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void striderSettings() {
          striderRidable = getBoolean("mobs.strider.ridable", striderRidable);
          striderRidableInWater = getBoolean("mobs.strider.ridable-in-water", striderRidableInWater);
-@@ -1769,6 +1882,7 @@ public class PurpurWorldConfig {
+@@ -1771,6 +1884,7 @@ public class PurpurWorldConfig {
          striderMaxHealth = getDouble("mobs.strider.attributes.max_health", striderMaxHealth);
          striderBreedingTicks = getInt("mobs.strider.breeding-delay-ticks", striderBreedingTicks);
          striderGiveSaddleBack = getBoolean("mobs.strider.give-saddle-back", striderGiveSaddleBack);
@@ -2089,7 +2089,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean tadpoleRidable = false;
-@@ -1790,6 +1904,7 @@ public class PurpurWorldConfig {
+@@ -1792,6 +1906,7 @@ public class PurpurWorldConfig {
      public double traderLlamaMovementSpeedMin = 0.175D;
      public double traderLlamaMovementSpeedMax = 0.175D;
      public int traderLlamaBreedingTicks = 6000;
@@ -2097,7 +2097,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void traderLlamaSettings() {
          traderLlamaRidable = getBoolean("mobs.trader_llama.ridable", traderLlamaRidable);
          traderLlamaRidableInWater = getBoolean("mobs.trader_llama.ridable-in-water", traderLlamaRidableInWater);
-@@ -1808,11 +1923,13 @@ public class PurpurWorldConfig {
+@@ -1810,11 +1925,13 @@ public class PurpurWorldConfig {
          traderLlamaMovementSpeedMin = getDouble("mobs.trader_llama.attributes.movement_speed.min", traderLlamaMovementSpeedMin);
          traderLlamaMovementSpeedMax = getDouble("mobs.trader_llama.attributes.movement_speed.max", traderLlamaMovementSpeedMax);
          traderLlamaBreedingTicks = getInt("mobs.trader_llama.breeding-delay-ticks", traderLlamaBreedingTicks);
@@ -2111,7 +2111,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void tropicalFishSettings() {
          tropicalFishRidable = getBoolean("mobs.tropical_fish.ridable", tropicalFishRidable);
          tropicalFishControllable = getBoolean("mobs.tropical_fish.controllable", tropicalFishControllable);
-@@ -1822,6 +1939,7 @@ public class PurpurWorldConfig {
+@@ -1824,6 +1941,7 @@ public class PurpurWorldConfig {
              set("mobs.tropical_fish.attributes.max_health", oldValue);
          }
          tropicalFishMaxHealth = getDouble("mobs.tropical_fish.attributes.max_health", tropicalFishMaxHealth);
@@ -2119,7 +2119,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean turtleRidable = false;
-@@ -1829,6 +1947,7 @@ public class PurpurWorldConfig {
+@@ -1831,6 +1949,7 @@ public class PurpurWorldConfig {
      public boolean turtleControllable = true;
      public double turtleMaxHealth = 30.0D;
      public int turtleBreedingTicks = 6000;
@@ -2127,7 +2127,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void turtleSettings() {
          turtleRidable = getBoolean("mobs.turtle.ridable", turtleRidable);
          turtleRidableInWater = getBoolean("mobs.turtle.ridable-in-water", turtleRidableInWater);
-@@ -1840,6 +1959,7 @@ public class PurpurWorldConfig {
+@@ -1842,6 +1961,7 @@ public class PurpurWorldConfig {
          }
          turtleMaxHealth = getDouble("mobs.turtle.attributes.max_health", turtleMaxHealth);
          turtleBreedingTicks = getInt("mobs.turtle.breeding-delay-ticks", turtleBreedingTicks);
@@ -2135,7 +2135,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean vexRidable = false;
-@@ -1847,6 +1967,7 @@ public class PurpurWorldConfig {
+@@ -1849,6 +1969,7 @@ public class PurpurWorldConfig {
      public boolean vexControllable = true;
      public double vexMaxY = 320D;
      public double vexMaxHealth = 14.0D;
@@ -2143,7 +2143,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void vexSettings() {
          vexRidable = getBoolean("mobs.vex.ridable", vexRidable);
          vexRidableInWater = getBoolean("mobs.vex.ridable-in-water", vexRidableInWater);
-@@ -1858,6 +1979,7 @@ public class PurpurWorldConfig {
+@@ -1860,6 +1981,7 @@ public class PurpurWorldConfig {
              set("mobs.vex.attributes.max_health", oldValue);
          }
          vexMaxHealth = getDouble("mobs.vex.attributes.max_health", vexMaxHealth);
@@ -2151,7 +2151,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean villagerRidable = false;
-@@ -1873,6 +1995,7 @@ public class PurpurWorldConfig {
+@@ -1875,6 +1997,7 @@ public class PurpurWorldConfig {
      public boolean villagerClericsFarmWarts = false;
      public boolean villagerClericFarmersThrowWarts = true;
      public boolean villagerBypassMobGriefing = false;
@@ -2159,7 +2159,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -1892,6 +2015,7 @@ public class PurpurWorldConfig {
+@@ -1894,6 +2017,7 @@ public class PurpurWorldConfig {
          villagerClericsFarmWarts = getBoolean("mobs.villager.clerics-farm-warts", villagerClericsFarmWarts);
          villagerClericFarmersThrowWarts = getBoolean("mobs.villager.cleric-wart-farmers-throw-warts-at-villagers", villagerClericFarmersThrowWarts);
          villagerBypassMobGriefing = getBoolean("mobs.villager.bypass-mob-griefing", villagerBypassMobGriefing);
@@ -2167,7 +2167,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean vindicatorRidable = false;
-@@ -1899,6 +2023,7 @@ public class PurpurWorldConfig {
+@@ -1901,6 +2025,7 @@ public class PurpurWorldConfig {
      public boolean vindicatorControllable = true;
      public double vindicatorMaxHealth = 24.0D;
      public double vindicatorJohnnySpawnChance = 0D;
@@ -2175,7 +2175,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void vindicatorSettings() {
          vindicatorRidable = getBoolean("mobs.vindicator.ridable", vindicatorRidable);
          vindicatorRidableInWater = getBoolean("mobs.vindicator.ridable-in-water", vindicatorRidableInWater);
-@@ -1910,6 +2035,7 @@ public class PurpurWorldConfig {
+@@ -1912,6 +2037,7 @@ public class PurpurWorldConfig {
          }
          vindicatorMaxHealth = getDouble("mobs.vindicator.attributes.max_health", vindicatorMaxHealth);
          vindicatorJohnnySpawnChance = getDouble("mobs.vindicator.johnny.spawn-chance", vindicatorJohnnySpawnChance);
@@ -2183,7 +2183,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean wanderingTraderRidable = false;
-@@ -1918,6 +2044,7 @@ public class PurpurWorldConfig {
+@@ -1920,6 +2046,7 @@ public class PurpurWorldConfig {
      public double wanderingTraderMaxHealth = 20.0D;
      public boolean wanderingTraderFollowEmeraldBlock = false;
      public boolean wanderingTraderCanBeLeashed = false;
@@ -2191,7 +2191,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void wanderingTraderSettings() {
          wanderingTraderRidable = getBoolean("mobs.wandering_trader.ridable", wanderingTraderRidable);
          wanderingTraderRidableInWater = getBoolean("mobs.wandering_trader.ridable-in-water", wanderingTraderRidableInWater);
-@@ -1930,6 +2057,7 @@ public class PurpurWorldConfig {
+@@ -1932,6 +2059,7 @@ public class PurpurWorldConfig {
          wanderingTraderMaxHealth = getDouble("mobs.wandering_trader.attributes.max_health", wanderingTraderMaxHealth);
          wanderingTraderFollowEmeraldBlock = getBoolean("mobs.wandering_trader.follow-emerald-blocks", wanderingTraderFollowEmeraldBlock);
          wanderingTraderCanBeLeashed = getBoolean("mobs.wandering_trader.can-be-leashed", wanderingTraderCanBeLeashed);
@@ -2199,7 +2199,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean wardenRidable = false;
-@@ -1945,6 +2073,7 @@ public class PurpurWorldConfig {
+@@ -1947,6 +2075,7 @@ public class PurpurWorldConfig {
      public boolean witchRidableInWater = false;
      public boolean witchControllable = true;
      public double witchMaxHealth = 26.0D;
@@ -2207,7 +2207,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void witchSettings() {
          witchRidable = getBoolean("mobs.witch.ridable", witchRidable);
          witchRidableInWater = getBoolean("mobs.witch.ridable-in-water", witchRidableInWater);
-@@ -1955,6 +2084,7 @@ public class PurpurWorldConfig {
+@@ -1957,6 +2086,7 @@ public class PurpurWorldConfig {
              set("mobs.witch.attributes.max_health", oldValue);
          }
          witchMaxHealth = getDouble("mobs.witch.attributes.max_health", witchMaxHealth);
@@ -2215,7 +2215,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean witherRidable = false;
-@@ -1965,6 +2095,7 @@ public class PurpurWorldConfig {
+@@ -1967,6 +2097,7 @@ public class PurpurWorldConfig {
      public float witherHealthRegenAmount = 1.0f;
      public int witherHealthRegenDelay = 20;
      public boolean witherBypassMobGriefing = false;
@@ -2223,7 +2223,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -1983,12 +2114,14 @@ public class PurpurWorldConfig {
+@@ -1985,12 +2116,14 @@ public class PurpurWorldConfig {
          witherHealthRegenAmount = (float) getDouble("mobs.wither.health-regen-amount", witherHealthRegenAmount);
          witherHealthRegenDelay = getInt("mobs.wither.health-regen-delay", witherHealthRegenDelay);
          witherBypassMobGriefing = getBoolean("mobs.wither.bypass-mob-griefing", witherBypassMobGriefing);
@@ -2238,7 +2238,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void witherSkeletonSettings() {
          witherSkeletonRidable = getBoolean("mobs.wither_skeleton.ridable", witherSkeletonRidable);
          witherSkeletonRidableInWater = getBoolean("mobs.wither_skeleton.ridable-in-water", witherSkeletonRidableInWater);
-@@ -1999,6 +2132,7 @@ public class PurpurWorldConfig {
+@@ -2001,6 +2134,7 @@ public class PurpurWorldConfig {
              set("mobs.wither_skeleton.attributes.max_health", oldValue);
          }
          witherSkeletonMaxHealth = getDouble("mobs.wither_skeleton.attributes.max_health", witherSkeletonMaxHealth);
@@ -2246,7 +2246,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean wolfRidable = false;
-@@ -2009,6 +2143,7 @@ public class PurpurWorldConfig {
+@@ -2011,6 +2145,7 @@ public class PurpurWorldConfig {
      public boolean wolfMilkCuresRabies = true;
      public double wolfNaturalRabid = 0.0D;
      public int wolfBreedingTicks = 6000;
@@ -2254,7 +2254,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void wolfSettings() {
          wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
          wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
-@@ -2027,12 +2162,14 @@ public class PurpurWorldConfig {
+@@ -2029,12 +2164,14 @@ public class PurpurWorldConfig {
          wolfMilkCuresRabies = getBoolean("mobs.wolf.milk-cures-rabid-wolves", wolfMilkCuresRabies);
          wolfNaturalRabid = getDouble("mobs.wolf.spawn-rabid-chance", wolfNaturalRabid);
          wolfBreedingTicks = getInt("mobs.wolf.breeding-delay-ticks", wolfBreedingTicks);
@@ -2269,7 +2269,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void zoglinSettings() {
          zoglinRidable = getBoolean("mobs.zoglin.ridable", zoglinRidable);
          zoglinRidableInWater = getBoolean("mobs.zoglin.ridable-in-water", zoglinRidableInWater);
-@@ -2043,6 +2180,7 @@ public class PurpurWorldConfig {
+@@ -2045,6 +2182,7 @@ public class PurpurWorldConfig {
              set("mobs.zoglin.attributes.max_health", oldValue);
          }
          zoglinMaxHealth = getDouble("mobs.zoglin.attributes.max_health", zoglinMaxHealth);
@@ -2277,7 +2277,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean zombieRidable = false;
-@@ -2055,6 +2193,7 @@ public class PurpurWorldConfig {
+@@ -2057,6 +2195,7 @@ public class PurpurWorldConfig {
      public boolean zombieJockeyTryExistingChickens = true;
      public boolean zombieAggressiveTowardsVillagerWhenLagging = true;
      public boolean zombieBypassMobGriefing = false;
@@ -2285,7 +2285,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -2071,6 +2210,7 @@ public class PurpurWorldConfig {
+@@ -2073,6 +2212,7 @@ public class PurpurWorldConfig {
          zombieJockeyTryExistingChickens = getBoolean("mobs.zombie.jockey.try-existing-chickens", zombieJockeyTryExistingChickens);
          zombieAggressiveTowardsVillagerWhenLagging = getBoolean("mobs.zombie.aggressive-towards-villager-when-lagging", zombieAggressiveTowardsVillagerWhenLagging);
          zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
@@ -2293,7 +2293,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean zombieHorseRidableInWater = false;
-@@ -2082,6 +2222,7 @@ public class PurpurWorldConfig {
+@@ -2084,6 +2224,7 @@ public class PurpurWorldConfig {
      public double zombieHorseMovementSpeedMin = 0.2D;
      public double zombieHorseMovementSpeedMax = 0.2D;
      public double zombieHorseSpawnChance = 0.0D;
@@ -2301,7 +2301,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void zombieHorseSettings() {
          zombieHorseRidableInWater = getBoolean("mobs.zombie_horse.ridable-in-water", zombieHorseRidableInWater);
          zombieHorseCanSwim = getBoolean("mobs.zombie_horse.can-swim", zombieHorseCanSwim);
-@@ -2098,6 +2239,7 @@ public class PurpurWorldConfig {
+@@ -2100,6 +2241,7 @@ public class PurpurWorldConfig {
          zombieHorseMovementSpeedMin = getDouble("mobs.zombie_horse.attributes.movement_speed.min", zombieHorseMovementSpeedMin);
          zombieHorseMovementSpeedMax = getDouble("mobs.zombie_horse.attributes.movement_speed.max", zombieHorseMovementSpeedMax);
          zombieHorseSpawnChance = getDouble("mobs.zombie_horse.spawn-chance", zombieHorseSpawnChance);
@@ -2309,7 +2309,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean zombieVillagerRidable = false;
-@@ -2108,6 +2250,7 @@ public class PurpurWorldConfig {
+@@ -2110,6 +2252,7 @@ public class PurpurWorldConfig {
      public boolean zombieVillagerJockeyOnlyBaby = true;
      public double zombieVillagerJockeyChance = 0.05D;
      public boolean zombieVillagerJockeyTryExistingChickens = true;
@@ -2317,7 +2317,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2122,6 +2265,7 @@ public class PurpurWorldConfig {
+@@ -2124,6 +2267,7 @@ public class PurpurWorldConfig {
          zombieVillagerJockeyOnlyBaby = getBoolean("mobs.zombie_villager.jockey.only-babies", zombieVillagerJockeyOnlyBaby);
          zombieVillagerJockeyChance = getDouble("mobs.zombie_villager.jockey.chance", zombieVillagerJockeyChance);
          zombieVillagerJockeyTryExistingChickens = getBoolean("mobs.zombie_villager.jockey.try-existing-chickens", zombieVillagerJockeyTryExistingChickens);
@@ -2325,7 +2325,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      }
  
      public boolean zombifiedPiglinRidable = false;
-@@ -2133,6 +2277,7 @@ public class PurpurWorldConfig {
+@@ -2135,6 +2279,7 @@ public class PurpurWorldConfig {
      public double zombifiedPiglinJockeyChance = 0.05D;
      public boolean zombifiedPiglinJockeyTryExistingChickens = true;
      public boolean zombifiedPiglinCountAsPlayerKillWhenAngry = true;
@@ -2333,7 +2333,7 @@ index cc6c0c3dc982ce6322aa882289620befce0d8d05..74961f18a221031be6e677579fc83ddf
      private void zombifiedPiglinSettings() {
          zombifiedPiglinRidable = getBoolean("mobs.zombified_piglin.ridable", zombifiedPiglinRidable);
          zombifiedPiglinRidableInWater = getBoolean("mobs.zombified_piglin.ridable-in-water", zombifiedPiglinRidableInWater);
-@@ -2148,5 +2293,6 @@ public class PurpurWorldConfig {
+@@ -2150,5 +2295,6 @@ public class PurpurWorldConfig {
          zombifiedPiglinJockeyChance = getDouble("mobs.zombified_piglin.jockey.chance", zombifiedPiglinJockeyChance);
          zombifiedPiglinJockeyTryExistingChickens = getBoolean("mobs.zombified_piglin.jockey.try-existing-chickens", zombifiedPiglinJockeyTryExistingChickens);
          zombifiedPiglinCountAsPlayerKillWhenAngry = getBoolean("mobs.zombified_piglin.count-as-player-kill-when-angry", zombifiedPiglinCountAsPlayerKillWhenAngry);

--- a/patches/server/0138-End-crystal-explosion-options.patch
+++ b/patches/server/0138-End-crystal-explosion-options.patch
@@ -52,10 +52,10 @@ index e1493079d06a91f3e14e333e2a0408725a8f5bea..59d7f4ef118b2a87d1fe9cc1dd2fea89
  
                  this.onDestroyedBy(source);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 702a2caacf1cee7cf057fad12a9a490fc7f84e69..0e87b9ef34280b92b3b906f1b20fcc38b27181a1 100644
+index 94288b749f183b195ce5bd974ab770bc50d0721b..af37829b104073589d67d66ab826bb64fb95d7dc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -464,6 +464,35 @@ public class PurpurWorldConfig {
+@@ -466,6 +466,35 @@ public class PurpurWorldConfig {
          dispenserPlaceAnvils = getBoolean("blocks.dispenser.place-anvils", dispenserPlaceAnvils);
      }
  

--- a/patches/server/0139-Configs-for-if-Wither-Ender-Dragon-can-ride-vehicles.patch
+++ b/patches/server/0139-Configs-for-if-Wither-Ender-Dragon-can-ride-vehicles.patch
@@ -29,10 +29,10 @@ index d5fc11b01fcd064562173fb35856686f6977144e..0c3fe609a9d4c4c485b1a11e6ec39c06
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 0e87b9ef34280b92b3b906f1b20fcc38b27181a1..b9700ec497ab84dde2424c1faa79a5ce5fcd4ad1 100644
+index af37829b104073589d67d66ab826bb64fb95d7dc..13eb84cf590bbe4c5a71b47f1c08e57b5711f089 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -915,6 +915,7 @@ public class PurpurWorldConfig {
+@@ -917,6 +917,7 @@ public class PurpurWorldConfig {
      public boolean enderDragonAlwaysDropsFullExp = false;
      public boolean enderDragonBypassMobGriefing = false;
      public boolean enderDragonTakeDamageFromWater = false;
@@ -40,7 +40,7 @@ index 0e87b9ef34280b92b3b906f1b20fcc38b27181a1..b9700ec497ab84dde2424c1faa79a5ce
      private void enderDragonSettings() {
          enderDragonRidable = getBoolean("mobs.ender_dragon.ridable", enderDragonRidable);
          enderDragonRidableInWater = getBoolean("mobs.ender_dragon.ridable-in-water", enderDragonRidableInWater);
-@@ -933,6 +934,7 @@ public class PurpurWorldConfig {
+@@ -935,6 +936,7 @@ public class PurpurWorldConfig {
          enderDragonAlwaysDropsFullExp = getBoolean("mobs.ender_dragon.always-drop-full-exp", enderDragonAlwaysDropsFullExp);
          enderDragonBypassMobGriefing = getBoolean("mobs.ender_dragon.bypass-mob-griefing", enderDragonBypassMobGriefing);
          enderDragonTakeDamageFromWater = getBoolean("mobs.ender_dragon.takes-damage-from-water", enderDragonTakeDamageFromWater);
@@ -48,7 +48,7 @@ index 0e87b9ef34280b92b3b906f1b20fcc38b27181a1..b9700ec497ab84dde2424c1faa79a5ce
      }
  
      public boolean endermanRidable = false;
-@@ -2127,6 +2129,7 @@ public class PurpurWorldConfig {
+@@ -2129,6 +2131,7 @@ public class PurpurWorldConfig {
      public int witherHealthRegenDelay = 20;
      public boolean witherBypassMobGriefing = false;
      public boolean witherTakeDamageFromWater = false;
@@ -56,7 +56,7 @@ index 0e87b9ef34280b92b3b906f1b20fcc38b27181a1..b9700ec497ab84dde2424c1faa79a5ce
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2146,6 +2149,7 @@ public class PurpurWorldConfig {
+@@ -2148,6 +2151,7 @@ public class PurpurWorldConfig {
          witherHealthRegenDelay = getInt("mobs.wither.health-regen-delay", witherHealthRegenDelay);
          witherBypassMobGriefing = getBoolean("mobs.wither.bypass-mob-griefing", witherBypassMobGriefing);
          witherTakeDamageFromWater = getBoolean("mobs.wither.takes-damage-from-water", witherTakeDamageFromWater);

--- a/patches/server/0145-Config-Enderman-aggressiveness-towards-Endermites.patch
+++ b/patches/server/0145-Config-Enderman-aggressiveness-towards-Endermites.patch
@@ -18,10 +18,10 @@ index 3d554d0c6f371a10fa939f87893d7dd727439541..78501dcf53672125d6895fb5ca159745
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b04d1dd43bec362f0632fe52436aa14c8988b1e1..9f91a83e7b6a0e7be3342db3e2fe42f3e6d098fe 100644
+index a1ed00066243e86c796acf49ed830b184e4871c5..66582892312d6cdcd0c8b3b2a14d424138929318 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -961,6 +961,8 @@ public class PurpurWorldConfig {
+@@ -963,6 +963,8 @@ public class PurpurWorldConfig {
      public boolean endermanDespawnEvenWithBlock = false;
      public boolean endermanBypassMobGriefing = false;
      public boolean endermanTakeDamageFromWater = true;
@@ -30,7 +30,7 @@ index b04d1dd43bec362f0632fe52436aa14c8988b1e1..9f91a83e7b6a0e7be3342db3e2fe42f3
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -970,11 +972,17 @@ public class PurpurWorldConfig {
+@@ -972,11 +974,17 @@ public class PurpurWorldConfig {
              set("mobs.enderman.attributes.max-health", null);
              set("mobs.enderman.attributes.max_health", oldValue);
          }

--- a/patches/server/0146-Config-to-ignore-Dragon-Head-wearers-and-stare-aggro.patch
+++ b/patches/server/0146-Config-to-ignore-Dragon-Head-wearers-and-stare-aggro.patch
@@ -20,10 +20,10 @@ index 78501dcf53672125d6895fb5ca1597450157e1d8..6c1de46576c3cb65526de48400d26869
          } else {
              Vec3 vec3d = player.getViewVector(1.0F).normalize();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9f91a83e7b6a0e7be3342db3e2fe42f3e6d098fe..7747a92b15ee5282810180ef8dfa4bcae74ec836 100644
+index 66582892312d6cdcd0c8b3b2a14d424138929318..e07f75e38d012d5f266df7ac86f6239674d4281e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -963,6 +963,8 @@ public class PurpurWorldConfig {
+@@ -965,6 +965,8 @@ public class PurpurWorldConfig {
      public boolean endermanTakeDamageFromWater = true;
      public boolean endermanAggroEndermites = true;
      public boolean endermanAggroEndermitesOnlyIfPlayerSpawned = false;
@@ -32,7 +32,7 @@ index 9f91a83e7b6a0e7be3342db3e2fe42f3e6d098fe..7747a92b15ee5282810180ef8dfa4bca
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -983,6 +985,8 @@ public class PurpurWorldConfig {
+@@ -985,6 +987,8 @@ public class PurpurWorldConfig {
          endermanTakeDamageFromWater = getBoolean("mobs.enderman.takes-damage-from-water", endermanTakeDamageFromWater);
          endermanAggroEndermites = getBoolean("mobs.enderman.aggressive-towards-endermites", endermanAggroEndermites);
          endermanAggroEndermitesOnlyIfPlayerSpawned = getBoolean("mobs.enderman.aggressive-towards-endermites-only-spawned-by-player-thrown-ender-pearls", endermanAggroEndermitesOnlyIfPlayerSpawned);

--- a/patches/server/0148-Config-to-disable-Llama-caravans.patch
+++ b/patches/server/0148-Config-to-disable-Llama-caravans.patch
@@ -32,10 +32,10 @@ index a83bc1451fe7895bba46aae2da2bc8cb29c7da04..06177b60406aa949c71277f75158f154
          this.caravanHead.caravanTail = this;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a23158f7e766ff15b63f2950aec2f02a81674cee..f14adabf3fac668aed31b0c9b47b993f598be1d3 100644
+index e62ebd4a24de2e5b231a4db21d25e4b01b5b0f02..6b2d5f92c9884d2c3e3ae997a7d90800b09186b0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1295,6 +1295,7 @@ public class PurpurWorldConfig {
+@@ -1297,6 +1297,7 @@ public class PurpurWorldConfig {
      public double llamaMovementSpeedMax = 0.175D;
      public int llamaBreedingTicks = 6000;
      public boolean llamaTakeDamageFromWater = false;
@@ -43,7 +43,7 @@ index a23158f7e766ff15b63f2950aec2f02a81674cee..f14adabf3fac668aed31b0c9b47b993f
      private void llamaSettings() {
          llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
          llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
-@@ -1314,6 +1315,7 @@ public class PurpurWorldConfig {
+@@ -1316,6 +1317,7 @@ public class PurpurWorldConfig {
          llamaMovementSpeedMax = getDouble("mobs.llama.attributes.movement_speed.max", llamaMovementSpeedMax);
          llamaBreedingTicks = getInt("mobs.llama.breeding-delay-ticks", llamaBreedingTicks);
          llamaTakeDamageFromWater = getBoolean("mobs.llama.takes-damage-from-water", llamaTakeDamageFromWater);

--- a/patches/server/0149-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0149-Config-to-make-Creepers-explode-on-death.patch
@@ -50,10 +50,10 @@ index 6de0dccb7a70d9ebde7a518f820258a445bed000..2ffa10ddd1a19aa44c088a41fdfcbd59
  
      private void spawnLingeringCloud() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f14adabf3fac668aed31b0c9b47b993f598be1d3..7f4b76cb8de86cb4265b765ed48ea00422a837db 100644
+index 6b2d5f92c9884d2c3e3ae997a7d90800b09186b0..141aca86c5fe70f3fad838021d93c66d4b630139 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -815,6 +815,7 @@ public class PurpurWorldConfig {
+@@ -817,6 +817,7 @@ public class PurpurWorldConfig {
      public boolean creeperAllowGriefing = true;
      public boolean creeperBypassMobGriefing = false;
      public boolean creeperTakeDamageFromWater = false;
@@ -61,7 +61,7 @@ index f14adabf3fac668aed31b0c9b47b993f598be1d3..7f4b76cb8de86cb4265b765ed48ea004
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -829,6 +830,7 @@ public class PurpurWorldConfig {
+@@ -831,6 +832,7 @@ public class PurpurWorldConfig {
          creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
          creeperBypassMobGriefing = getBoolean("mobs.creeper.bypass-mob-griefing", creeperBypassMobGriefing);
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);

--- a/patches/server/0150-Configurable-ravager-griefable-blocks-list.patch
+++ b/patches/server/0150-Configurable-ravager-griefable-blocks-list.patch
@@ -31,10 +31,10 @@ index a68bf10353e5c19adfa86c2dd6290f2386af9a9d..38bc19edc2dcfa33b3191cfa3b69f00d
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7f4b76cb8de86cb4265b765ed48ea00422a837db..b575819bc23362f21b080c675e89b799b6ed99d2 100644
+index 141aca86c5fe70f3fad838021d93c66d4b630139..37d4e08d6c1c3683514f679a9ab772a28d4010a1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1679,6 +1679,7 @@ public class PurpurWorldConfig {
+@@ -1681,6 +1681,7 @@ public class PurpurWorldConfig {
      public double ravagerMaxHealth = 100.0D;
      public boolean ravagerBypassMobGriefing = false;
      public boolean ravagerTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index 7f4b76cb8de86cb4265b765ed48ea00422a837db..b575819bc23362f21b080c675e89b799
      private void ravagerSettings() {
          ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
          ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
-@@ -1691,6 +1692,23 @@ public class PurpurWorldConfig {
+@@ -1693,6 +1694,23 @@ public class PurpurWorldConfig {
          ravagerMaxHealth = getDouble("mobs.ravager.attributes.max_health", ravagerMaxHealth);
          ravagerBypassMobGriefing = getBoolean("mobs.ravager.bypass-mob-griefing", ravagerBypassMobGriefing);
          ravagerTakeDamageFromWater = getBoolean("mobs.ravager.takes-damage-from-water", ravagerTakeDamageFromWater);

--- a/patches/server/0151-Sneak-to-bulk-process-composter.patch
+++ b/patches/server/0151-Sneak-to-bulk-process-composter.patch
@@ -90,10 +90,10 @@ index 492e3ffd6a4588a521486db631f3e8b2a25b74ec..954c4a112d675144befd253abe880251
          int i = (Integer) iblockdata.getValue(ComposterBlock.LEVEL);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b575819bc23362f21b080c675e89b799b6ed99d2..1d101f9fe489122e2c3a83f901bc19b2232a5d72 100644
+index 37d4e08d6c1c3683514f679a9ab772a28d4010a1..9649618c5d5721e1ce2fb4f59d22e352b4b614dd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -475,6 +475,11 @@ public class PurpurWorldConfig {
+@@ -477,6 +477,11 @@ public class PurpurWorldConfig {
          chestOpenWithBlockOnTop = getBoolean("blocks.chest.open-with-solid-block-on-top", chestOpenWithBlockOnTop);
      }
  

--- a/patches/server/0153-Add-config-for-villager-trading.patch
+++ b/patches/server/0153-Add-config-for-villager-trading.patch
@@ -31,10 +31,10 @@ index 6dd8856816bebb2766203589048cc68b3f5c8f5c..8d6930868a42b9fc98d7672bff433ec5
                      this.openTradingScreen(player, this.getDisplayName(), 1);
                  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f36e00c716532b0ab12565ca0076c94b7d73e5b3..f398ddb46d2ebc99d0ae4235fd9c7a85271d850d 100644
+index 7eb68d2f6a56a1110bba275fbeb91cb8605c0e0a..91e2410ea09333ae65960ca67414333625857cb5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2088,6 +2088,7 @@ public class PurpurWorldConfig {
+@@ -2090,6 +2090,7 @@ public class PurpurWorldConfig {
      public boolean villagerClericFarmersThrowWarts = true;
      public boolean villagerBypassMobGriefing = false;
      public boolean villagerTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index f36e00c716532b0ab12565ca0076c94b7d73e5b3..f398ddb46d2ebc99d0ae4235fd9c7a85
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2108,6 +2109,7 @@ public class PurpurWorldConfig {
+@@ -2110,6 +2111,7 @@ public class PurpurWorldConfig {
          villagerClericFarmersThrowWarts = getBoolean("mobs.villager.cleric-wart-farmers-throw-warts-at-villagers", villagerClericFarmersThrowWarts);
          villagerBypassMobGriefing = getBoolean("mobs.villager.bypass-mob-griefing", villagerBypassMobGriefing);
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
@@ -50,7 +50,7 @@ index f36e00c716532b0ab12565ca0076c94b7d73e5b3..f398ddb46d2ebc99d0ae4235fd9c7a85
      }
  
      public boolean vindicatorRidable = false;
-@@ -2137,6 +2139,7 @@ public class PurpurWorldConfig {
+@@ -2139,6 +2141,7 @@ public class PurpurWorldConfig {
      public boolean wanderingTraderFollowEmeraldBlock = false;
      public boolean wanderingTraderCanBeLeashed = false;
      public boolean wanderingTraderTakeDamageFromWater = false;
@@ -58,7 +58,7 @@ index f36e00c716532b0ab12565ca0076c94b7d73e5b3..f398ddb46d2ebc99d0ae4235fd9c7a85
      private void wanderingTraderSettings() {
          wanderingTraderRidable = getBoolean("mobs.wandering_trader.ridable", wanderingTraderRidable);
          wanderingTraderRidableInWater = getBoolean("mobs.wandering_trader.ridable-in-water", wanderingTraderRidableInWater);
-@@ -2150,6 +2153,7 @@ public class PurpurWorldConfig {
+@@ -2152,6 +2155,7 @@ public class PurpurWorldConfig {
          wanderingTraderFollowEmeraldBlock = getBoolean("mobs.wandering_trader.follow-emerald-blocks", wanderingTraderFollowEmeraldBlock);
          wanderingTraderCanBeLeashed = getBoolean("mobs.wandering_trader.can-be-leashed", wanderingTraderCanBeLeashed);
          wanderingTraderTakeDamageFromWater = getBoolean("mobs.wandering_trader.takes-damage-from-water", wanderingTraderTakeDamageFromWater);

--- a/patches/server/0156-Break-individual-slabs-when-sneaking.patch
+++ b/patches/server/0156-Break-individual-slabs-when-sneaking.patch
@@ -47,10 +47,10 @@ index 18b603d646081926343dea108b55d641df1c2c34..fdbbd2e5d4fd970a4593b55f16bd0f82
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 504c3fe629cb9cb969aac125d0bfc2b7b37838ef..1209134e0b812f2da5579ddade5075684792b62f 100644
+index efba22df32b2c89360046005a381bf8b9c332f18..e920bf83bfd5ea009d72c0fbcb848115d1779ad5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -590,6 +590,11 @@ public class PurpurWorldConfig {
+@@ -592,6 +592,11 @@ public class PurpurWorldConfig {
          signRightClickEdit = getBoolean("blocks.sign.right-click-edit", signRightClickEdit);
      }
  

--- a/patches/server/0157-Config-to-disable-hostile-mob-spawn-on-ice.patch
+++ b/patches/server/0157-Config-to-disable-hostile-mob-spawn-on-ice.patch
@@ -24,10 +24,10 @@ index 55c245d0dfa369dc6de2197ae37335fba4fae4ae..c9b40515f4c2ff1eedfc9510930c3bae
              return false;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1209134e0b812f2da5579ddade5075684792b62f..6bc5244fd4bf15544db099283613d9e6bb79e702 100644
+index e920bf83bfd5ea009d72c0fbcb848115d1779ad5..d866acee76f81954813daf2cc988cccaa83cb791 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -553,6 +553,13 @@ public class PurpurWorldConfig {
+@@ -555,6 +555,13 @@ public class PurpurWorldConfig {
          furnaceUseLavaFromUnderneath = getBoolean("blocks.furnace.use-lava-from-underneath", furnaceUseLavaFromUnderneath);
      }
  

--- a/patches/server/0159-Option-to-make-doors-require-redstone.patch
+++ b/patches/server/0159-Option-to-make-doors-require-redstone.patch
@@ -67,10 +67,10 @@ index aa5289f652392515952cc10f70627ed2cdc6c398..d1d3323559f12f60ef0564e2218ca153
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index fb69f0d8797e37f2c934e6a148b2ec6d2eb242b1..7dd52eedee594c8e728a4e722dc263f8fcffd758 100644
+index 3427a092ee2ab58dfa9e8cec1d1ec77b85e45486..592d8f28bb1c5f35ff2a48874a0f76a64be9bd50 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -500,6 +500,16 @@ public class PurpurWorldConfig {
+@@ -502,6 +502,16 @@ public class PurpurWorldConfig {
          dispenserPlaceAnvils = getBoolean("blocks.dispenser.place-anvils", dispenserPlaceAnvils);
      }
  

--- a/patches/server/0160-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0160-Config-to-allow-for-unsafe-enchants.patch
@@ -27,7 +27,7 @@ index 7c012f1e37b0085c0939797b0dae8996b4953ab8..155b0a1aa58b891e98a55e10f112f611
                              ++i;
                          } else if (targets.size() == 1) {
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 800df3b7c04ce7ed52f265d681e7752f63ae4ec7..33c33a953cdd47c30720225b10a5378f16daf225 100644
+index 4b706a22859c5be41abeb6255680e1f085f050a2..1761b5b2f03a1f6557c1edceef998e8d270bf6d7 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 @@ -209,7 +209,8 @@ public class AnvilMenu extends ItemCombinerMenu {
@@ -60,7 +60,7 @@ index 800df3b7c04ce7ed52f265d681e7752f63ae4ec7..33c33a953cdd47c30720225b10a5378f
                                      i2 = enchantment.getMaxLevel();
                                  }
  
-@@ -333,7 +334,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -335,7 +336,7 @@ public class AnvilMenu extends ItemCombinerMenu {
              sendAllDataToRemote(); // CraftBukkit - SPIGOT-6686: Always send completed inventory to stay in sync with client
              this.broadcastChanges();
              // Purpur start

--- a/patches/server/0161-Configurable-sponge-absorption.patch
+++ b/patches/server/0161-Configurable-sponge-absorption.patch
@@ -43,10 +43,10 @@ index 7304b2659eb45bc4bc9fa7c43e6ca07221d0fc73..d96e3fbc0fd4275c29e7e6154ef66e9e
              }
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7dd52eedee594c8e728a4e722dc263f8fcffd758..151a66be1dccef8891f2655c38e982821afac5be 100644
+index 592d8f28bb1c5f35ff2a48874a0f76a64be9bd50..f5260bea7f54bd9f05099f6a34f582b1f69d3daf 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -619,6 +619,13 @@ public class PurpurWorldConfig {
+@@ -621,6 +621,13 @@ public class PurpurWorldConfig {
          spawnerDeactivateByRedstone = getBoolean("blocks.spawner.deactivate-by-redstone", spawnerDeactivateByRedstone);
      }
  

--- a/patches/server/0163-Config-for-powered-rail-activation-distance.patch
+++ b/patches/server/0163-Config-for-powered-rail-activation-distance.patch
@@ -18,10 +18,10 @@ index 7fddb6fa8fd30ef88346a59f7867aae792f13772..40893e71fe8447b695350273bef9623b
          } else {
              int j = pos.getX();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 02914dd4541772bfd7d659169b703725569bff05..51882af5cfc4fe431cf151b37ea4954f57b120b6 100644
+index 00c1ff2cf7435ccc69df870ace00beeb2cd68bf5..b1ee7134cf9e3bc51fcd4fb7c64f151244f2f34c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -605,6 +605,11 @@ public class PurpurWorldConfig {
+@@ -607,6 +607,11 @@ public class PurpurWorldConfig {
          powderSnowBypassMobGriefing = getBoolean("blocks.powder_snow.bypass-mob-griefing", powderSnowBypassMobGriefing);
      }
  

--- a/patches/server/0164-Piglin-portal-spawn-modifier.patch
+++ b/patches/server/0164-Piglin-portal-spawn-modifier.patch
@@ -31,10 +31,10 @@ index 65fa00b3d4d35a4125f8de444e77ac54e9e28551..dd9badfb2879def258bf725a5d802f7d
                  pos = pos.below();
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 51882af5cfc4fe431cf151b37ea4954f57b120b6..5f719e9590b83aee2c826dc6f75cf4f70f2ce2d8 100644
+index b1ee7134cf9e3bc51fcd4fb7c64f151244f2f34c..83931e389e021af77680f1ca8e82f23f9b9eef32 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1623,6 +1623,7 @@ public class PurpurWorldConfig {
+@@ -1625,6 +1625,7 @@ public class PurpurWorldConfig {
      public double piglinMaxHealth = 16.0D;
      public boolean piglinBypassMobGriefing = false;
      public boolean piglinTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index 51882af5cfc4fe431cf151b37ea4954f57b120b6..5f719e9590b83aee2c826dc6f75cf4f7
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -1635,6 +1636,7 @@ public class PurpurWorldConfig {
+@@ -1637,6 +1638,7 @@ public class PurpurWorldConfig {
          piglinMaxHealth = getDouble("mobs.piglin.attributes.max_health", piglinMaxHealth);
          piglinBypassMobGriefing = getBoolean("mobs.piglin.bypass-mob-griefing", piglinBypassMobGriefing);
          piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);

--- a/patches/server/0166-Config-for-wither-explosion-radius.patch
+++ b/patches/server/0166-Config-for-wither-explosion-radius.patch
@@ -18,10 +18,10 @@ index 1654b08f76e02e20a8ce5de618f8def82f1feeeb..7938a81fea35ef79fb1054e7b1117573
  
              if (!event.isCancelled()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5f719e9590b83aee2c826dc6f75cf4f70f2ce2d8..98f8de1af0985c49a47bb9083d1a21e2efed2598 100644
+index 83931e389e021af77680f1ca8e82f23f9b9eef32..87476d216f4e6ecfc3289fc6f5332187a0a2405a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2257,6 +2257,7 @@ public class PurpurWorldConfig {
+@@ -2259,6 +2259,7 @@ public class PurpurWorldConfig {
      public boolean witherBypassMobGriefing = false;
      public boolean witherTakeDamageFromWater = false;
      public boolean witherCanRideVehicles = false;
@@ -29,7 +29,7 @@ index 5f719e9590b83aee2c826dc6f75cf4f70f2ce2d8..98f8de1af0985c49a47bb9083d1a21e2
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2277,6 +2278,7 @@ public class PurpurWorldConfig {
+@@ -2279,6 +2280,7 @@ public class PurpurWorldConfig {
          witherBypassMobGriefing = getBoolean("mobs.wither.bypass-mob-griefing", witherBypassMobGriefing);
          witherTakeDamageFromWater = getBoolean("mobs.wither.takes-damage-from-water", witherTakeDamageFromWater);
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);

--- a/patches/server/0169-Configurable-piston-push-limit.patch
+++ b/patches/server/0169-Configurable-piston-push-limit.patch
@@ -36,10 +36,10 @@ index 744d91546d1a810f60a43c15ed74b4158f341a4a..354538daefa603f6df5a139b6bff87db
                      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index c4e578bb502afdd46831269088127010dcbe1b33..3fa0701635c5c429d8d836c47edcdb5b371dbbec 100644
+index f6f076b8e5231b8f68a121f9a432b74647cdde14..b787b34b11f7379249575b058fe3a07a1a7d3d83 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -615,6 +615,11 @@ public class PurpurWorldConfig {
+@@ -617,6 +617,11 @@ public class PurpurWorldConfig {
          lavaSpeedNotNether = getInt("blocks.lava.speed.not-nether", lavaSpeedNotNether);
      }
  

--- a/patches/server/0173-Config-for-health-to-impact-Creeper-explosion-radius.patch
+++ b/patches/server/0173-Config-for-health-to-impact-Creeper-explosion-radius.patch
@@ -21,10 +21,10 @@ index 2ffa10ddd1a19aa44c088a41fdfcbd596e493791..663232752b74fea95010510d237b439d
              if (!event.isCancelled()) {
                  this.dead = true;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 65c691cae79214e03eb5d719e5d9d65c564823a9..7f5515cdb760d928d5ece5d9577af11083846ea7 100644
+index d5b2ff0a8527f074b3a0cd145086e5218d557c8a..59c8a0d0f7b98020c30c4696f814e91436c3ef61 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -907,6 +907,7 @@ public class PurpurWorldConfig {
+@@ -909,6 +909,7 @@ public class PurpurWorldConfig {
      public boolean creeperBypassMobGriefing = false;
      public boolean creeperTakeDamageFromWater = false;
      public boolean creeperExplodeWhenKilled = false;
@@ -32,7 +32,7 @@ index 65c691cae79214e03eb5d719e5d9d65c564823a9..7f5515cdb760d928d5ece5d9577af110
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -922,6 +923,7 @@ public class PurpurWorldConfig {
+@@ -924,6 +925,7 @@ public class PurpurWorldConfig {
          creeperBypassMobGriefing = getBoolean("mobs.creeper.bypass-mob-griefing", creeperBypassMobGriefing);
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);

--- a/patches/server/0174-Iron-golem-calm-anger-options.patch
+++ b/patches/server/0174-Iron-golem-calm-anger-options.patch
@@ -26,10 +26,10 @@ index e3d725e656bc5ffc5fc92133794a80799fb21c48..fdad66c329ff8945a76a944deca7751a
              }
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7f5515cdb760d928d5ece5d9577af11083846ea7..da819628dac32476a24a3553ea6404ca6b89a04f 100644
+index 59c8a0d0f7b98020c30c4696f814e91436c3ef61..3d3b717aa59abf63528afc383e99c083e9be6aff 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1365,6 +1365,8 @@ public class PurpurWorldConfig {
+@@ -1367,6 +1367,8 @@ public class PurpurWorldConfig {
      public boolean ironGolemCanSwim = false;
      public double ironGolemMaxHealth = 100.0D;
      public boolean ironGolemTakeDamageFromWater = false;
@@ -38,7 +38,7 @@ index 7f5515cdb760d928d5ece5d9577af11083846ea7..da819628dac32476a24a3553ea6404ca
      private void ironGolemSettings() {
          ironGolemRidable = getBoolean("mobs.iron_golem.ridable", ironGolemRidable);
          ironGolemRidableInWater = getBoolean("mobs.iron_golem.ridable-in-water", ironGolemRidableInWater);
-@@ -1377,6 +1379,8 @@ public class PurpurWorldConfig {
+@@ -1379,6 +1381,8 @@ public class PurpurWorldConfig {
          }
          ironGolemMaxHealth = getDouble("mobs.iron_golem.attributes.max_health", ironGolemMaxHealth);
          ironGolemTakeDamageFromWater = getBoolean("mobs.iron_golem.takes-damage-from-water", ironGolemTakeDamageFromWater);

--- a/patches/server/0175-Breedable-parrots.patch
+++ b/patches/server/0175-Breedable-parrots.patch
@@ -50,10 +50,10 @@ index 11291851f11127f6781b3c77c0d59534606eb9dd..4f4df0f5459e3f62db4b15c57a536dc2
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index da819628dac32476a24a3553ea6404ca6b89a04f..cd64916a3e47760b2046a34c3b9ec97d491d65a2 100644
+index 3d3b717aa59abf63528afc383e99c083e9be6aff..8d4dc7d526cf9f4ec05e845ec9b10a47ff422d1e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1535,6 +1535,7 @@ public class PurpurWorldConfig {
+@@ -1537,6 +1537,7 @@ public class PurpurWorldConfig {
      public double parrotMaxY = 320D;
      public double parrotMaxHealth = 6.0D;
      public boolean parrotTakeDamageFromWater = false;
@@ -61,7 +61,7 @@ index da819628dac32476a24a3553ea6404ca6b89a04f..cd64916a3e47760b2046a34c3b9ec97d
      private void parrotSettings() {
          parrotRidable = getBoolean("mobs.parrot.ridable", parrotRidable);
          parrotRidableInWater = getBoolean("mobs.parrot.ridable-in-water", parrotRidableInWater);
-@@ -1547,6 +1548,7 @@ public class PurpurWorldConfig {
+@@ -1549,6 +1550,7 @@ public class PurpurWorldConfig {
          }
          parrotMaxHealth = getDouble("mobs.parrot.attributes.max_health", parrotMaxHealth);
          parrotTakeDamageFromWater = getBoolean("mobs.parrot.takes-damage-from-water", parrotTakeDamageFromWater);

--- a/patches/server/0178-Option-to-disable-dragon-egg-teleporting.patch
+++ b/patches/server/0178-Option-to-disable-dragon-egg-teleporting.patch
@@ -19,10 +19,10 @@ index 7e1edcc7b9f170b7c649437c2f0dd78c0bab9be4..5f8ac1fdac2c334951261f2b9702f5e7
              BlockPos blockposition1 = pos.offset(world.random.nextInt(16) - world.random.nextInt(16), world.random.nextInt(8) - world.random.nextInt(8), world.random.nextInt(16) - world.random.nextInt(16));
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b9040b9e965535db3431e794fe4bb0298146ddfc..17198148ca73a04f5a1fa119690b8e810c5b7707 100644
+index ef4c053236914f87c4ec48d1bfd0437ff75abd13..d346d1fa9badcf979b7aa2b2d69ad99316837944 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -548,6 +548,11 @@ public class PurpurWorldConfig {
+@@ -550,6 +550,11 @@ public class PurpurWorldConfig {
          });
      }
  

--- a/patches/server/0180-Make-anvil-cumulative-cost-configurable.patch
+++ b/patches/server/0180-Make-anvil-cumulative-cost-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make anvil cumulative cost configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 33c33a953cdd47c30720225b10a5378f16daf225..0ecda463452a3f9205dfbd97f28ae7cff5fa7698 100644
+index 1761b5b2f03a1f6557c1edceef998e8d270bf6d7..4a3d216006037b308d71f7784e5fef4d6278bde7 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-@@ -343,7 +343,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -345,7 +345,7 @@ public class AnvilMenu extends ItemCombinerMenu {
      }
  
      public static int calculateIncreasedRepairCost(int cost) {

--- a/patches/server/0181-ShulkerBox-allow-oversized-stacks.patch
+++ b/patches/server/0181-ShulkerBox-allow-oversized-stacks.patch
@@ -35,10 +35,10 @@ index 0ca6d495005bded447c3f940dfd571a003301cb0..f4c47f7a7f2572dedbaee4890c98e1f3
                  blockEntity.saveToItem(itemStack);
                  if (shulkerBoxBlockEntity.hasCustomName()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 17198148ca73a04f5a1fa119690b8e810c5b7707..751f3d3e727b152278d5f9c48b062ad17f9404d0 100644
+index d346d1fa9badcf979b7aa2b2d69ad99316837944..9e5093d566f78cd3b28570ade5529bcce2db027f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -657,6 +657,11 @@ public class PurpurWorldConfig {
+@@ -659,6 +659,11 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0182-Bee-can-work-when-raining-or-at-night.patch
+++ b/patches/server/0182-Bee-can-work-when-raining-or-at-night.patch
@@ -31,10 +31,10 @@ index a16a1df28258d605cf5908dbe19bda5d71ad4f45..7b82842b97ce795745cf6ee6399f618c
              return false;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 751f3d3e727b152278d5f9c48b062ad17f9404d0..07ff861240b5f76178f613986872685114d996a3 100644
+index 9e5093d566f78cd3b28570ade5529bcce2db027f..14eeef9823c1631d08d05fab579a18f72669dbfc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -767,6 +767,8 @@ public class PurpurWorldConfig {
+@@ -769,6 +769,8 @@ public class PurpurWorldConfig {
      public double beeMaxHealth = 10.0D;
      public int beeBreedingTicks = 6000;
      public boolean beeTakeDamageFromWater = false;
@@ -43,7 +43,7 @@ index 751f3d3e727b152278d5f9c48b062ad17f9404d0..07ff861240b5f76178f6139868726851
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -780,6 +782,8 @@ public class PurpurWorldConfig {
+@@ -782,6 +784,8 @@ public class PurpurWorldConfig {
          beeMaxHealth = getDouble("mobs.bee.attributes.max_health", beeMaxHealth);
          beeBreedingTicks = getInt("mobs.bee.breeding-delay-ticks", beeBreedingTicks);
          beeTakeDamageFromWater = getBoolean("mobs.bee.takes-damage-from-water", beeTakeDamageFromWater);

--- a/patches/server/0185-Beacon-Activation-Range-Configurable.patch
+++ b/patches/server/0185-Beacon-Activation-Range-Configurable.patch
@@ -26,11 +26,11 @@ index 5f6eeb36f57bd342b18590c8f0ffb668d2bf273c..59259dd3d8d8fd02c02d7435a4443779
          } else {
              return effectRange;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4710230baec5e13452f9c12f71de73a218c1f050..2a189ce43fbcaa901041b3d8b403fe70726410f5 100644
+index 4a41e0c169d31ae29d1039f3c06691b941026f66..b6110258766f41604adcb28629ad02bf563b62b4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -520,6 +520,17 @@ public class PurpurWorldConfig {
-         anvilAllowColors = getBoolean("blocks.anvil.allow-colors", anvilAllowColors);
+@@ -522,6 +522,17 @@ public class PurpurWorldConfig {
+         anvilColorsUseMiniMessage = getBoolean("blocks.anvil.use-mini-message", anvilColorsUseMiniMessage);
      }
  
 +    public int beaconLevelOne = 20;

--- a/patches/server/0186-Add-toggle-for-sand-duping-fix.patch
+++ b/patches/server/0186-Add-toggle-for-sand-duping-fix.patch
@@ -27,10 +27,10 @@ index ef07967b64180c54338b8fb2ba1780adec87f333..71e4178bf7d553141719c8a6cb7488d3
              }
              // Paper end - fix sand duping
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 2a189ce43fbcaa901041b3d8b403fe70726410f5..3cc3460374c9b656338fdfcaa313668cc5358611 100644
+index b6110258766f41604adcb28629ad02bf563b62b4..6944ed93105adb3833f870c03b9bba89aa083f6f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -683,6 +683,11 @@ public class PurpurWorldConfig {
+@@ -685,6 +685,11 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0187-Add-toggle-for-end-portal-safe-teleporting.patch
+++ b/patches/server/0187-Add-toggle-for-end-portal-safe-teleporting.patch
@@ -45,10 +45,10 @@ index 04bae5085756842ce88710646a17e9dc1aad5994..e7658fa9806701505e15cbf1d28ea3bd
              entity.portalWorld = ((ServerLevel)world);
              entity.portalBlock = pos.immutable();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3cc3460374c9b656338fdfcaa313668cc5358611..12609a41c9d6f23c807e509d059dba3bab295a6c 100644
+index 6944ed93105adb3833f870c03b9bba89aa083f6f..ebf607069030efaa5dc8fe70187533f0aec4918e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -634,6 +634,11 @@ public class PurpurWorldConfig {
+@@ -636,6 +636,11 @@ public class PurpurWorldConfig {
          furnaceUseLavaFromUnderneath = getBoolean("blocks.furnace.use-lava-from-underneath", furnaceUseLavaFromUnderneath);
      }
  

--- a/patches/server/0193-Shulker-spawn-from-bullet-options.patch
+++ b/patches/server/0193-Shulker-spawn-from-bullet-options.patch
@@ -61,10 +61,10 @@ index 2d3dbc228a6a7b88167a36ba739d9eb2f03472ba..7621978ab3d90d58e8b7c6807e0e0519
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4a86e1ccb948608ad686ecc23ed78c1953298cf4..b1d092b53aaeb5e6a28aa7f87c23bd04cda314bb 100644
+index 04d4af37567af133c5a92fa0ade9a9b5d5f2377c..d2414671efae789e0258dd3d5313df6a41d94c79 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1911,6 +1911,11 @@ public class PurpurWorldConfig {
+@@ -1913,6 +1913,11 @@ public class PurpurWorldConfig {
      public boolean shulkerControllable = true;
      public double shulkerMaxHealth = 30.0D;
      public boolean shulkerTakeDamageFromWater = false;
@@ -76,7 +76,7 @@ index 4a86e1ccb948608ad686ecc23ed78c1953298cf4..b1d092b53aaeb5e6a28aa7f87c23bd04
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -1922,6 +1927,11 @@ public class PurpurWorldConfig {
+@@ -1924,6 +1929,11 @@ public class PurpurWorldConfig {
          }
          shulkerMaxHealth = getDouble("mobs.shulker.attributes.max_health", shulkerMaxHealth);
          shulkerTakeDamageFromWater = getBoolean("mobs.shulker.takes-damage-from-water", shulkerTakeDamageFromWater);

--- a/patches/server/0195-Option-to-make-drowned-break-doors.patch
+++ b/patches/server/0195-Option-to-make-drowned-break-doors.patch
@@ -34,10 +34,10 @@ index 037d77b47d0be69dfeda01f4a0d52ad72aea2c8d..6e0a575a95ac0bcbc9e3909178ea566a
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ba1cdcd29aa7f1cbce02ef1d8a1d8f9e2173d5eb..511b1eae73c3daa61f97f9905983ace9d78cb9ef 100644
+index 9c83a02877ca0987887d8457783a667431a93b10..bc68a98299f5482d2d87d8f3dc1865fb450879a3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1045,6 +1045,7 @@ public class PurpurWorldConfig {
+@@ -1047,6 +1047,7 @@ public class PurpurWorldConfig {
      public double drownedJockeyChance = 0.05D;
      public boolean drownedJockeyTryExistingChickens = true;
      public boolean drownedTakeDamageFromWater = false;
@@ -45,7 +45,7 @@ index ba1cdcd29aa7f1cbce02ef1d8a1d8f9e2173d5eb..511b1eae73c3daa61f97f9905983ace9
      private void drownedSettings() {
          drownedRidable = getBoolean("mobs.drowned.ridable", drownedRidable);
          drownedRidableInWater = getBoolean("mobs.drowned.ridable-in-water", drownedRidableInWater);
-@@ -1060,6 +1061,7 @@ public class PurpurWorldConfig {
+@@ -1062,6 +1063,7 @@ public class PurpurWorldConfig {
          drownedJockeyChance = getDouble("mobs.drowned.jockey.chance", drownedJockeyChance);
          drownedJockeyTryExistingChickens = getBoolean("mobs.drowned.jockey.try-existing-chickens", drownedJockeyTryExistingChickens);
          drownedTakeDamageFromWater = getBoolean("mobs.drowned.takes-damage-from-water", drownedTakeDamageFromWater);

--- a/patches/server/0196-Configurable-hunger-starvation-damage.patch
+++ b/patches/server/0196-Configurable-hunger-starvation-damage.patch
@@ -18,10 +18,10 @@ index 65421cfff05c0493f5fef1bdff03172c9e33f33e..63584faeec4e5013be7a377e3203ec16
  
                  this.tickTimer = 0;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 511b1eae73c3daa61f97f9905983ace9d78cb9ef..d8284b22048a214bed4c6643cf9ec9445f110840 100644
+index bc68a98299f5482d2d87d8f3dc1865fb450879a3..7e8a1a4f56be6792279ee9f1065e706fcfceee2b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2559,4 +2559,9 @@ public class PurpurWorldConfig {
+@@ -2561,4 +2561,9 @@ public class PurpurWorldConfig {
          zombifiedPiglinCountAsPlayerKillWhenAngry = getBoolean("mobs.zombified_piglin.count-as-player-kill-when-angry", zombifiedPiglinCountAsPlayerKillWhenAngry);
          zombifiedPiglinTakeDamageFromWater = getBoolean("mobs.zombified_piglin.takes-damage-from-water", zombifiedPiglinTakeDamageFromWater);
      }

--- a/patches/server/0201-Tool-actionable-options.patch
+++ b/patches/server/0201-Tool-actionable-options.patch
@@ -122,7 +122,7 @@ index 180aec596110309aade13d2080f8824d152b07cb..c4aec1e5135a79837918b692e75a7b55
                  return InteractionResult.PASS;
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3fe900ff2aa17825d331c0f0c205a566c4464b5a..15ce90caf29e68b0a302a6929ad398690b42135f 100644
+index fbab9f6543d42d211f2ce4fda7428550d1a78f29..8d41e963d4f481fa610e09c606d337d4b28d7951 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -523,6 +523,159 @@ public class PurpurWorldConfig {
@@ -283,8 +283,8 @@ index 3fe900ff2aa17825d331c0f0c205a566c4464b5a..15ce90caf29e68b0a302a6929ad39869
 +    }
 +
      public boolean anvilAllowColors = false;
+     public boolean anvilColorsUseMiniMessage;
      private void anvilSettings() {
-         anvilAllowColors = getBoolean("blocks.anvil.allow-colors", anvilAllowColors);
 diff --git a/src/main/java/org/purpurmc/purpur/tool/Actionable.java b/src/main/java/org/purpurmc/purpur/tool/Actionable.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..e18c37f06730da9d3055d5215e813b1477c1e70e

--- a/patches/server/0206-Silk-touchable-budding-amethyst.patch
+++ b/patches/server/0206-Silk-touchable-budding-amethyst.patch
@@ -24,10 +24,10 @@ index bedccb8717d08d5a60058445b04ddff149e7d36c..5293ffca3da94c9c485a87d1232b6a90
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index acf932fb6a418b971eb9c497806d36e348634fd1..a71b83d5a63e66d645f5961f3048ab59fd6bb2cd 100644
+index 9a87b8bec1867b50fc5c38e912305419db8a3371..e24fc44809c3fda9fae52368d3daca11ffd6c54c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -710,6 +710,11 @@ public class PurpurWorldConfig {
+@@ -712,6 +712,11 @@ public class PurpurWorldConfig {
          }
      }
  
@@ -39,7 +39,7 @@ index acf932fb6a418b971eb9c497806d36e348634fd1..a71b83d5a63e66d645f5961f3048ab59
      public boolean chestOpenWithBlockOnTop = false;
      private void chestSettings() {
          chestOpenWithBlockOnTop = getBoolean("blocks.chest.open-with-solid-block-on-top", chestOpenWithBlockOnTop);
-@@ -2724,3 +2729,4 @@ public class PurpurWorldConfig {
+@@ -2726,3 +2731,4 @@ public class PurpurWorldConfig {
          hungerStarvationDamage = (float) getDouble("hunger.starvation-damage", hungerStarvationDamage);
      }
  }

--- a/patches/server/0207-Big-dripleaf-tilt-delay.patch
+++ b/patches/server/0207-Big-dripleaf-tilt-delay.patch
@@ -24,10 +24,10 @@ index 63aa6b82ba21ec8e8f362b390063e4e275a979a5..81ed6e69494337f402a6d9f854fb26fa
          if (i != -1) {
              world.scheduleTick(blockposition, (Block) this, i);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a71b83d5a63e66d645f5961f3048ab59fd6bb2cd..cf78a5164628ad14388567a19342ba642fa23dd5 100644
+index e24fc44809c3fda9fae52368d3daca11ffd6c54c..3a54bb63c814bf48081b5789440ede3946326fc5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -710,6 +710,22 @@ public class PurpurWorldConfig {
+@@ -712,6 +712,22 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0209-Config-to-disable-Enderman-teleport-on-projectile-hi.patch
+++ b/patches/server/0209-Config-to-disable-Enderman-teleport-on-projectile-hi.patch
@@ -18,10 +18,10 @@ index 6c1de46576c3cb65526de48400d268695ca53024..a8367e8086fb1c075102f414a5c30ccb
              boolean flag;
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 8a0221f1f94f4d39a692d61b990b7bc06a24bf8e..56a0d27364805a71541cc2a9ccd2c6d7e1fe8804 100644
+index 97c949bb1aa36e252112a608b9fe5d800d82d4b4..4544aae1760811c083435f24b3af2dcff8708745 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1304,6 +1304,7 @@ public class PurpurWorldConfig {
+@@ -1306,6 +1306,7 @@ public class PurpurWorldConfig {
      public boolean endermanAggroEndermitesOnlyIfPlayerSpawned = false;
      public boolean endermanIgnorePlayerDragonHead = false;
      public boolean endermanDisableStareAggro = false;
@@ -29,7 +29,7 @@ index 8a0221f1f94f4d39a692d61b990b7bc06a24bf8e..56a0d27364805a71541cc2a9ccd2c6d7
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1326,6 +1327,7 @@ public class PurpurWorldConfig {
+@@ -1328,6 +1329,7 @@ public class PurpurWorldConfig {
          endermanAggroEndermitesOnlyIfPlayerSpawned = getBoolean("mobs.enderman.aggressive-towards-endermites-only-spawned-by-player-thrown-ender-pearls", endermanAggroEndermitesOnlyIfPlayerSpawned);
          endermanIgnorePlayerDragonHead = getBoolean("mobs.enderman.ignore-players-wearing-dragon-head", endermanIgnorePlayerDragonHead);
          endermanDisableStareAggro = getBoolean("mobs.enderman.disable-player-stare-aggression", endermanDisableStareAggro);

--- a/patches/server/0211-Config-to-prevent-horses-from-standing-with-riders.patch
+++ b/patches/server/0211-Config-to-prevent-horses-from-standing-with-riders.patch
@@ -20,10 +20,10 @@ index a1ffa88c3796df2973a2fc0aeafda5f78208bf85..7466c437b2e996f16a08aaefc5c2b7cb
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3b1f31ee2c49da4a8006fb4f9f1676ac24cb764c..3a5567f440f72fcdaf1b26ea5deff6c4a5a1c738 100644
+index 08bb03f4c66a985b4c52dfe91f6e4d8612834aa1..bb22fe9212141f1f8ddd040d701ada488c3c7fac 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1534,6 +1534,7 @@ public class PurpurWorldConfig {
+@@ -1536,6 +1536,7 @@ public class PurpurWorldConfig {
      public double horseMovementSpeedMax = 0.3375D;
      public int horseBreedingTicks = 6000;
      public boolean horseTakeDamageFromWater = false;
@@ -31,7 +31,7 @@ index 3b1f31ee2c49da4a8006fb4f9f1676ac24cb764c..3a5567f440f72fcdaf1b26ea5deff6c4
      private void horseSettings() {
          horseRidableInWater = getBoolean("mobs.horse.ridable-in-water", horseRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1551,6 +1552,7 @@ public class PurpurWorldConfig {
+@@ -1553,6 +1554,7 @@ public class PurpurWorldConfig {
          horseMovementSpeedMax = getDouble("mobs.horse.attributes.movement_speed.max", horseMovementSpeedMax);
          horseBreedingTicks = getInt("mobs.horse.breeding-delay-ticks", horseBreedingTicks);
          horseTakeDamageFromWater = getBoolean("mobs.horse.takes-damage-from-water", horseTakeDamageFromWater);

--- a/patches/server/0214-Customizeable-Zombie-Villager-curing-times.patch
+++ b/patches/server/0214-Customizeable-Zombie-Villager-curing-times.patch
@@ -18,10 +18,10 @@ index 51fe59657b5b4608fc1528086c8692030d243a7a..f0f4542949de4927f15c75d067eb7d21
  
                  return InteractionResult.SUCCESS;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 58ee16f4344be8f907c1e697f08f3ee7e7f16ec8..0c1d2dfbb909c2d890d8f5e84bcfcdd63096432d 100644
+index 24daccf3a599e412a62870d172c23da79732fd9a..ac920b4aedc88274fc9683e620abc3ff174f40b9 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2710,6 +2710,8 @@ public class PurpurWorldConfig {
+@@ -2712,6 +2712,8 @@ public class PurpurWorldConfig {
      public double zombieVillagerJockeyChance = 0.05D;
      public boolean zombieVillagerJockeyTryExistingChickens = true;
      public boolean zombieVillagerTakeDamageFromWater = false;
@@ -30,7 +30,7 @@ index 58ee16f4344be8f907c1e697f08f3ee7e7f16ec8..0c1d2dfbb909c2d890d8f5e84bcfcdd6
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2725,6 +2727,8 @@ public class PurpurWorldConfig {
+@@ -2727,6 +2729,8 @@ public class PurpurWorldConfig {
          zombieVillagerJockeyChance = getDouble("mobs.zombie_villager.jockey.chance", zombieVillagerJockeyChance);
          zombieVillagerJockeyTryExistingChickens = getBoolean("mobs.zombie_villager.jockey.try-existing-chickens", zombieVillagerJockeyTryExistingChickens);
          zombieVillagerTakeDamageFromWater = getBoolean("mobs.zombie_villager.takes-damage-from-water", zombieVillagerTakeDamageFromWater);

--- a/patches/server/0215-Option-for-sponges-to-work-on-lava.patch
+++ b/patches/server/0215-Option-for-sponges-to-work-on-lava.patch
@@ -18,10 +18,10 @@ index d96e3fbc0fd4275c29e7e6154ef66e9ed1a5d829..df04a571ebd3c04bc7b58c1ee5661a1f
                          ++i;
                          if (j < world.purpurConfig.spongeAbsorptionRadius) { // Purpur
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 0c1d2dfbb909c2d890d8f5e84bcfcdd63096432d..4a71ef25c59416f6f494a318935a5531311bb6a1 100644
+index ac920b4aedc88274fc9683e620abc3ff174f40b9..001e60ae60d5b83136252553dd96c022fea8b6b1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -910,9 +910,11 @@ public class PurpurWorldConfig {
+@@ -912,9 +912,11 @@ public class PurpurWorldConfig {
  
      public int spongeAbsorptionArea = 64;
      public int spongeAbsorptionRadius = 6;

--- a/patches/server/0216-Toggle-for-Wither-s-spawn-sound.patch
+++ b/patches/server/0216-Toggle-for-Wither-s-spawn-sound.patch
@@ -18,10 +18,10 @@ index bf608c0bad8f1cd99f27b610c0d6dfa4d638374d..3f0b62c733c62b8d1a9fc6494d787c98
                      // this.world.globalLevelEvent(1023, new BlockPosition(this), 0);
                      int viewDistance = ((ServerLevel) this.level).getCraftServer().getViewDistance() * 16;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4a71ef25c59416f6f494a318935a5531311bb6a1..aff12279877c8786f9fa3a047c853df9359d88b7 100644
+index 001e60ae60d5b83136252553dd96c022fea8b6b1..38be9d24d61c9d95e4379e6d8fd11127da6ee143 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2555,6 +2555,7 @@ public class PurpurWorldConfig {
+@@ -2557,6 +2557,7 @@ public class PurpurWorldConfig {
      public boolean witherTakeDamageFromWater = false;
      public boolean witherCanRideVehicles = false;
      public float witherExplosionRadius = 1.0F;
@@ -29,7 +29,7 @@ index 4a71ef25c59416f6f494a318935a5531311bb6a1..aff12279877c8786f9fa3a047c853df9
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2576,6 +2577,7 @@ public class PurpurWorldConfig {
+@@ -2578,6 +2579,7 @@ public class PurpurWorldConfig {
          witherTakeDamageFromWater = getBoolean("mobs.wither.takes-damage-from-water", witherTakeDamageFromWater);
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);
          witherExplosionRadius = (float) getDouble("mobs.wither.explosion-radius", witherExplosionRadius);

--- a/patches/server/0217-Cactus-breaks-from-solid-neighbors-config.patch
+++ b/patches/server/0217-Cactus-breaks-from-solid-neighbors-config.patch
@@ -18,10 +18,10 @@ index 0fbabb84ef13e68b12212d9bfeb885c78893c116..56fa0e377b20ed063e47358be9e6bba8
          return false;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index aff12279877c8786f9fa3a047c853df9359d88b7..285f29c9f1a2f8b145b9151b86d79283671f7df8 100644
+index 38be9d24d61c9d95e4379e6d8fd11127da6ee143..3b5db512cdcde6052866aea020c129c51a2123ec 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -742,6 +742,11 @@ public class PurpurWorldConfig {
+@@ -744,6 +744,11 @@ public class PurpurWorldConfig {
          buddingAmethystSilkTouch = getBoolean("blocks.budding_amethyst.silk-touch", buddingAmethystSilkTouch);
      }
  

--- a/patches/server/0219-Conduit-behavior-configuration.patch
+++ b/patches/server/0219-Conduit-behavior-configuration.patch
@@ -77,10 +77,10 @@ index 05eab04e4aec4151018f25b59f92ddbbb4c09f87..3b5c502fc211940dd908f1d276fa11e3
          });
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 771c770c1bf73276abb3dac42941295e641b7f2b..f7acadac07695e4f1a4631d4fec5c8b84bf32b6a 100644
+index 29e9ef16cf3f9b7a143108a03437e5bb18987a13..ba31302438d81f8cec2782ab0762e78255b9dc5f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2774,5 +2774,28 @@ public class PurpurWorldConfig {
+@@ -2776,5 +2776,28 @@ public class PurpurWorldConfig {
      private void hungerSettings() {
          hungerStarvationDamage = (float) getDouble("hunger.starvation-damage", hungerStarvationDamage);
      }

--- a/patches/server/0220-Cauldron-fill-chances.patch
+++ b/patches/server/0220-Cauldron-fill-chances.patch
@@ -47,10 +47,10 @@ index ce4265a9cf01db335a6a88b91ae5e6ff4518ef92..f889729b3bbbe1c82fa8bc7e1ab1f7b0
  
                      if (dripChance < f1) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f7acadac07695e4f1a4631d4fec5c8b84bf32b6a..4053f1658ee55ecfdc2a3c30a3aaf928e52f2cb0 100644
+index ba31302438d81f8cec2782ab0762e78255b9dc5f..353e64e3b1740624051ea3805af99b9b476d9e70 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2797,5 +2797,16 @@ public class PurpurWorldConfig {
+@@ -2799,5 +2799,16 @@ public class PurpurWorldConfig {
          });
          conduitBlocks = conduitBlockList.toArray(Block[]::new);
      }

--- a/patches/server/0222-Shulker-change-color-with-dye.patch
+++ b/patches/server/0222-Shulker-change-color-with-dye.patch
@@ -47,10 +47,10 @@ index ada070d8e1a2d328c02455eb9e5ad056046bcd0a..691b59f784e34b061ea156a3236c09f2
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 672b4dcf5fbded33638d23749ab4feaf251d1dc3..82318edeecb92a59514942aa346019f79e290115 100644
+index 4347a2dcedf5a1e98b284274832b351f22289c3e..389725a9e7f58b74e6fbafb02bff7e33da01ebbf 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2126,6 +2126,7 @@ public class PurpurWorldConfig {
+@@ -2128,6 +2128,7 @@ public class PurpurWorldConfig {
      public double shulkerSpawnFromBulletNearbyRange = 8.0D;
      public String shulkerSpawnFromBulletNearbyEquation = "(nearby - 1) / 5.0";
      public boolean shulkerSpawnFromBulletRandomColor = false;
@@ -58,7 +58,7 @@ index 672b4dcf5fbded33638d23749ab4feaf251d1dc3..82318edeecb92a59514942aa346019f7
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -2142,6 +2143,7 @@ public class PurpurWorldConfig {
+@@ -2144,6 +2145,7 @@ public class PurpurWorldConfig {
          shulkerSpawnFromBulletNearbyRange = getDouble("mobs.shulker.spawn-from-bullet.nearby-range", shulkerSpawnFromBulletNearbyRange);
          shulkerSpawnFromBulletNearbyEquation = getString("mobs.shulker.spawn-from-bullet.nearby-equation", shulkerSpawnFromBulletNearbyEquation);
          shulkerSpawnFromBulletRandomColor = getBoolean("mobs.shulker.spawn-from-bullet.random-color", shulkerSpawnFromBulletRandomColor);

--- a/patches/server/0226-Chance-for-azalea-blocks-to-grow-into-trees-naturall.patch
+++ b/patches/server/0226-Chance-for-azalea-blocks-to-grow-into-trees-naturall.patch
@@ -45,11 +45,11 @@ index bcc1ce196c1dbf60cf6ae73d95766dc41ed22012..ad0ee0d333ffd862fe74ac3a097c51d5
      public static final Block MOSS_BLOCK = register("moss_block", new MossBlock(BlockBehaviour.Properties.of(Material.MOSS, MaterialColor.COLOR_GREEN).strength(0.1F).sound(SoundType.MOSS)));
      public static final Block BIG_DRIPLEAF = register("big_dripleaf", new BigDripleafBlock(BlockBehaviour.Properties.of(Material.PLANT).strength(0.1F).sound(SoundType.BIG_DRIPLEAF)));
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 18fd455f1317f613db213f19d5aac768eda8b8cf..33bc5617b560e4f673e938450dbe8b057309cad8 100644
+index 291807a50b27f9c1991f4c5933b6a636e29386ae..1405d653f1d77979dd67916d31f9a0a83f14de4c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -702,6 +702,11 @@ public class PurpurWorldConfig {
-         anvilAllowColors = getBoolean("blocks.anvil.allow-colors", anvilAllowColors);
+@@ -704,6 +704,11 @@ public class PurpurWorldConfig {
+         anvilColorsUseMiniMessage = getBoolean("blocks.anvil.use-mini-message", anvilColorsUseMiniMessage);
      }
  
 +    public double azaleaGrowthChance = 0.0D;
@@ -60,7 +60,7 @@ index 18fd455f1317f613db213f19d5aac768eda8b8cf..33bc5617b560e4f673e938450dbe8b05
      public int beaconLevelOne = 20;
      public int beaconLevelTwo = 30;
      public int beaconLevelThree = 40;
-@@ -831,6 +836,11 @@ public class PurpurWorldConfig {
+@@ -833,6 +838,11 @@ public class PurpurWorldConfig {
          farmlandTramplingFeatherFalling = getBoolean("blocks.farmland.feather-fall-distance-affects-trampling", farmlandTramplingFeatherFalling);
      }
  

--- a/patches/server/0228-Dolphins-naturally-aggressive-to-players-chance.patch
+++ b/patches/server/0228-Dolphins-naturally-aggressive-to-players-chance.patch
@@ -47,10 +47,10 @@ index b0c933644c1f4b5aa142c7c4d26a9b81cb4051f7..f8be4c96e7e7b8e6d8c538b1f425f01d
  
      public static AttributeSupplier.Builder createAttributes() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 82a4f0aab63f2a2aca525aedb5998eda0a78cb6e..ea6ae178e5cbbad4e23c5d9c0a2c7bfeebfc0ba1 100644
+index a00fb284545287c8d583846da80a03ccaac1a1ac..595ebbceaf4d36d55d0b8ff6d9e1093f683193f8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1210,6 +1210,7 @@ public class PurpurWorldConfig {
+@@ -1212,6 +1212,7 @@ public class PurpurWorldConfig {
      public double dolphinMaxHealth = 10.0D;
      public boolean dolphinDisableTreasureSearching = false;
      public boolean dolphinTakeDamageFromWater = false;
@@ -58,7 +58,7 @@ index 82a4f0aab63f2a2aca525aedb5998eda0a78cb6e..ea6ae178e5cbbad4e23c5d9c0a2c7bfe
      private void dolphinSettings() {
          dolphinRidable = getBoolean("mobs.dolphin.ridable", dolphinRidable);
          dolphinControllable = getBoolean("mobs.dolphin.controllable", dolphinControllable);
-@@ -1224,6 +1225,7 @@ public class PurpurWorldConfig {
+@@ -1226,6 +1227,7 @@ public class PurpurWorldConfig {
          dolphinMaxHealth = getDouble("mobs.dolphin.attributes.max_health", dolphinMaxHealth);
          dolphinDisableTreasureSearching = getBoolean("mobs.dolphin.disable-treasure-searching", dolphinDisableTreasureSearching);
          dolphinTakeDamageFromWater = getBoolean("mobs.dolphin.takes-damage-from-water", dolphinTakeDamageFromWater);

--- a/patches/server/0229-Cows-naturally-aggressive-to-players-chance.patch
+++ b/patches/server/0229-Cows-naturally-aggressive-to-players-chance.patch
@@ -59,10 +59,10 @@ index 00eec3f51e62858e7b85b3340e76bf66bfd4370f..b5002526f20fb8ae52783a6ba95ccd2d
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ea6ae178e5cbbad4e23c5d9c0a2c7bfeebfc0ba1..2c79f11fa01b07ba1d0a721011a6bfa8b68a4e8c 100644
+index 595ebbceaf4d36d55d0b8ff6d9e1093f683193f8..720893f3cbb06da3d5b285e8813be89807feee92 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1159,7 +1159,14 @@ public class PurpurWorldConfig {
+@@ -1161,7 +1161,14 @@ public class PurpurWorldConfig {
      public int cowFeedMushrooms = 0;
      public int cowBreedingTicks = 6000;
      public boolean cowTakeDamageFromWater = false;
@@ -77,7 +77,7 @@ index ea6ae178e5cbbad4e23c5d9c0a2c7bfeebfc0ba1..2c79f11fa01b07ba1d0a721011a6bfa8
          cowRidable = getBoolean("mobs.cow.ridable", cowRidable);
          cowRidableInWater = getBoolean("mobs.cow.ridable-in-water", cowRidableInWater);
          cowControllable = getBoolean("mobs.cow.controllable", cowControllable);
-@@ -1172,6 +1179,8 @@ public class PurpurWorldConfig {
+@@ -1174,6 +1181,8 @@ public class PurpurWorldConfig {
          cowFeedMushrooms = getInt("mobs.cow.feed-mushrooms-for-mooshroom", cowFeedMushrooms);
          cowBreedingTicks = getInt("mobs.cow.breeding-delay-ticks", cowBreedingTicks);
          cowTakeDamageFromWater = getBoolean("mobs.cow.takes-damage-from-water", cowTakeDamageFromWater);

--- a/patches/server/0230-Option-for-beds-to-explode-on-villager-sleep.patch
+++ b/patches/server/0230-Option-for-beds-to-explode-on-villager-sleep.patch
@@ -22,10 +22,10 @@ index 89435b0742064d77c7cc8bb871949acc9852f2c0..f04778287545e9619ee0359f1e51151d
          this.brain.setMemory(MemoryModuleType.LAST_SLEPT, this.level.getGameTime()); // CraftBukkit - decompile error
          this.brain.eraseMemory(MemoryModuleType.WALK_TARGET);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 2c79f11fa01b07ba1d0a721011a6bfa8b68a4e8c..54aa7755d419402c1132fcecea603a7e052a27a6 100644
+index 720893f3cbb06da3d5b285e8813be89807feee92..fcb234b5fc6396f9be77c5b9e00644d9604b2167 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -721,11 +721,13 @@ public class PurpurWorldConfig {
+@@ -723,11 +723,13 @@ public class PurpurWorldConfig {
      }
  
      public boolean bedExplode = true;

--- a/patches/server/0231-Halloween-options-and-optimizations.patch
+++ b/patches/server/0231-Halloween-options-and-optimizations.patch
@@ -60,10 +60,10 @@ index da2f736bd162a1e2e39473a963ef20bcbb31aa2a..38014afb40ac5781f6724a942d593aee
                  this.armorDropChances[EquipmentSlot.HEAD.getIndex()] = 0.0F;
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 54aa7755d419402c1132fcecea603a7e052a27a6..16fa9195c135627a9b406743440f20ec1fc909bc 100644
+index fcb234b5fc6396f9be77c5b9e00644d9604b2167..fa6ec7b7e67968eedfcf4d2360922a9fc0edad79 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1552,6 +1552,13 @@ public class PurpurWorldConfig {
+@@ -1554,6 +1554,13 @@ public class PurpurWorldConfig {
          guardianTakeDamageFromWater = getBoolean("mobs.guardian.takes-damage-from-water", guardianTakeDamageFromWater);
      }
  

--- a/patches/server/0234-Campfire-option-for-lit-when-placed.patch
+++ b/patches/server/0234-Campfire-option-for-lit-when-placed.patch
@@ -18,10 +18,10 @@ index a4c44cb59dee29cf227dbb51bfc1576d89dfb2e3..551bacade8642e6aad17120d8a901bcc
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 16fa9195c135627a9b406743440f20ec1fc909bc..8010b5d5f9eeffbdbada0cf6b1ea496e4f57b6f4 100644
+index fa6ec7b7e67968eedfcf4d2360922a9fc0edad79..a6ff4c051ac645ea2086898139ccff5b6a52d306 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -764,6 +764,11 @@ public class PurpurWorldConfig {
+@@ -766,6 +766,11 @@ public class PurpurWorldConfig {
          cactusBreaksFromSolidNeighbors = getBoolean("blocks.cactus.breaks-from-solid-neighbors", cactusBreaksFromSolidNeighbors);
      }
  

--- a/patches/server/0236-Add-option-to-disable-zombie-villagers-cure.patch
+++ b/patches/server/0236-Add-option-to-disable-zombie-villagers-cure.patch
@@ -18,10 +18,10 @@ index f0f4542949de4927f15c75d067eb7d213599aa85..780f7d8a44acea8987736544c1991fec
                      itemstack.shrink(1);
                  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4e1db316b779456c7b1cc5ce614c8fb6e84183a6..d3c760b223503a2d1ac1a58df43dac656877f273 100644
+index 41eb34529068789f751b36c5539d00892e50a62e..62d0cc043f137dd4338d86991d452851d6861fa2 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2774,6 +2774,7 @@ public class PurpurWorldConfig {
+@@ -2776,6 +2776,7 @@ public class PurpurWorldConfig {
      public boolean zombieVillagerTakeDamageFromWater = false;
      public int zombieVillagerCuringTimeMin = 3600;
      public int zombieVillagerCuringTimeMax = 6000;
@@ -29,7 +29,7 @@ index 4e1db316b779456c7b1cc5ce614c8fb6e84183a6..d3c760b223503a2d1ac1a58df43dac65
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2791,6 +2792,7 @@ public class PurpurWorldConfig {
+@@ -2793,6 +2794,7 @@ public class PurpurWorldConfig {
          zombieVillagerTakeDamageFromWater = getBoolean("mobs.zombie_villager.takes-damage-from-water", zombieVillagerTakeDamageFromWater);
          zombieVillagerCuringTimeMin = getInt("mobs.zombie_villager.curing_time.min", zombieVillagerCuringTimeMin);
          zombieVillagerCuringTimeMax = getInt("mobs.zombie_villager.curing_time.max", zombieVillagerCuringTimeMax);

--- a/patches/server/0238-Signs-allow-color-codes.patch
+++ b/patches/server/0238-Signs-allow-color-codes.patch
@@ -70,10 +70,10 @@ index def4fdd2c7e4f925fa128692a744e5d10ae0203a..73382580cc23cbc868a6003e74826a55
      public CompoundTag getUpdateTag() {
          return this.saveWithoutMetadata();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a69a3ea4f97d80c90916524290b22b71415da81b..90b295d75b858dd48026ede68a0e9c49311f6e46 100644
+index a28b24db6e69e0b192e97d25f182758df968965f..58fcb6e70a10c514a13b622ac8473da4eb92c2cc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -934,8 +934,10 @@ public class PurpurWorldConfig {
+@@ -936,8 +936,10 @@ public class PurpurWorldConfig {
      }
  
      public boolean signRightClickEdit = false;

--- a/patches/server/0240-Mobs-always-drop-experience.patch
+++ b/patches/server/0240-Mobs-always-drop-experience.patch
@@ -421,7 +421,7 @@ index 858a5beea8b038822789e6daec9561634c63447c..b543387da275a0b3675a968b6cebf05c
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
-index ae50bb7e86cddd95a0b49a89682083994ddf14ef..4688e567dff250437335cbde34db4483f535b79a 100644
+index c95126870665d3c456940a9d1d9f54d30d8d6cd4..7c13f243ee8990fba49f03a5e0dbc3ab9c92fa1d 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/goat/Goat.java
 @@ -119,6 +119,11 @@ public class Goat extends Animal {
@@ -1157,10 +1157,10 @@ index 8d6930868a42b9fc98d7672bff433ec50d36999e..53bebecd30fee7613af73901b3aa9961
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0c52bf9a2 100644
+index 58fcb6e70a10c514a13b622ac8473da4eb92c2cc..a51c6cc72cd9659cdaa51fe2c92f7b6e516f6a21 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1000,12 +1000,14 @@ public class PurpurWorldConfig {
+@@ -1002,12 +1002,14 @@ public class PurpurWorldConfig {
      public double axolotlMaxHealth = 14.0D;
      public int axolotlBreedingTicks = 6000;
      public boolean axolotlTakeDamageFromWater = false;
@@ -1175,7 +1175,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean batRidable = false;
-@@ -1021,6 +1023,7 @@ public class PurpurWorldConfig {
+@@ -1023,6 +1025,7 @@ public class PurpurWorldConfig {
      public double batArmorToughness = 0.0D;
      public double batAttackKnockback = 0.0D;
      public boolean batTakeDamageFromWater = false;
@@ -1183,7 +1183,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void batSettings() {
          batRidable = getBoolean("mobs.bat.ridable", batRidable);
          batRidableInWater = getBoolean("mobs.bat.ridable-in-water", batRidableInWater);
-@@ -1033,6 +1036,7 @@ public class PurpurWorldConfig {
+@@ -1035,6 +1038,7 @@ public class PurpurWorldConfig {
          }
          batMaxHealth = getDouble("mobs.bat.attributes.max_health", batMaxHealth);
          batTakeDamageFromWater = getBoolean("mobs.bat.takes-damage-from-water", batTakeDamageFromWater);
@@ -1191,7 +1191,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean beeRidable = false;
-@@ -1044,6 +1048,7 @@ public class PurpurWorldConfig {
+@@ -1046,6 +1050,7 @@ public class PurpurWorldConfig {
      public boolean beeTakeDamageFromWater = false;
      public boolean beeCanWorkAtNight = false;
      public boolean beeCanWorkInRain = false;
@@ -1199,7 +1199,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -1059,6 +1064,7 @@ public class PurpurWorldConfig {
+@@ -1061,6 +1066,7 @@ public class PurpurWorldConfig {
          beeTakeDamageFromWater = getBoolean("mobs.bee.takes-damage-from-water", beeTakeDamageFromWater);
          beeCanWorkAtNight = getBoolean("mobs.bee.can-work-at-night", beeCanWorkAtNight);
          beeCanWorkInRain = getBoolean("mobs.bee.can-work-in-rain", beeCanWorkInRain);
@@ -1207,7 +1207,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean blazeRidable = false;
-@@ -1067,6 +1073,7 @@ public class PurpurWorldConfig {
+@@ -1069,6 +1075,7 @@ public class PurpurWorldConfig {
      public double blazeMaxY = 320D;
      public double blazeMaxHealth = 20.0D;
      public boolean blazeTakeDamageFromWater = true;
@@ -1215,7 +1215,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void blazeSettings() {
          blazeRidable = getBoolean("mobs.blaze.ridable", blazeRidable);
          blazeRidableInWater = getBoolean("mobs.blaze.ridable-in-water", blazeRidableInWater);
-@@ -1079,6 +1086,7 @@ public class PurpurWorldConfig {
+@@ -1081,6 +1088,7 @@ public class PurpurWorldConfig {
          }
          blazeMaxHealth = getDouble("mobs.blaze.attributes.max_health", blazeMaxHealth);
          blazeTakeDamageFromWater = getBoolean("mobs.blaze.takes-damage-from-water", blazeTakeDamageFromWater);
@@ -1223,7 +1223,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean catRidable = false;
-@@ -1091,6 +1099,7 @@ public class PurpurWorldConfig {
+@@ -1093,6 +1101,7 @@ public class PurpurWorldConfig {
      public int catBreedingTicks = 6000;
      public DyeColor catDefaultCollarColor = DyeColor.RED;
      public boolean catTakeDamageFromWater = false;
@@ -1231,7 +1231,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void catSettings() {
          catRidable = getBoolean("mobs.cat.ridable", catRidable);
          catRidableInWater = getBoolean("mobs.cat.ridable-in-water", catRidableInWater);
-@@ -1111,6 +1120,7 @@ public class PurpurWorldConfig {
+@@ -1113,6 +1122,7 @@ public class PurpurWorldConfig {
              catDefaultCollarColor = DyeColor.RED;
          }
          catTakeDamageFromWater = getBoolean("mobs.cat.takes-damage-from-water", catTakeDamageFromWater);
@@ -1239,7 +1239,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean caveSpiderRidable = false;
-@@ -1118,6 +1128,7 @@ public class PurpurWorldConfig {
+@@ -1120,6 +1130,7 @@ public class PurpurWorldConfig {
      public boolean caveSpiderControllable = true;
      public double caveSpiderMaxHealth = 12.0D;
      public boolean caveSpiderTakeDamageFromWater = false;
@@ -1247,7 +1247,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void caveSpiderSettings() {
          caveSpiderRidable = getBoolean("mobs.cave_spider.ridable", caveSpiderRidable);
          caveSpiderRidableInWater = getBoolean("mobs.cave_spider.ridable-in-water", caveSpiderRidableInWater);
-@@ -1129,6 +1140,7 @@ public class PurpurWorldConfig {
+@@ -1131,6 +1142,7 @@ public class PurpurWorldConfig {
          }
          caveSpiderMaxHealth = getDouble("mobs.cave_spider.attributes.max_health", caveSpiderMaxHealth);
          caveSpiderTakeDamageFromWater = getBoolean("mobs.cave_spider.takes-damage-from-water", caveSpiderTakeDamageFromWater);
@@ -1255,7 +1255,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean chickenRidable = false;
-@@ -1138,6 +1150,7 @@ public class PurpurWorldConfig {
+@@ -1140,6 +1152,7 @@ public class PurpurWorldConfig {
      public boolean chickenRetaliate = false;
      public int chickenBreedingTicks = 6000;
      public boolean chickenTakeDamageFromWater = false;
@@ -1263,7 +1263,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void chickenSettings() {
          chickenRidable = getBoolean("mobs.chicken.ridable", chickenRidable);
          chickenRidableInWater = getBoolean("mobs.chicken.ridable-in-water", chickenRidableInWater);
-@@ -1151,12 +1164,14 @@ public class PurpurWorldConfig {
+@@ -1153,12 +1166,14 @@ public class PurpurWorldConfig {
          chickenRetaliate = getBoolean("mobs.chicken.retaliate", chickenRetaliate);
          chickenBreedingTicks = getInt("mobs.chicken.breeding-delay-ticks", chickenBreedingTicks);
          chickenTakeDamageFromWater = getBoolean("mobs.chicken.takes-damage-from-water", chickenTakeDamageFromWater);
@@ -1278,7 +1278,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void codSettings() {
          codRidable = getBoolean("mobs.cod.ridable", codRidable);
          codControllable = getBoolean("mobs.cod.controllable", codControllable);
-@@ -1167,6 +1182,7 @@ public class PurpurWorldConfig {
+@@ -1169,6 +1184,7 @@ public class PurpurWorldConfig {
          }
          codMaxHealth = getDouble("mobs.cod.attributes.max_health", codMaxHealth);
          codTakeDamageFromWater = getBoolean("mobs.cod.takes-damage-from-water", codTakeDamageFromWater);
@@ -1286,7 +1286,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean cowRidable = false;
-@@ -1178,6 +1194,7 @@ public class PurpurWorldConfig {
+@@ -1180,6 +1196,7 @@ public class PurpurWorldConfig {
      public boolean cowTakeDamageFromWater = false;
      public double cowNaturallyAggressiveToPlayersChance = 0.0D;
      public double cowNaturallyAggressiveToPlayersDamage = 2.0D;
@@ -1294,7 +1294,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void cowSettings() {
          if (PurpurConfig.version < 22) {
              double oldValue = getDouble("mobs.cow.naturally-aggressive-to-players-chance", cowNaturallyAggressiveToPlayersChance);
-@@ -1198,6 +1215,7 @@ public class PurpurWorldConfig {
+@@ -1200,6 +1217,7 @@ public class PurpurWorldConfig {
          cowTakeDamageFromWater = getBoolean("mobs.cow.takes-damage-from-water", cowTakeDamageFromWater);
          cowNaturallyAggressiveToPlayersChance = getDouble("mobs.cow.naturally-aggressive-to-players.chance", cowNaturallyAggressiveToPlayersChance);
          cowNaturallyAggressiveToPlayersDamage = getDouble("mobs.cow.naturally-aggressive-to-players.damage", cowNaturallyAggressiveToPlayersDamage);
@@ -1302,7 +1302,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean creeperRidable = false;
-@@ -1210,6 +1228,7 @@ public class PurpurWorldConfig {
+@@ -1212,6 +1230,7 @@ public class PurpurWorldConfig {
      public boolean creeperTakeDamageFromWater = false;
      public boolean creeperExplodeWhenKilled = false;
      public boolean creeperHealthRadius = false;
@@ -1310,7 +1310,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1226,6 +1245,7 @@ public class PurpurWorldConfig {
+@@ -1228,6 +1247,7 @@ public class PurpurWorldConfig {
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
@@ -1318,7 +1318,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean dolphinRidable = false;
-@@ -1237,6 +1257,7 @@ public class PurpurWorldConfig {
+@@ -1239,6 +1259,7 @@ public class PurpurWorldConfig {
      public boolean dolphinDisableTreasureSearching = false;
      public boolean dolphinTakeDamageFromWater = false;
      public double dolphinNaturallyAggressiveToPlayersChance = 0.0D;
@@ -1326,7 +1326,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void dolphinSettings() {
          dolphinRidable = getBoolean("mobs.dolphin.ridable", dolphinRidable);
          dolphinControllable = getBoolean("mobs.dolphin.controllable", dolphinControllable);
-@@ -1252,6 +1273,7 @@ public class PurpurWorldConfig {
+@@ -1254,6 +1275,7 @@ public class PurpurWorldConfig {
          dolphinDisableTreasureSearching = getBoolean("mobs.dolphin.disable-treasure-searching", dolphinDisableTreasureSearching);
          dolphinTakeDamageFromWater = getBoolean("mobs.dolphin.takes-damage-from-water", dolphinTakeDamageFromWater);
          dolphinNaturallyAggressiveToPlayersChance = getDouble("mobs.dolphin.naturally-aggressive-to-players-chance", dolphinNaturallyAggressiveToPlayersChance);
@@ -1334,7 +1334,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean donkeyRidableInWater = false;
-@@ -1263,6 +1285,7 @@ public class PurpurWorldConfig {
+@@ -1265,6 +1287,7 @@ public class PurpurWorldConfig {
      public double donkeyMovementSpeedMax = 0.175D;
      public int donkeyBreedingTicks = 6000;
      public boolean donkeyTakeDamageFromWater = false;
@@ -1342,7 +1342,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void donkeySettings() {
          donkeyRidableInWater = getBoolean("mobs.donkey.ridable-in-water", donkeyRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1280,6 +1303,7 @@ public class PurpurWorldConfig {
+@@ -1282,6 +1305,7 @@ public class PurpurWorldConfig {
          donkeyMovementSpeedMax = getDouble("mobs.donkey.attributes.movement_speed.max", donkeyMovementSpeedMax);
          donkeyBreedingTicks = getInt("mobs.donkey.breeding-delay-ticks", donkeyBreedingTicks);
          donkeyTakeDamageFromWater = getBoolean("mobs.donkey.takes-damage-from-water", donkeyTakeDamageFromWater);
@@ -1350,7 +1350,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean drownedRidable = false;
-@@ -1292,6 +1316,7 @@ public class PurpurWorldConfig {
+@@ -1294,6 +1318,7 @@ public class PurpurWorldConfig {
      public boolean drownedJockeyTryExistingChickens = true;
      public boolean drownedTakeDamageFromWater = false;
      public boolean drownedBreakDoors = false;
@@ -1358,7 +1358,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void drownedSettings() {
          drownedRidable = getBoolean("mobs.drowned.ridable", drownedRidable);
          drownedRidableInWater = getBoolean("mobs.drowned.ridable-in-water", drownedRidableInWater);
-@@ -1308,12 +1333,14 @@ public class PurpurWorldConfig {
+@@ -1310,12 +1335,14 @@ public class PurpurWorldConfig {
          drownedJockeyTryExistingChickens = getBoolean("mobs.drowned.jockey.try-existing-chickens", drownedJockeyTryExistingChickens);
          drownedTakeDamageFromWater = getBoolean("mobs.drowned.takes-damage-from-water", drownedTakeDamageFromWater);
          drownedBreakDoors = getBoolean("mobs.drowned.can-break-doors", drownedBreakDoors);
@@ -1373,7 +1373,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void elderGuardianSettings() {
          elderGuardianRidable = getBoolean("mobs.elder_guardian.ridable", elderGuardianRidable);
          elderGuardianControllable = getBoolean("mobs.elder_guardian.controllable", elderGuardianControllable);
-@@ -1324,6 +1351,7 @@ public class PurpurWorldConfig {
+@@ -1326,6 +1353,7 @@ public class PurpurWorldConfig {
          }
          elderGuardianMaxHealth = getDouble("mobs.elder_guardian.attributes.max_health", elderGuardianMaxHealth);
          elderGuardianTakeDamageFromWater = getBoolean("mobs.elder_guardian.takes-damage-from-water", elderGuardianTakeDamageFromWater);
@@ -1381,7 +1381,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean enderDragonRidable = false;
-@@ -1369,6 +1397,7 @@ public class PurpurWorldConfig {
+@@ -1371,6 +1399,7 @@ public class PurpurWorldConfig {
      public boolean endermanIgnorePlayerDragonHead = false;
      public boolean endermanDisableStareAggro = false;
      public boolean endermanIgnoreProjectiles = false;
@@ -1389,7 +1389,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1392,6 +1421,7 @@ public class PurpurWorldConfig {
+@@ -1394,6 +1423,7 @@ public class PurpurWorldConfig {
          endermanIgnorePlayerDragonHead = getBoolean("mobs.enderman.ignore-players-wearing-dragon-head", endermanIgnorePlayerDragonHead);
          endermanDisableStareAggro = getBoolean("mobs.enderman.disable-player-stare-aggression", endermanDisableStareAggro);
          endermanIgnoreProjectiles = getBoolean("mobs.enderman.ignore-projectiles", endermanIgnoreProjectiles);
@@ -1397,7 +1397,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean endermiteRidable = false;
-@@ -1399,6 +1429,7 @@ public class PurpurWorldConfig {
+@@ -1401,6 +1431,7 @@ public class PurpurWorldConfig {
      public boolean endermiteControllable = true;
      public double endermiteMaxHealth = 8.0D;
      public boolean endermiteTakeDamageFromWater = false;
@@ -1405,7 +1405,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void endermiteSettings() {
          endermiteRidable = getBoolean("mobs.endermite.ridable", endermiteRidable);
          endermiteRidableInWater = getBoolean("mobs.endermite.ridable-in-water", endermiteRidableInWater);
-@@ -1410,6 +1441,7 @@ public class PurpurWorldConfig {
+@@ -1412,6 +1443,7 @@ public class PurpurWorldConfig {
          }
          endermiteMaxHealth = getDouble("mobs.endermite.attributes.max_health", endermiteMaxHealth);
          endermiteTakeDamageFromWater = getBoolean("mobs.endermite.takes-damage-from-water", endermiteTakeDamageFromWater);
@@ -1413,7 +1413,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean evokerRidable = false;
-@@ -1418,6 +1450,7 @@ public class PurpurWorldConfig {
+@@ -1420,6 +1452,7 @@ public class PurpurWorldConfig {
      public double evokerMaxHealth = 24.0D;
      public boolean evokerBypassMobGriefing = false;
      public boolean evokerTakeDamageFromWater = false;
@@ -1421,7 +1421,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void evokerSettings() {
          evokerRidable = getBoolean("mobs.evoker.ridable", evokerRidable);
          evokerRidableInWater = getBoolean("mobs.evoker.ridable-in-water", evokerRidableInWater);
-@@ -1430,6 +1463,7 @@ public class PurpurWorldConfig {
+@@ -1432,6 +1465,7 @@ public class PurpurWorldConfig {
          evokerMaxHealth = getDouble("mobs.evoker.attributes.max_health", evokerMaxHealth);
          evokerBypassMobGriefing = getBoolean("mobs.evoker.bypass-mob-griefing", evokerBypassMobGriefing);
          evokerTakeDamageFromWater = getBoolean("mobs.evoker.takes-damage-from-water", evokerTakeDamageFromWater);
@@ -1429,7 +1429,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean foxRidable = false;
-@@ -1440,6 +1474,7 @@ public class PurpurWorldConfig {
+@@ -1442,6 +1476,7 @@ public class PurpurWorldConfig {
      public int foxBreedingTicks = 6000;
      public boolean foxBypassMobGriefing = false;
      public boolean foxTakeDamageFromWater = false;
@@ -1437,7 +1437,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void foxSettings() {
          foxRidable = getBoolean("mobs.fox.ridable", foxRidable);
          foxRidableInWater = getBoolean("mobs.fox.ridable-in-water", foxRidableInWater);
-@@ -1454,6 +1489,7 @@ public class PurpurWorldConfig {
+@@ -1456,6 +1491,7 @@ public class PurpurWorldConfig {
          foxBreedingTicks = getInt("mobs.fox.breeding-delay-ticks", foxBreedingTicks);
          foxBypassMobGriefing = getBoolean("mobs.fox.bypass-mob-griefing", foxBypassMobGriefing);
          foxTakeDamageFromWater = getBoolean("mobs.fox.takes-damage-from-water", foxTakeDamageFromWater);
@@ -1445,7 +1445,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean frogRidable = false;
-@@ -1475,6 +1511,7 @@ public class PurpurWorldConfig {
+@@ -1477,6 +1513,7 @@ public class PurpurWorldConfig {
      public double ghastMaxY = 320D;
      public double ghastMaxHealth = 10.0D;
      public boolean ghastTakeDamageFromWater = false;
@@ -1453,7 +1453,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void ghastSettings() {
          ghastRidable = getBoolean("mobs.ghast.ridable", ghastRidable);
          ghastRidableInWater = getBoolean("mobs.ghast.ridable-in-water", ghastRidableInWater);
-@@ -1487,6 +1524,7 @@ public class PurpurWorldConfig {
+@@ -1489,6 +1526,7 @@ public class PurpurWorldConfig {
          }
          ghastMaxHealth = getDouble("mobs.ghast.attributes.max_health", ghastMaxHealth);
          ghastTakeDamageFromWater = getBoolean("mobs.ghast.takes-damage-from-water", ghastTakeDamageFromWater);
@@ -1461,7 +1461,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean giantRidable = false;
-@@ -1500,6 +1538,7 @@ public class PurpurWorldConfig {
+@@ -1502,6 +1540,7 @@ public class PurpurWorldConfig {
      public boolean giantHaveAI = false;
      public boolean giantHaveHostileAI = false;
      public boolean giantTakeDamageFromWater = false;
@@ -1469,7 +1469,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void giantSettings() {
          giantRidable = getBoolean("mobs.giant.ridable", giantRidable);
          giantRidableInWater = getBoolean("mobs.giant.ridable-in-water", giantRidableInWater);
-@@ -1521,6 +1560,7 @@ public class PurpurWorldConfig {
+@@ -1523,6 +1562,7 @@ public class PurpurWorldConfig {
          giantHaveAI = getBoolean("mobs.giant.have-ai", giantHaveAI);
          giantHaveHostileAI = getBoolean("mobs.giant.have-hostile-ai", giantHaveHostileAI);
          giantTakeDamageFromWater = getBoolean("mobs.giant.takes-damage-from-water", giantTakeDamageFromWater);
@@ -1477,7 +1477,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean glowSquidRidable = false;
-@@ -1528,12 +1568,14 @@ public class PurpurWorldConfig {
+@@ -1530,12 +1570,14 @@ public class PurpurWorldConfig {
      public double glowSquidMaxHealth = 10.0D;
      public boolean glowSquidsCanFly = false;
      public boolean glowSquidTakeDamageFromWater = false;
@@ -1492,7 +1492,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean goatRidable = false;
-@@ -1542,6 +1584,7 @@ public class PurpurWorldConfig {
+@@ -1544,6 +1586,7 @@ public class PurpurWorldConfig {
      public double goatMaxHealth = 10.0D;
      public int goatBreedingTicks = 6000;
      public boolean goatTakeDamageFromWater = false;
@@ -1500,7 +1500,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void goatSettings() {
          goatRidable = getBoolean("mobs.goat.ridable", goatRidable);
          goatRidableInWater = getBoolean("mobs.goat.ridable-in-water", goatRidableInWater);
-@@ -1549,12 +1592,14 @@ public class PurpurWorldConfig {
+@@ -1551,12 +1594,14 @@ public class PurpurWorldConfig {
          goatMaxHealth = getDouble("mobs.goat.attributes.max_health", goatMaxHealth);
          goatBreedingTicks = getInt("mobs.goat.breeding-delay-ticks", goatBreedingTicks);
          goatTakeDamageFromWater = getBoolean("mobs.goat.takes-damage-from-water", goatTakeDamageFromWater);
@@ -1515,7 +1515,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void guardianSettings() {
          guardianRidable = getBoolean("mobs.guardian.ridable", guardianRidable);
          guardianControllable = getBoolean("mobs.guardian.controllable", guardianControllable);
-@@ -1565,6 +1610,7 @@ public class PurpurWorldConfig {
+@@ -1567,6 +1612,7 @@ public class PurpurWorldConfig {
          }
          guardianMaxHealth = getDouble("mobs.guardian.attributes.max_health", guardianMaxHealth);
          guardianTakeDamageFromWater = getBoolean("mobs.guardian.takes-damage-from-water", guardianTakeDamageFromWater);
@@ -1523,7 +1523,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean forceHalloweenSeason = false;
-@@ -1580,6 +1626,7 @@ public class PurpurWorldConfig {
+@@ -1582,6 +1628,7 @@ public class PurpurWorldConfig {
      public double hoglinMaxHealth = 40.0D;
      public int hoglinBreedingTicks = 6000;
      public boolean hoglinTakeDamageFromWater = false;
@@ -1531,7 +1531,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void hoglinSettings() {
          hoglinRidable = getBoolean("mobs.hoglin.ridable", hoglinRidable);
          hoglinRidableInWater = getBoolean("mobs.hoglin.ridable-in-water", hoglinRidableInWater);
-@@ -1592,6 +1639,7 @@ public class PurpurWorldConfig {
+@@ -1594,6 +1641,7 @@ public class PurpurWorldConfig {
          hoglinMaxHealth = getDouble("mobs.hoglin.attributes.max_health", hoglinMaxHealth);
          hoglinBreedingTicks = getInt("mobs.hoglin.breeding-delay-ticks", hoglinBreedingTicks);
          hoglinTakeDamageFromWater = getBoolean("mobs.hoglin.takes-damage-from-water", hoglinTakeDamageFromWater);
@@ -1539,7 +1539,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean horseRidableInWater = false;
-@@ -1604,6 +1652,7 @@ public class PurpurWorldConfig {
+@@ -1606,6 +1654,7 @@ public class PurpurWorldConfig {
      public int horseBreedingTicks = 6000;
      public boolean horseTakeDamageFromWater = false;
      public boolean horseStandWithRider = true;
@@ -1547,7 +1547,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void horseSettings() {
          horseRidableInWater = getBoolean("mobs.horse.ridable-in-water", horseRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1622,6 +1671,7 @@ public class PurpurWorldConfig {
+@@ -1624,6 +1673,7 @@ public class PurpurWorldConfig {
          horseBreedingTicks = getInt("mobs.horse.breeding-delay-ticks", horseBreedingTicks);
          horseTakeDamageFromWater = getBoolean("mobs.horse.takes-damage-from-water", horseTakeDamageFromWater);
          horseStandWithRider = getBoolean("mobs.horse.stand-with-rider", horseStandWithRider);
@@ -1555,7 +1555,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean huskRidable = false;
-@@ -1633,6 +1683,7 @@ public class PurpurWorldConfig {
+@@ -1635,6 +1685,7 @@ public class PurpurWorldConfig {
      public double huskJockeyChance = 0.05D;
      public boolean huskJockeyTryExistingChickens = true;
      public boolean huskTakeDamageFromWater = false;
@@ -1563,7 +1563,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void huskSettings() {
          huskRidable = getBoolean("mobs.husk.ridable", huskRidable);
          huskRidableInWater = getBoolean("mobs.husk.ridable-in-water", huskRidableInWater);
-@@ -1648,6 +1699,7 @@ public class PurpurWorldConfig {
+@@ -1650,6 +1701,7 @@ public class PurpurWorldConfig {
          huskJockeyChance = getDouble("mobs.husk.jockey.chance", huskJockeyChance);
          huskJockeyTryExistingChickens = getBoolean("mobs.husk.jockey.try-existing-chickens", huskJockeyTryExistingChickens);
          huskTakeDamageFromWater = getBoolean("mobs.husk.takes-damage-from-water", huskTakeDamageFromWater);
@@ -1571,7 +1571,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean illusionerRidable = false;
-@@ -1657,6 +1709,7 @@ public class PurpurWorldConfig {
+@@ -1659,6 +1711,7 @@ public class PurpurWorldConfig {
      public double illusionerFollowRange = 18.0D;
      public double illusionerMaxHealth = 32.0D;
      public boolean illusionerTakeDamageFromWater = false;
@@ -1579,7 +1579,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void illusionerSettings() {
          illusionerRidable = getBoolean("mobs.illusioner.ridable", illusionerRidable);
          illusionerRidableInWater = getBoolean("mobs.illusioner.ridable-in-water", illusionerRidableInWater);
-@@ -1674,6 +1727,7 @@ public class PurpurWorldConfig {
+@@ -1676,6 +1729,7 @@ public class PurpurWorldConfig {
          }
          illusionerMaxHealth = getDouble("mobs.illusioner.attributes.max_health", illusionerMaxHealth);
          illusionerTakeDamageFromWater = getBoolean("mobs.illusioner.takes-damage-from-water", illusionerTakeDamageFromWater);
@@ -1587,7 +1587,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean ironGolemRidable = false;
-@@ -1684,6 +1738,7 @@ public class PurpurWorldConfig {
+@@ -1686,6 +1740,7 @@ public class PurpurWorldConfig {
      public boolean ironGolemTakeDamageFromWater = false;
      public boolean ironGolemPoppyCalm = false;
      public boolean ironGolemHealCalm = false;
@@ -1595,7 +1595,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void ironGolemSettings() {
          ironGolemRidable = getBoolean("mobs.iron_golem.ridable", ironGolemRidable);
          ironGolemRidableInWater = getBoolean("mobs.iron_golem.ridable-in-water", ironGolemRidableInWater);
-@@ -1698,6 +1753,7 @@ public class PurpurWorldConfig {
+@@ -1700,6 +1755,7 @@ public class PurpurWorldConfig {
          ironGolemTakeDamageFromWater = getBoolean("mobs.iron_golem.takes-damage-from-water", ironGolemTakeDamageFromWater);
          ironGolemPoppyCalm = getBoolean("mobs.iron_golem.poppy-calms-anger", ironGolemPoppyCalm);
          ironGolemHealCalm = getBoolean("mobs.iron_golem.healing-calms-anger", ironGolemHealCalm);
@@ -1603,7 +1603,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean llamaRidable = false;
-@@ -1712,6 +1768,7 @@ public class PurpurWorldConfig {
+@@ -1714,6 +1770,7 @@ public class PurpurWorldConfig {
      public int llamaBreedingTicks = 6000;
      public boolean llamaTakeDamageFromWater = false;
      public boolean llamaJoinCaravans = true;
@@ -1611,7 +1611,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void llamaSettings() {
          llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
          llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
-@@ -1732,6 +1789,7 @@ public class PurpurWorldConfig {
+@@ -1734,6 +1791,7 @@ public class PurpurWorldConfig {
          llamaBreedingTicks = getInt("mobs.llama.breeding-delay-ticks", llamaBreedingTicks);
          llamaTakeDamageFromWater = getBoolean("mobs.llama.takes-damage-from-water", llamaTakeDamageFromWater);
          llamaJoinCaravans = getBoolean("mobs.llama.join-caravans", llamaJoinCaravans);
@@ -1619,7 +1619,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean magmaCubeRidable = false;
-@@ -1742,6 +1800,7 @@ public class PurpurWorldConfig {
+@@ -1744,6 +1802,7 @@ public class PurpurWorldConfig {
      public Map<Integer, Double> magmaCubeMaxHealthCache = new HashMap<>();
      public Map<Integer, Double> magmaCubeAttackDamageCache = new HashMap<>();
      public boolean magmaCubeTakeDamageFromWater = false;
@@ -1627,7 +1627,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void magmaCubeSettings() {
          magmaCubeRidable = getBoolean("mobs.magma_cube.ridable", magmaCubeRidable);
          magmaCubeRidableInWater = getBoolean("mobs.magma_cube.ridable-in-water", magmaCubeRidableInWater);
-@@ -1756,6 +1815,7 @@ public class PurpurWorldConfig {
+@@ -1758,6 +1817,7 @@ public class PurpurWorldConfig {
          magmaCubeMaxHealthCache.clear();
          magmaCubeAttackDamageCache.clear();
          magmaCubeTakeDamageFromWater = getBoolean("mobs.magma_cube.takes-damage-from-water", magmaCubeTakeDamageFromWater);
@@ -1635,7 +1635,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean mooshroomRidable = false;
-@@ -1764,6 +1824,7 @@ public class PurpurWorldConfig {
+@@ -1766,6 +1826,7 @@ public class PurpurWorldConfig {
      public double mooshroomMaxHealth = 10.0D;
      public int mooshroomBreedingTicks = 6000;
      public boolean mooshroomTakeDamageFromWater = false;
@@ -1643,7 +1643,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void mooshroomSettings() {
          mooshroomRidable = getBoolean("mobs.mooshroom.ridable", mooshroomRidable);
          mooshroomRidableInWater = getBoolean("mobs.mooshroom.ridable-in-water", mooshroomRidableInWater);
-@@ -1776,6 +1837,7 @@ public class PurpurWorldConfig {
+@@ -1778,6 +1839,7 @@ public class PurpurWorldConfig {
          mooshroomMaxHealth = getDouble("mobs.mooshroom.attributes.max_health", mooshroomMaxHealth);
          mooshroomBreedingTicks = getInt("mobs.mooshroom.breeding-delay-ticks", mooshroomBreedingTicks);
          mooshroomTakeDamageFromWater = getBoolean("mobs.mooshroom.takes-damage-from-water", mooshroomTakeDamageFromWater);
@@ -1651,7 +1651,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean muleRidableInWater = false;
-@@ -1787,6 +1849,7 @@ public class PurpurWorldConfig {
+@@ -1789,6 +1851,7 @@ public class PurpurWorldConfig {
      public double muleMovementSpeedMax = 0.175D;
      public int muleBreedingTicks = 6000;
      public boolean muleTakeDamageFromWater = false;
@@ -1659,7 +1659,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void muleSettings() {
          muleRidableInWater = getBoolean("mobs.mule.ridable-in-water", muleRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1804,6 +1867,7 @@ public class PurpurWorldConfig {
+@@ -1806,6 +1869,7 @@ public class PurpurWorldConfig {
          muleMovementSpeedMax = getDouble("mobs.mule.attributes.movement_speed.max", muleMovementSpeedMax);
          muleBreedingTicks = getInt("mobs.mule.breeding-delay-ticks", muleBreedingTicks);
          muleTakeDamageFromWater = getBoolean("mobs.mule.takes-damage-from-water", muleTakeDamageFromWater);
@@ -1667,7 +1667,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean ocelotRidable = false;
-@@ -1812,6 +1876,7 @@ public class PurpurWorldConfig {
+@@ -1814,6 +1878,7 @@ public class PurpurWorldConfig {
      public double ocelotMaxHealth = 10.0D;
      public int ocelotBreedingTicks = 6000;
      public boolean ocelotTakeDamageFromWater = false;
@@ -1675,7 +1675,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void ocelotSettings() {
          ocelotRidable = getBoolean("mobs.ocelot.ridable", ocelotRidable);
          ocelotRidableInWater = getBoolean("mobs.ocelot.ridable-in-water", ocelotRidableInWater);
-@@ -1824,6 +1889,7 @@ public class PurpurWorldConfig {
+@@ -1826,6 +1891,7 @@ public class PurpurWorldConfig {
          ocelotMaxHealth = getDouble("mobs.ocelot.attributes.max_health", ocelotMaxHealth);
          ocelotBreedingTicks = getInt("mobs.ocelot.breeding-delay-ticks", ocelotBreedingTicks);
          ocelotTakeDamageFromWater = getBoolean("mobs.ocelot.takes-damage-from-water", ocelotTakeDamageFromWater);
@@ -1683,7 +1683,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean pandaRidable = false;
-@@ -1832,6 +1898,7 @@ public class PurpurWorldConfig {
+@@ -1834,6 +1900,7 @@ public class PurpurWorldConfig {
      public double pandaMaxHealth = 20.0D;
      public int pandaBreedingTicks = 6000;
      public boolean pandaTakeDamageFromWater = false;
@@ -1691,7 +1691,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void pandaSettings() {
          pandaRidable = getBoolean("mobs.panda.ridable", pandaRidable);
          pandaRidableInWater = getBoolean("mobs.panda.ridable-in-water", pandaRidableInWater);
-@@ -1844,6 +1911,7 @@ public class PurpurWorldConfig {
+@@ -1846,6 +1913,7 @@ public class PurpurWorldConfig {
          pandaMaxHealth = getDouble("mobs.panda.attributes.max_health", pandaMaxHealth);
          pandaBreedingTicks = getInt("mobs.panda.breeding-delay-ticks", pandaBreedingTicks);
          pandaTakeDamageFromWater = getBoolean("mobs.panda.takes-damage-from-water", pandaTakeDamageFromWater);
@@ -1699,7 +1699,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean parrotRidable = false;
-@@ -1853,6 +1921,7 @@ public class PurpurWorldConfig {
+@@ -1855,6 +1923,7 @@ public class PurpurWorldConfig {
      public double parrotMaxHealth = 6.0D;
      public boolean parrotTakeDamageFromWater = false;
      public boolean parrotBreedable = false;
@@ -1707,7 +1707,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void parrotSettings() {
          parrotRidable = getBoolean("mobs.parrot.ridable", parrotRidable);
          parrotRidableInWater = getBoolean("mobs.parrot.ridable-in-water", parrotRidableInWater);
-@@ -1866,6 +1935,7 @@ public class PurpurWorldConfig {
+@@ -1868,6 +1937,7 @@ public class PurpurWorldConfig {
          parrotMaxHealth = getDouble("mobs.parrot.attributes.max_health", parrotMaxHealth);
          parrotTakeDamageFromWater = getBoolean("mobs.parrot.takes-damage-from-water", parrotTakeDamageFromWater);
          parrotBreedable = getBoolean("mobs.parrot.can-breed", parrotBreedable);
@@ -1715,7 +1715,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean phantomRidable = false;
-@@ -1899,6 +1969,7 @@ public class PurpurWorldConfig {
+@@ -1901,6 +1971,7 @@ public class PurpurWorldConfig {
      public boolean phantomBurnInDaylight = true;
      public boolean phantomFlamesOnSwoop = false;
      public boolean phantomTakeDamageFromWater = false;
@@ -1723,7 +1723,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void phantomSettings() {
          phantomRidable = getBoolean("mobs.phantom.ridable", phantomRidable);
          phantomRidableInWater = getBoolean("mobs.phantom.ridable-in-water", phantomRidableInWater);
-@@ -1940,6 +2011,7 @@ public class PurpurWorldConfig {
+@@ -1942,6 +2013,7 @@ public class PurpurWorldConfig {
          phantomIgnorePlayersWithTorch = getBoolean("mobs.phantom.ignore-players-with-torch", phantomIgnorePlayersWithTorch);
          phantomFlamesOnSwoop = getBoolean("mobs.phantom.flames-on-swoop", phantomFlamesOnSwoop);
          phantomTakeDamageFromWater = getBoolean("mobs.phantom.takes-damage-from-water", phantomTakeDamageFromWater);
@@ -1731,7 +1731,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean pigRidable = false;
-@@ -1949,6 +2021,7 @@ public class PurpurWorldConfig {
+@@ -1951,6 +2023,7 @@ public class PurpurWorldConfig {
      public boolean pigGiveSaddleBack = false;
      public int pigBreedingTicks = 6000;
      public boolean pigTakeDamageFromWater = false;
@@ -1739,7 +1739,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void pigSettings() {
          pigRidable = getBoolean("mobs.pig.ridable", pigRidable);
          pigRidableInWater = getBoolean("mobs.pig.ridable-in-water", pigRidableInWater);
-@@ -1962,6 +2035,7 @@ public class PurpurWorldConfig {
+@@ -1964,6 +2037,7 @@ public class PurpurWorldConfig {
          pigGiveSaddleBack = getBoolean("mobs.pig.give-saddle-back", pigGiveSaddleBack);
          pigBreedingTicks = getInt("mobs.pig.breeding-delay-ticks", pigBreedingTicks);
          pigTakeDamageFromWater = getBoolean("mobs.pig.takes-damage-from-water", pigTakeDamageFromWater);
@@ -1747,7 +1747,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean piglinRidable = false;
-@@ -1971,6 +2045,7 @@ public class PurpurWorldConfig {
+@@ -1973,6 +2047,7 @@ public class PurpurWorldConfig {
      public boolean piglinBypassMobGriefing = false;
      public boolean piglinTakeDamageFromWater = false;
      public int piglinPortalSpawnModifier = 2000;
@@ -1755,7 +1755,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -1984,6 +2059,7 @@ public class PurpurWorldConfig {
+@@ -1986,6 +2061,7 @@ public class PurpurWorldConfig {
          piglinBypassMobGriefing = getBoolean("mobs.piglin.bypass-mob-griefing", piglinBypassMobGriefing);
          piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);
          piglinPortalSpawnModifier = getInt("mobs.piglin.portal-spawn-modifier", piglinPortalSpawnModifier);
@@ -1763,7 +1763,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean piglinBruteRidable = false;
-@@ -1991,6 +2067,7 @@ public class PurpurWorldConfig {
+@@ -1993,6 +2069,7 @@ public class PurpurWorldConfig {
      public boolean piglinBruteControllable = true;
      public double piglinBruteMaxHealth = 50.0D;
      public boolean piglinBruteTakeDamageFromWater = false;
@@ -1771,7 +1771,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void piglinBruteSettings() {
          piglinBruteRidable = getBoolean("mobs.piglin_brute.ridable", piglinBruteRidable);
          piglinBruteRidableInWater = getBoolean("mobs.piglin_brute.ridable-in-water", piglinBruteRidableInWater);
-@@ -2002,6 +2079,7 @@ public class PurpurWorldConfig {
+@@ -2004,6 +2081,7 @@ public class PurpurWorldConfig {
          }
          piglinBruteMaxHealth = getDouble("mobs.piglin_brute.attributes.max_health", piglinBruteMaxHealth);
          piglinBruteTakeDamageFromWater = getBoolean("mobs.piglin_brute.takes-damage-from-water", piglinBruteTakeDamageFromWater);
@@ -1779,7 +1779,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean pillagerRidable = false;
-@@ -2010,6 +2088,7 @@ public class PurpurWorldConfig {
+@@ -2012,6 +2090,7 @@ public class PurpurWorldConfig {
      public double pillagerMaxHealth = 24.0D;
      public boolean pillagerBypassMobGriefing = false;
      public boolean pillagerTakeDamageFromWater = false;
@@ -1787,7 +1787,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void pillagerSettings() {
          pillagerRidable = getBoolean("mobs.pillager.ridable", pillagerRidable);
          pillagerRidableInWater = getBoolean("mobs.pillager.ridable-in-water", pillagerRidableInWater);
-@@ -2022,6 +2101,7 @@ public class PurpurWorldConfig {
+@@ -2024,6 +2103,7 @@ public class PurpurWorldConfig {
          pillagerMaxHealth = getDouble("mobs.pillager.attributes.max_health", pillagerMaxHealth);
          pillagerBypassMobGriefing = getBoolean("mobs.pillager.bypass-mob-griefing", pillagerBypassMobGriefing);
          pillagerTakeDamageFromWater = getBoolean("mobs.pillager.takes-damage-from-water", pillagerTakeDamageFromWater);
@@ -1795,7 +1795,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean polarBearRidable = false;
-@@ -2032,6 +2112,7 @@ public class PurpurWorldConfig {
+@@ -2034,6 +2114,7 @@ public class PurpurWorldConfig {
      public Item polarBearBreedableItem = null;
      public int polarBearBreedingTicks = 6000;
      public boolean polarBearTakeDamageFromWater = false;
@@ -1803,7 +1803,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void polarBearSettings() {
          polarBearRidable = getBoolean("mobs.polar_bear.ridable", polarBearRidable);
          polarBearRidableInWater = getBoolean("mobs.polar_bear.ridable-in-water", polarBearRidableInWater);
-@@ -2047,12 +2128,14 @@ public class PurpurWorldConfig {
+@@ -2049,12 +2130,14 @@ public class PurpurWorldConfig {
          if (item != Items.AIR) polarBearBreedableItem = item;
          polarBearBreedingTicks = getInt("mobs.polar_bear.breeding-delay-ticks", polarBearBreedingTicks);
          polarBearTakeDamageFromWater = getBoolean("mobs.polar_bear.takes-damage-from-water", polarBearTakeDamageFromWater);
@@ -1818,7 +1818,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void pufferfishSettings() {
          pufferfishRidable = getBoolean("mobs.pufferfish.ridable", pufferfishRidable);
          pufferfishControllable = getBoolean("mobs.pufferfish.controllable", pufferfishControllable);
-@@ -2063,6 +2146,7 @@ public class PurpurWorldConfig {
+@@ -2065,6 +2148,7 @@ public class PurpurWorldConfig {
          }
          pufferfishMaxHealth = getDouble("mobs.pufferfish.attributes.max_health", pufferfishMaxHealth);
          pufferfishTakeDamageFromWater = getBoolean("mobs.pufferfish.takes-damage-from-water", pufferfishTakeDamageFromWater);
@@ -1826,7 +1826,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean rabbitRidable = false;
-@@ -2074,6 +2158,7 @@ public class PurpurWorldConfig {
+@@ -2076,6 +2160,7 @@ public class PurpurWorldConfig {
      public int rabbitBreedingTicks = 6000;
      public boolean rabbitBypassMobGriefing = false;
      public boolean rabbitTakeDamageFromWater = false;
@@ -1834,7 +1834,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void rabbitSettings() {
          rabbitRidable = getBoolean("mobs.rabbit.ridable", rabbitRidable);
          rabbitRidableInWater = getBoolean("mobs.rabbit.ridable-in-water", rabbitRidableInWater);
-@@ -2089,6 +2174,7 @@ public class PurpurWorldConfig {
+@@ -2091,6 +2176,7 @@ public class PurpurWorldConfig {
          rabbitBreedingTicks = getInt("mobs.rabbit.breeding-delay-ticks", rabbitBreedingTicks);
          rabbitBypassMobGriefing = getBoolean("mobs.rabbit.bypass-mob-griefing", rabbitBypassMobGriefing);
          rabbitTakeDamageFromWater = getBoolean("mobs.rabbit.takes-damage-from-water", rabbitTakeDamageFromWater);
@@ -1842,7 +1842,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean ravagerRidable = false;
-@@ -2098,6 +2184,7 @@ public class PurpurWorldConfig {
+@@ -2100,6 +2186,7 @@ public class PurpurWorldConfig {
      public boolean ravagerBypassMobGriefing = false;
      public boolean ravagerTakeDamageFromWater = false;
      public List<Block> ravagerGriefableBlocks = new ArrayList<>();
@@ -1850,7 +1850,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void ravagerSettings() {
          ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
          ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
-@@ -2127,12 +2214,14 @@ public class PurpurWorldConfig {
+@@ -2129,12 +2216,14 @@ public class PurpurWorldConfig {
                  ravagerGriefableBlocks.add(block);
              }
          });
@@ -1865,7 +1865,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void salmonSettings() {
          salmonRidable = getBoolean("mobs.salmon.ridable", salmonRidable);
          salmonControllable = getBoolean("mobs.salmon.controllable", salmonControllable);
-@@ -2143,6 +2232,7 @@ public class PurpurWorldConfig {
+@@ -2145,6 +2234,7 @@ public class PurpurWorldConfig {
          }
          salmonMaxHealth = getDouble("mobs.salmon.attributes.max_health", salmonMaxHealth);
          salmonTakeDamageFromWater = getBoolean("mobs.salmon.takes-damage-from-water", salmonTakeDamageFromWater);
@@ -1873,7 +1873,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean sheepRidable = false;
-@@ -2152,6 +2242,7 @@ public class PurpurWorldConfig {
+@@ -2154,6 +2244,7 @@ public class PurpurWorldConfig {
      public int sheepBreedingTicks = 6000;
      public boolean sheepBypassMobGriefing = false;
      public boolean sheepTakeDamageFromWater = false;
@@ -1881,7 +1881,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -2165,6 +2256,7 @@ public class PurpurWorldConfig {
+@@ -2167,6 +2258,7 @@ public class PurpurWorldConfig {
          sheepBreedingTicks = getInt("mobs.sheep.breeding-delay-ticks", sheepBreedingTicks);
          sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
          sheepTakeDamageFromWater = getBoolean("mobs.sheep.takes-damage-from-water", sheepTakeDamageFromWater);
@@ -1889,7 +1889,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean shulkerRidable = false;
-@@ -2178,6 +2270,7 @@ public class PurpurWorldConfig {
+@@ -2180,6 +2272,7 @@ public class PurpurWorldConfig {
      public String shulkerSpawnFromBulletNearbyEquation = "(nearby - 1) / 5.0";
      public boolean shulkerSpawnFromBulletRandomColor = false;
      public boolean shulkerChangeColorWithDye = false;
@@ -1897,7 +1897,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -2195,6 +2288,7 @@ public class PurpurWorldConfig {
+@@ -2197,6 +2290,7 @@ public class PurpurWorldConfig {
          shulkerSpawnFromBulletNearbyEquation = getString("mobs.shulker.spawn-from-bullet.nearby-equation", shulkerSpawnFromBulletNearbyEquation);
          shulkerSpawnFromBulletRandomColor = getBoolean("mobs.shulker.spawn-from-bullet.random-color", shulkerSpawnFromBulletRandomColor);
          shulkerChangeColorWithDye = getBoolean("mobs.shulker.change-color-with-dye", shulkerChangeColorWithDye);
@@ -1905,7 +1905,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean silverfishRidable = false;
-@@ -2203,6 +2297,7 @@ public class PurpurWorldConfig {
+@@ -2205,6 +2299,7 @@ public class PurpurWorldConfig {
      public double silverfishMaxHealth = 8.0D;
      public boolean silverfishBypassMobGriefing = false;
      public boolean silverfishTakeDamageFromWater = false;
@@ -1913,7 +1913,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void silverfishSettings() {
          silverfishRidable = getBoolean("mobs.silverfish.ridable", silverfishRidable);
          silverfishRidableInWater = getBoolean("mobs.silverfish.ridable-in-water", silverfishRidableInWater);
-@@ -2215,6 +2310,7 @@ public class PurpurWorldConfig {
+@@ -2217,6 +2312,7 @@ public class PurpurWorldConfig {
          silverfishMaxHealth = getDouble("mobs.silverfish.attributes.max_health", silverfishMaxHealth);
          silverfishBypassMobGriefing = getBoolean("mobs.silverfish.bypass-mob-griefing", silverfishBypassMobGriefing);
          silverfishTakeDamageFromWater = getBoolean("mobs.silverfish.takes-damage-from-water", silverfishTakeDamageFromWater);
@@ -1921,7 +1921,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean skeletonRidable = false;
-@@ -2222,6 +2318,7 @@ public class PurpurWorldConfig {
+@@ -2224,6 +2320,7 @@ public class PurpurWorldConfig {
      public boolean skeletonControllable = true;
      public double skeletonMaxHealth = 20.0D;
      public boolean skeletonTakeDamageFromWater = false;
@@ -1929,7 +1929,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2233,6 +2330,7 @@ public class PurpurWorldConfig {
+@@ -2235,6 +2332,7 @@ public class PurpurWorldConfig {
          }
          skeletonMaxHealth = getDouble("mobs.skeleton.attributes.max_health", skeletonMaxHealth);
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
@@ -1937,7 +1937,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean skeletonHorseRidableInWater = true;
-@@ -2244,6 +2342,7 @@ public class PurpurWorldConfig {
+@@ -2246,6 +2344,7 @@ public class PurpurWorldConfig {
      public double skeletonHorseMovementSpeedMin = 0.2D;
      public double skeletonHorseMovementSpeedMax = 0.2D;
      public boolean skeletonHorseTakeDamageFromWater = false;
@@ -1945,7 +1945,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void skeletonHorseSettings() {
          skeletonHorseRidableInWater = getBoolean("mobs.skeleton_horse.ridable-in-water", skeletonHorseRidableInWater);
          skeletonHorseCanSwim = getBoolean("mobs.skeleton_horse.can-swim", skeletonHorseCanSwim);
-@@ -2260,6 +2359,7 @@ public class PurpurWorldConfig {
+@@ -2262,6 +2361,7 @@ public class PurpurWorldConfig {
          skeletonHorseMovementSpeedMin = getDouble("mobs.skeleton_horse.attributes.movement_speed.min", skeletonHorseMovementSpeedMin);
          skeletonHorseMovementSpeedMax = getDouble("mobs.skeleton_horse.attributes.movement_speed.max", skeletonHorseMovementSpeedMax);
          skeletonHorseTakeDamageFromWater = getBoolean("mobs.skeleton_horse.takes-damage-from-water", skeletonHorseTakeDamageFromWater);
@@ -1953,7 +1953,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean slimeRidable = false;
-@@ -2270,6 +2370,7 @@ public class PurpurWorldConfig {
+@@ -2272,6 +2372,7 @@ public class PurpurWorldConfig {
      public Map<Integer, Double> slimeMaxHealthCache = new HashMap<>();
      public Map<Integer, Double> slimeAttackDamageCache = new HashMap<>();
      public boolean slimeTakeDamageFromWater = false;
@@ -1961,7 +1961,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void slimeSettings() {
          slimeRidable = getBoolean("mobs.slime.ridable", slimeRidable);
          slimeRidableInWater = getBoolean("mobs.slime.ridable-in-water", slimeRidableInWater);
-@@ -2284,6 +2385,7 @@ public class PurpurWorldConfig {
+@@ -2286,6 +2387,7 @@ public class PurpurWorldConfig {
          slimeMaxHealthCache.clear();
          slimeAttackDamageCache.clear();
          slimeTakeDamageFromWater = getBoolean("mobs.slime.takes-damage-from-water", slimeTakeDamageFromWater);
@@ -1969,7 +1969,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean snowGolemRidable = false;
-@@ -2299,6 +2401,7 @@ public class PurpurWorldConfig {
+@@ -2301,6 +2403,7 @@ public class PurpurWorldConfig {
      public double snowGolemAttackDistance = 1.25D;
      public boolean snowGolemBypassMobGriefing = false;
      public boolean snowGolemTakeDamageFromWater = true;
@@ -1977,7 +1977,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void snowGolemSettings() {
          snowGolemRidable = getBoolean("mobs.snow_golem.ridable", snowGolemRidable);
          snowGolemRidableInWater = getBoolean("mobs.snow_golem.ridable-in-water", snowGolemRidableInWater);
-@@ -2318,6 +2421,7 @@ public class PurpurWorldConfig {
+@@ -2320,6 +2423,7 @@ public class PurpurWorldConfig {
          snowGolemAttackDistance = getDouble("mobs.snow_golem.attack-distance", snowGolemAttackDistance);
          snowGolemBypassMobGriefing = getBoolean("mobs.snow_golem.bypass-mob-griefing", snowGolemBypassMobGriefing);
          snowGolemTakeDamageFromWater = getBoolean("mobs.snow_golem.takes-damage-from-water", snowGolemTakeDamageFromWater);
@@ -1985,7 +1985,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean squidRidable = false;
-@@ -2327,6 +2431,7 @@ public class PurpurWorldConfig {
+@@ -2329,6 +2433,7 @@ public class PurpurWorldConfig {
      public double squidOffsetWaterCheck = 0.0D;
      public boolean squidsCanFly = false;
      public boolean squidTakeDamageFromWater = false;
@@ -1993,7 +1993,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void squidSettings() {
          squidRidable = getBoolean("mobs.squid.ridable", squidRidable);
          squidControllable = getBoolean("mobs.squid.controllable", squidControllable);
-@@ -2340,6 +2445,7 @@ public class PurpurWorldConfig {
+@@ -2342,6 +2447,7 @@ public class PurpurWorldConfig {
          squidOffsetWaterCheck = getDouble("mobs.squid.water-offset-check", squidOffsetWaterCheck);
          squidsCanFly = getBoolean("mobs.squid.can-fly", squidsCanFly);
          squidTakeDamageFromWater = getBoolean("mobs.squid.takes-damage-from-water", squidTakeDamageFromWater);
@@ -2001,7 +2001,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean spiderRidable = false;
-@@ -2347,6 +2453,7 @@ public class PurpurWorldConfig {
+@@ -2349,6 +2455,7 @@ public class PurpurWorldConfig {
      public boolean spiderControllable = true;
      public double spiderMaxHealth = 16.0D;
      public boolean spiderTakeDamageFromWater = false;
@@ -2009,7 +2009,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void spiderSettings() {
          spiderRidable = getBoolean("mobs.spider.ridable", spiderRidable);
          spiderRidableInWater = getBoolean("mobs.spider.ridable-in-water", spiderRidableInWater);
-@@ -2358,6 +2465,7 @@ public class PurpurWorldConfig {
+@@ -2360,6 +2467,7 @@ public class PurpurWorldConfig {
          }
          spiderMaxHealth = getDouble("mobs.spider.attributes.max_health", spiderMaxHealth);
          spiderTakeDamageFromWater = getBoolean("mobs.spider.takes-damage-from-water", spiderTakeDamageFromWater);
@@ -2017,7 +2017,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean strayRidable = false;
-@@ -2365,6 +2473,7 @@ public class PurpurWorldConfig {
+@@ -2367,6 +2475,7 @@ public class PurpurWorldConfig {
      public boolean strayControllable = true;
      public double strayMaxHealth = 20.0D;
      public boolean strayTakeDamageFromWater = false;
@@ -2025,7 +2025,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void straySettings() {
          strayRidable = getBoolean("mobs.stray.ridable", strayRidable);
          strayRidableInWater = getBoolean("mobs.stray.ridable-in-water", strayRidableInWater);
-@@ -2376,6 +2485,7 @@ public class PurpurWorldConfig {
+@@ -2378,6 +2487,7 @@ public class PurpurWorldConfig {
          }
          strayMaxHealth = getDouble("mobs.stray.attributes.max_health", strayMaxHealth);
          strayTakeDamageFromWater = getBoolean("mobs.stray.takes-damage-from-water", strayTakeDamageFromWater);
@@ -2033,7 +2033,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean striderRidable = false;
-@@ -2385,6 +2495,7 @@ public class PurpurWorldConfig {
+@@ -2387,6 +2497,7 @@ public class PurpurWorldConfig {
      public int striderBreedingTicks = 6000;
      public boolean striderGiveSaddleBack = false;
      public boolean striderTakeDamageFromWater = true;
@@ -2041,7 +2041,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void striderSettings() {
          striderRidable = getBoolean("mobs.strider.ridable", striderRidable);
          striderRidableInWater = getBoolean("mobs.strider.ridable-in-water", striderRidableInWater);
-@@ -2398,6 +2509,7 @@ public class PurpurWorldConfig {
+@@ -2400,6 +2511,7 @@ public class PurpurWorldConfig {
          striderBreedingTicks = getInt("mobs.strider.breeding-delay-ticks", striderBreedingTicks);
          striderGiveSaddleBack = getBoolean("mobs.strider.give-saddle-back", striderGiveSaddleBack);
          striderTakeDamageFromWater = getBoolean("mobs.strider.takes-damage-from-water", striderTakeDamageFromWater);
@@ -2049,7 +2049,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean tadpoleRidable = false;
-@@ -2420,6 +2532,7 @@ public class PurpurWorldConfig {
+@@ -2422,6 +2534,7 @@ public class PurpurWorldConfig {
      public double traderLlamaMovementSpeedMax = 0.175D;
      public int traderLlamaBreedingTicks = 6000;
      public boolean traderLlamaTakeDamageFromWater = false;
@@ -2057,7 +2057,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void traderLlamaSettings() {
          traderLlamaRidable = getBoolean("mobs.trader_llama.ridable", traderLlamaRidable);
          traderLlamaRidableInWater = getBoolean("mobs.trader_llama.ridable-in-water", traderLlamaRidableInWater);
-@@ -2439,12 +2552,14 @@ public class PurpurWorldConfig {
+@@ -2441,12 +2554,14 @@ public class PurpurWorldConfig {
          traderLlamaMovementSpeedMax = getDouble("mobs.trader_llama.attributes.movement_speed.max", traderLlamaMovementSpeedMax);
          traderLlamaBreedingTicks = getInt("mobs.trader_llama.breeding-delay-ticks", traderLlamaBreedingTicks);
          traderLlamaTakeDamageFromWater = getBoolean("mobs.trader_llama.takes-damage-from-water", traderLlamaTakeDamageFromWater);
@@ -2072,7 +2072,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void tropicalFishSettings() {
          tropicalFishRidable = getBoolean("mobs.tropical_fish.ridable", tropicalFishRidable);
          tropicalFishControllable = getBoolean("mobs.tropical_fish.controllable", tropicalFishControllable);
-@@ -2455,6 +2570,7 @@ public class PurpurWorldConfig {
+@@ -2457,6 +2572,7 @@ public class PurpurWorldConfig {
          }
          tropicalFishMaxHealth = getDouble("mobs.tropical_fish.attributes.max_health", tropicalFishMaxHealth);
          tropicalFishTakeDamageFromWater = getBoolean("mobs.tropical_fish.takes-damage-from-water", tropicalFishTakeDamageFromWater);
@@ -2080,7 +2080,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean turtleRidable = false;
-@@ -2463,6 +2579,7 @@ public class PurpurWorldConfig {
+@@ -2465,6 +2581,7 @@ public class PurpurWorldConfig {
      public double turtleMaxHealth = 30.0D;
      public int turtleBreedingTicks = 6000;
      public boolean turtleTakeDamageFromWater = false;
@@ -2088,7 +2088,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void turtleSettings() {
          turtleRidable = getBoolean("mobs.turtle.ridable", turtleRidable);
          turtleRidableInWater = getBoolean("mobs.turtle.ridable-in-water", turtleRidableInWater);
-@@ -2475,6 +2592,7 @@ public class PurpurWorldConfig {
+@@ -2477,6 +2594,7 @@ public class PurpurWorldConfig {
          turtleMaxHealth = getDouble("mobs.turtle.attributes.max_health", turtleMaxHealth);
          turtleBreedingTicks = getInt("mobs.turtle.breeding-delay-ticks", turtleBreedingTicks);
          turtleTakeDamageFromWater = getBoolean("mobs.turtle.takes-damage-from-water", turtleTakeDamageFromWater);
@@ -2096,7 +2096,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean vexRidable = false;
-@@ -2483,6 +2601,7 @@ public class PurpurWorldConfig {
+@@ -2485,6 +2603,7 @@ public class PurpurWorldConfig {
      public double vexMaxY = 320D;
      public double vexMaxHealth = 14.0D;
      public boolean vexTakeDamageFromWater = false;
@@ -2104,7 +2104,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void vexSettings() {
          vexRidable = getBoolean("mobs.vex.ridable", vexRidable);
          vexRidableInWater = getBoolean("mobs.vex.ridable-in-water", vexRidableInWater);
-@@ -2495,6 +2614,7 @@ public class PurpurWorldConfig {
+@@ -2497,6 +2616,7 @@ public class PurpurWorldConfig {
          }
          vexMaxHealth = getDouble("mobs.vex.attributes.max_health", vexMaxHealth);
          vexTakeDamageFromWater = getBoolean("mobs.vex.takes-damage-from-water", vexTakeDamageFromWater);
@@ -2112,7 +2112,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean villagerRidable = false;
-@@ -2512,6 +2632,7 @@ public class PurpurWorldConfig {
+@@ -2514,6 +2634,7 @@ public class PurpurWorldConfig {
      public boolean villagerBypassMobGriefing = false;
      public boolean villagerTakeDamageFromWater = false;
      public boolean villagerAllowTrading = true;
@@ -2120,7 +2120,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2533,6 +2654,7 @@ public class PurpurWorldConfig {
+@@ -2535,6 +2656,7 @@ public class PurpurWorldConfig {
          villagerBypassMobGriefing = getBoolean("mobs.villager.bypass-mob-griefing", villagerBypassMobGriefing);
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
@@ -2128,7 +2128,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean vindicatorRidable = false;
-@@ -2541,6 +2663,7 @@ public class PurpurWorldConfig {
+@@ -2543,6 +2665,7 @@ public class PurpurWorldConfig {
      public double vindicatorMaxHealth = 24.0D;
      public double vindicatorJohnnySpawnChance = 0D;
      public boolean vindicatorTakeDamageFromWater = false;
@@ -2136,7 +2136,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void vindicatorSettings() {
          vindicatorRidable = getBoolean("mobs.vindicator.ridable", vindicatorRidable);
          vindicatorRidableInWater = getBoolean("mobs.vindicator.ridable-in-water", vindicatorRidableInWater);
-@@ -2553,6 +2676,7 @@ public class PurpurWorldConfig {
+@@ -2555,6 +2678,7 @@ public class PurpurWorldConfig {
          vindicatorMaxHealth = getDouble("mobs.vindicator.attributes.max_health", vindicatorMaxHealth);
          vindicatorJohnnySpawnChance = getDouble("mobs.vindicator.johnny.spawn-chance", vindicatorJohnnySpawnChance);
          vindicatorTakeDamageFromWater = getBoolean("mobs.vindicator.takes-damage-from-water", vindicatorTakeDamageFromWater);
@@ -2144,7 +2144,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean wanderingTraderRidable = false;
-@@ -2563,6 +2687,7 @@ public class PurpurWorldConfig {
+@@ -2565,6 +2689,7 @@ public class PurpurWorldConfig {
      public boolean wanderingTraderCanBeLeashed = false;
      public boolean wanderingTraderTakeDamageFromWater = false;
      public boolean wanderingTraderAllowTrading = true;
@@ -2152,7 +2152,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void wanderingTraderSettings() {
          wanderingTraderRidable = getBoolean("mobs.wandering_trader.ridable", wanderingTraderRidable);
          wanderingTraderRidableInWater = getBoolean("mobs.wandering_trader.ridable-in-water", wanderingTraderRidableInWater);
-@@ -2577,6 +2702,7 @@ public class PurpurWorldConfig {
+@@ -2579,6 +2704,7 @@ public class PurpurWorldConfig {
          wanderingTraderCanBeLeashed = getBoolean("mobs.wandering_trader.can-be-leashed", wanderingTraderCanBeLeashed);
          wanderingTraderTakeDamageFromWater = getBoolean("mobs.wandering_trader.takes-damage-from-water", wanderingTraderTakeDamageFromWater);
          wanderingTraderAllowTrading = getBoolean("mobs.wandering_trader.allow-trading", wanderingTraderAllowTrading);
@@ -2160,7 +2160,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean wardenRidable = false;
-@@ -2593,6 +2719,7 @@ public class PurpurWorldConfig {
+@@ -2595,6 +2721,7 @@ public class PurpurWorldConfig {
      public boolean witchControllable = true;
      public double witchMaxHealth = 26.0D;
      public boolean witchTakeDamageFromWater = false;
@@ -2168,7 +2168,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void witchSettings() {
          witchRidable = getBoolean("mobs.witch.ridable", witchRidable);
          witchRidableInWater = getBoolean("mobs.witch.ridable-in-water", witchRidableInWater);
-@@ -2604,6 +2731,7 @@ public class PurpurWorldConfig {
+@@ -2606,6 +2733,7 @@ public class PurpurWorldConfig {
          }
          witchMaxHealth = getDouble("mobs.witch.attributes.max_health", witchMaxHealth);
          witchTakeDamageFromWater = getBoolean("mobs.witch.takes-damage-from-water", witchTakeDamageFromWater);
@@ -2176,7 +2176,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean witherRidable = false;
-@@ -2618,6 +2746,7 @@ public class PurpurWorldConfig {
+@@ -2620,6 +2748,7 @@ public class PurpurWorldConfig {
      public boolean witherCanRideVehicles = false;
      public float witherExplosionRadius = 1.0F;
      public boolean witherPlaySpawnSound = true;
@@ -2184,7 +2184,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2640,6 +2769,7 @@ public class PurpurWorldConfig {
+@@ -2642,6 +2771,7 @@ public class PurpurWorldConfig {
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);
          witherExplosionRadius = (float) getDouble("mobs.wither.explosion-radius", witherExplosionRadius);
          witherPlaySpawnSound = getBoolean("mobs.wither.play-spawn-sound", witherPlaySpawnSound);
@@ -2192,7 +2192,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean witherSkeletonRidable = false;
-@@ -2647,6 +2777,7 @@ public class PurpurWorldConfig {
+@@ -2649,6 +2779,7 @@ public class PurpurWorldConfig {
      public boolean witherSkeletonControllable = true;
      public double witherSkeletonMaxHealth = 20.0D;
      public boolean witherSkeletonTakeDamageFromWater = false;
@@ -2200,7 +2200,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void witherSkeletonSettings() {
          witherSkeletonRidable = getBoolean("mobs.wither_skeleton.ridable", witherSkeletonRidable);
          witherSkeletonRidableInWater = getBoolean("mobs.wither_skeleton.ridable-in-water", witherSkeletonRidableInWater);
-@@ -2658,6 +2789,7 @@ public class PurpurWorldConfig {
+@@ -2660,6 +2791,7 @@ public class PurpurWorldConfig {
          }
          witherSkeletonMaxHealth = getDouble("mobs.wither_skeleton.attributes.max_health", witherSkeletonMaxHealth);
          witherSkeletonTakeDamageFromWater = getBoolean("mobs.wither_skeleton.takes-damage-from-water", witherSkeletonTakeDamageFromWater);
@@ -2208,7 +2208,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean wolfRidable = false;
-@@ -2669,6 +2801,7 @@ public class PurpurWorldConfig {
+@@ -2671,6 +2803,7 @@ public class PurpurWorldConfig {
      public double wolfNaturalRabid = 0.0D;
      public int wolfBreedingTicks = 6000;
      public boolean wolfTakeDamageFromWater = false;
@@ -2216,7 +2216,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void wolfSettings() {
          wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
          wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
-@@ -2688,6 +2821,7 @@ public class PurpurWorldConfig {
+@@ -2690,6 +2823,7 @@ public class PurpurWorldConfig {
          wolfNaturalRabid = getDouble("mobs.wolf.spawn-rabid-chance", wolfNaturalRabid);
          wolfBreedingTicks = getInt("mobs.wolf.breeding-delay-ticks", wolfBreedingTicks);
          wolfTakeDamageFromWater = getBoolean("mobs.wolf.takes-damage-from-water", wolfTakeDamageFromWater);
@@ -2224,7 +2224,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean zoglinRidable = false;
-@@ -2695,6 +2829,7 @@ public class PurpurWorldConfig {
+@@ -2697,6 +2831,7 @@ public class PurpurWorldConfig {
      public boolean zoglinControllable = true;
      public double zoglinMaxHealth = 40.0D;
      public boolean zoglinTakeDamageFromWater = false;
@@ -2232,7 +2232,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void zoglinSettings() {
          zoglinRidable = getBoolean("mobs.zoglin.ridable", zoglinRidable);
          zoglinRidableInWater = getBoolean("mobs.zoglin.ridable-in-water", zoglinRidableInWater);
-@@ -2706,6 +2841,7 @@ public class PurpurWorldConfig {
+@@ -2708,6 +2843,7 @@ public class PurpurWorldConfig {
          }
          zoglinMaxHealth = getDouble("mobs.zoglin.attributes.max_health", zoglinMaxHealth);
          zoglinTakeDamageFromWater = getBoolean("mobs.zoglin.takes-damage-from-water", zoglinTakeDamageFromWater);
@@ -2240,7 +2240,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean zombieRidable = false;
-@@ -2719,6 +2855,7 @@ public class PurpurWorldConfig {
+@@ -2721,6 +2857,7 @@ public class PurpurWorldConfig {
      public boolean zombieAggressiveTowardsVillagerWhenLagging = true;
      public boolean zombieBypassMobGriefing = false;
      public boolean zombieTakeDamageFromWater = false;
@@ -2248,7 +2248,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -2736,6 +2873,7 @@ public class PurpurWorldConfig {
+@@ -2738,6 +2875,7 @@ public class PurpurWorldConfig {
          zombieAggressiveTowardsVillagerWhenLagging = getBoolean("mobs.zombie.aggressive-towards-villager-when-lagging", zombieAggressiveTowardsVillagerWhenLagging);
          zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
          zombieTakeDamageFromWater = getBoolean("mobs.zombie.takes-damage-from-water", zombieTakeDamageFromWater);
@@ -2256,7 +2256,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean zombieHorseRidableInWater = false;
-@@ -2748,6 +2886,7 @@ public class PurpurWorldConfig {
+@@ -2750,6 +2888,7 @@ public class PurpurWorldConfig {
      public double zombieHorseMovementSpeedMax = 0.2D;
      public double zombieHorseSpawnChance = 0.0D;
      public boolean zombieHorseTakeDamageFromWater = false;
@@ -2264,7 +2264,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void zombieHorseSettings() {
          zombieHorseRidableInWater = getBoolean("mobs.zombie_horse.ridable-in-water", zombieHorseRidableInWater);
          zombieHorseCanSwim = getBoolean("mobs.zombie_horse.can-swim", zombieHorseCanSwim);
-@@ -2765,6 +2904,7 @@ public class PurpurWorldConfig {
+@@ -2767,6 +2906,7 @@ public class PurpurWorldConfig {
          zombieHorseMovementSpeedMax = getDouble("mobs.zombie_horse.attributes.movement_speed.max", zombieHorseMovementSpeedMax);
          zombieHorseSpawnChance = getDouble("mobs.zombie_horse.spawn-chance", zombieHorseSpawnChance);
          zombieHorseTakeDamageFromWater = getBoolean("mobs.zombie_horse.takes-damage-from-water", zombieHorseTakeDamageFromWater);
@@ -2272,7 +2272,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean zombieVillagerRidable = false;
-@@ -2779,6 +2919,7 @@ public class PurpurWorldConfig {
+@@ -2781,6 +2921,7 @@ public class PurpurWorldConfig {
      public int zombieVillagerCuringTimeMin = 3600;
      public int zombieVillagerCuringTimeMax = 6000;
      public boolean zombieVillagerCureEnabled = true;
@@ -2280,7 +2280,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2797,6 +2938,7 @@ public class PurpurWorldConfig {
+@@ -2799,6 +2940,7 @@ public class PurpurWorldConfig {
          zombieVillagerCuringTimeMin = getInt("mobs.zombie_villager.curing_time.min", zombieVillagerCuringTimeMin);
          zombieVillagerCuringTimeMax = getInt("mobs.zombie_villager.curing_time.max", zombieVillagerCuringTimeMax);
          zombieVillagerCureEnabled = getBoolean("mobs.zombie_villager.cure.enabled", zombieVillagerCureEnabled);
@@ -2288,7 +2288,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      }
  
      public boolean zombifiedPiglinRidable = false;
-@@ -2809,6 +2951,7 @@ public class PurpurWorldConfig {
+@@ -2811,6 +2953,7 @@ public class PurpurWorldConfig {
      public boolean zombifiedPiglinJockeyTryExistingChickens = true;
      public boolean zombifiedPiglinCountAsPlayerKillWhenAngry = true;
      public boolean zombifiedPiglinTakeDamageFromWater = false;
@@ -2296,7 +2296,7 @@ index 90b295d75b858dd48026ede68a0e9c49311f6e46..09185f0c00a1090b6a3b4b165487b9b0
      private void zombifiedPiglinSettings() {
          zombifiedPiglinRidable = getBoolean("mobs.zombified_piglin.ridable", zombifiedPiglinRidable);
          zombifiedPiglinRidableInWater = getBoolean("mobs.zombified_piglin.ridable-in-water", zombifiedPiglinRidableInWater);
-@@ -2825,6 +2968,7 @@ public class PurpurWorldConfig {
+@@ -2827,6 +2970,7 @@ public class PurpurWorldConfig {
          zombifiedPiglinJockeyTryExistingChickens = getBoolean("mobs.zombified_piglin.jockey.try-existing-chickens", zombifiedPiglinJockeyTryExistingChickens);
          zombifiedPiglinCountAsPlayerKillWhenAngry = getBoolean("mobs.zombified_piglin.count-as-player-kill-when-angry", zombifiedPiglinCountAsPlayerKillWhenAngry);
          zombifiedPiglinTakeDamageFromWater = getBoolean("mobs.zombified_piglin.takes-damage-from-water", zombifiedPiglinTakeDamageFromWater);

--- a/patches/server/0243-Option-to-prevent-spiders-from-climbing-world-border.patch
+++ b/patches/server/0243-Option-to-prevent-spiders-from-climbing-world-border.patch
@@ -39,10 +39,10 @@ index bdd4fc3072f7a5ea504ba35f6a08ae971e83b69f..b9ac8cefefe1f47548166330b7c889df
  
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 09185f0c00a1090b6a3b4b165487b9b0c52bf9a2..7a4500958100469a2bef2a38ce3ac4474906093a 100644
+index a51c6cc72cd9659cdaa51fe2c92f7b6e516f6a21..dcf170164103baf2ecc4d93d147294c75c622e87 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2454,6 +2454,7 @@ public class PurpurWorldConfig {
+@@ -2456,6 +2456,7 @@ public class PurpurWorldConfig {
      public double spiderMaxHealth = 16.0D;
      public boolean spiderTakeDamageFromWater = false;
      public boolean spiderAlwaysDropExp = false;
@@ -50,7 +50,7 @@ index 09185f0c00a1090b6a3b4b165487b9b0c52bf9a2..7a4500958100469a2bef2a38ce3ac447
      private void spiderSettings() {
          spiderRidable = getBoolean("mobs.spider.ridable", spiderRidable);
          spiderRidableInWater = getBoolean("mobs.spider.ridable-in-water", spiderRidableInWater);
-@@ -2466,6 +2467,7 @@ public class PurpurWorldConfig {
+@@ -2468,6 +2469,7 @@ public class PurpurWorldConfig {
          spiderMaxHealth = getDouble("mobs.spider.attributes.max_health", spiderMaxHealth);
          spiderTakeDamageFromWater = getBoolean("mobs.spider.takes-damage-from-water", spiderTakeDamageFromWater);
          spiderAlwaysDropExp = getBoolean("mobs.spider.always-drop-exp", spiderAlwaysDropExp);

--- a/patches/server/0245-Shearing-jeb-produces-random-color-wool.patch
+++ b/patches/server/0245-Shearing-jeb-produces-random-color-wool.patch
@@ -18,10 +18,10 @@ index 63aeab7204ac954b2908207dc6e743d17aa27f2e..aa6f6e252f6f2933825b97bf1b9679fe
  
              if (entityitem != null) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index af713f15614f16afea6ef5a0774c43d17518c321..7716a07d86fc5fbcde7b4d671ac3b0161be01bf4 100644
+index 2e4e3d54c6460c1a4fb9788309e54333a247dac4..c8a610cc4ddc7006a44d1b26ff94d279420e495f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2247,6 +2247,7 @@ public class PurpurWorldConfig {
+@@ -2249,6 +2249,7 @@ public class PurpurWorldConfig {
      public boolean sheepBypassMobGriefing = false;
      public boolean sheepTakeDamageFromWater = false;
      public boolean sheepAlwaysDropExp = false;
@@ -29,7 +29,7 @@ index af713f15614f16afea6ef5a0774c43d17518c321..7716a07d86fc5fbcde7b4d671ac3b016
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -2261,6 +2262,7 @@ public class PurpurWorldConfig {
+@@ -2263,6 +2264,7 @@ public class PurpurWorldConfig {
          sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
          sheepTakeDamageFromWater = getBoolean("mobs.sheep.takes-damage-from-water", sheepTakeDamageFromWater);
          sheepAlwaysDropExp = getBoolean("mobs.sheep.always-drop-exp", sheepAlwaysDropExp);

--- a/patches/server/0246-Turtle-eggs-random-tick-crack-chance.patch
+++ b/patches/server/0246-Turtle-eggs-random-tick-crack-chance.patch
@@ -32,10 +32,10 @@ index 4907e0acb7d01b7f57b75579e58ce743e3e000bb..5e6df1d6cbaecb986d1b8d382fe673a2
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7716a07d86fc5fbcde7b4d671ac3b0161be01bf4..de0652cec9f8a6b1f4bec03f9f8ce41ff45a3a23 100644
+index c8a610cc4ddc7006a44d1b26ff94d279420e495f..c90055c4f76769641f35ab3658d1162c674cbb5d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -967,11 +967,13 @@ public class PurpurWorldConfig {
+@@ -969,11 +969,13 @@ public class PurpurWorldConfig {
      public boolean turtleEggsBreakFromItems = true;
      public boolean turtleEggsBreakFromMinecarts = true;
      public boolean turtleEggsBypassMobGriefing = false;

--- a/patches/server/0247-Mob-head-visibility-percent.patch
+++ b/patches/server/0247-Mob-head-visibility-percent.patch
@@ -29,10 +29,10 @@ index 89a0878d77548d1e0e414903b04d5868c0b8c0b1..f04ce887e314110a136b4bff91d55d2e
              // Purpur start
              if (entity instanceof LivingEntity entityliving) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index de0652cec9f8a6b1f4bec03f9f8ce41ff45a3a23..0be973281d0b81736208f8a4dac1e93f5241ae0f 100644
+index c90055c4f76769641f35ab3658d1162c674cbb5d..3ac48e95459ef19beb4da8591f28cc8d882157df 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1235,6 +1235,7 @@ public class PurpurWorldConfig {
+@@ -1237,6 +1237,7 @@ public class PurpurWorldConfig {
      public boolean creeperExplodeWhenKilled = false;
      public boolean creeperHealthRadius = false;
      public boolean creeperAlwaysDropExp = false;
@@ -40,7 +40,7 @@ index de0652cec9f8a6b1f4bec03f9f8ce41ff45a3a23..0be973281d0b81736208f8a4dac1e93f
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1252,6 +1253,7 @@ public class PurpurWorldConfig {
+@@ -1254,6 +1255,7 @@ public class PurpurWorldConfig {
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
          creeperAlwaysDropExp = getBoolean("mobs.creeper.always-drop-exp", creeperAlwaysDropExp);
@@ -48,7 +48,7 @@ index de0652cec9f8a6b1f4bec03f9f8ce41ff45a3a23..0be973281d0b81736208f8a4dac1e93f
      }
  
      public boolean dolphinRidable = false;
-@@ -2327,6 +2329,7 @@ public class PurpurWorldConfig {
+@@ -2329,6 +2331,7 @@ public class PurpurWorldConfig {
      public double skeletonMaxHealth = 20.0D;
      public boolean skeletonTakeDamageFromWater = false;
      public boolean skeletonAlwaysDropExp = false;
@@ -56,7 +56,7 @@ index de0652cec9f8a6b1f4bec03f9f8ce41ff45a3a23..0be973281d0b81736208f8a4dac1e93f
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2339,6 +2342,7 @@ public class PurpurWorldConfig {
+@@ -2341,6 +2344,7 @@ public class PurpurWorldConfig {
          skeletonMaxHealth = getDouble("mobs.skeleton.attributes.max_health", skeletonMaxHealth);
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
@@ -64,7 +64,7 @@ index de0652cec9f8a6b1f4bec03f9f8ce41ff45a3a23..0be973281d0b81736208f8a4dac1e93f
      }
  
      public boolean skeletonHorseRidableInWater = true;
-@@ -2866,6 +2870,7 @@ public class PurpurWorldConfig {
+@@ -2868,6 +2872,7 @@ public class PurpurWorldConfig {
      public boolean zombieBypassMobGriefing = false;
      public boolean zombieTakeDamageFromWater = false;
      public boolean zombieAlwaysDropExp = false;
@@ -72,7 +72,7 @@ index de0652cec9f8a6b1f4bec03f9f8ce41ff45a3a23..0be973281d0b81736208f8a4dac1e93f
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -2884,6 +2889,7 @@ public class PurpurWorldConfig {
+@@ -2886,6 +2891,7 @@ public class PurpurWorldConfig {
          zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
          zombieTakeDamageFromWater = getBoolean("mobs.zombie.takes-damage-from-water", zombieTakeDamageFromWater);
          zombieAlwaysDropExp = getBoolean("mobs.zombie.always-drop-exp", zombieAlwaysDropExp);

--- a/patches/server/0250-Stop-bees-from-dying-after-stinging.patch
+++ b/patches/server/0250-Stop-bees-from-dying-after-stinging.patch
@@ -17,10 +17,10 @@ index f2410b90b892a0c9684bc1fb675c0cd35518ca19..353e3aae979181547e5efc9c944ea1c6
              ++this.timeSinceSting;
              if (this.timeSinceSting % 5 == 0 && this.random.nextInt(Mth.clamp(1200 - this.timeSinceSting, (int) 1, (int) 1200)) == 0) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 0be973281d0b81736208f8a4dac1e93f5241ae0f..d65b2e173458bfa43e8b320d9623c64f3eef1615 100644
+index 3ac48e95459ef19beb4da8591f28cc8d882157df..2466ec0c14abb1d7fcf591b98c688d6d0cabe703 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1055,6 +1055,7 @@ public class PurpurWorldConfig {
+@@ -1057,6 +1057,7 @@ public class PurpurWorldConfig {
      public boolean beeCanWorkAtNight = false;
      public boolean beeCanWorkInRain = false;
      public boolean beeAlwaysDropExp = false;
@@ -28,7 +28,7 @@ index 0be973281d0b81736208f8a4dac1e93f5241ae0f..d65b2e173458bfa43e8b320d9623c64f
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -1071,6 +1072,7 @@ public class PurpurWorldConfig {
+@@ -1073,6 +1074,7 @@ public class PurpurWorldConfig {
          beeCanWorkAtNight = getBoolean("mobs.bee.can-work-at-night", beeCanWorkAtNight);
          beeCanWorkInRain = getBoolean("mobs.bee.can-work-in-rain", beeCanWorkInRain);
          beeAlwaysDropExp = getBoolean("mobs.bee.always-drop-exp", beeAlwaysDropExp);

--- a/patches/server/0252-Configurable-farmland-trample-height.patch
+++ b/patches/server/0252-Configurable-farmland-trample-height.patch
@@ -35,10 +35,10 @@ index e5a3e3a4367dfb924624a913b816b3fd56e3fefd..7068cb39ab264fa0c65febff01236b8d
              org.bukkit.event.Cancellable cancellable;
              if (entity instanceof Player) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d65b2e173458bfa43e8b320d9623c64f3eef1615..746faa9d17f1f99ea97eafb22850b02ae81795ad 100644
+index 2466ec0c14abb1d7fcf591b98c688d6d0cabe703..e47e41ec83c369406c25bd3b6fbfae3bf025ba83 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -848,6 +848,7 @@ public class PurpurWorldConfig {
+@@ -850,6 +850,7 @@ public class PurpurWorldConfig {
      public boolean farmlandTramplingDisabled = false;
      public boolean farmlandTramplingOnlyPlayers = false;
      public boolean farmlandTramplingFeatherFalling = false;
@@ -46,7 +46,7 @@ index d65b2e173458bfa43e8b320d9623c64f3eef1615..746faa9d17f1f99ea97eafb22850b02a
      private void farmlandSettings() {
          farmlandBypassMobGriefing = getBoolean("blocks.farmland.bypass-mob-griefing", farmlandBypassMobGriefing);
          farmlandGetsMoistFromBelow = getBoolean("blocks.farmland.gets-moist-from-below", farmlandGetsMoistFromBelow);
-@@ -855,6 +856,7 @@ public class PurpurWorldConfig {
+@@ -857,6 +858,7 @@ public class PurpurWorldConfig {
          farmlandTramplingDisabled = getBoolean("blocks.farmland.disable-trampling", farmlandTramplingDisabled);
          farmlandTramplingOnlyPlayers = getBoolean("blocks.farmland.only-players-trample", farmlandTramplingOnlyPlayers);
          farmlandTramplingFeatherFalling = getBoolean("blocks.farmland.feather-fall-distance-affects-trampling", farmlandTramplingFeatherFalling);

--- a/patches/server/0256-Configurable-phantom-size.patch
+++ b/patches/server/0256-Configurable-phantom-size.patch
@@ -22,10 +22,10 @@ index 1afe38e0d83040f4f5702ac3a14ac1e7963b9e5e..08ef919c5e7edfa8f565ecef8f57b549
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 262e341a262d22664ef18a9032ab47cf00083d2e..adc1875d9e09ad561b71d1c86fc3ac85a77492e1 100644
+index e3777f73f4bcb28f4c29b061201ec84dac515489..b997e952f758f290fc1c67e483aee49992b80d8c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1986,6 +1986,8 @@ public class PurpurWorldConfig {
+@@ -1988,6 +1988,8 @@ public class PurpurWorldConfig {
      public boolean phantomFlamesOnSwoop = false;
      public boolean phantomTakeDamageFromWater = false;
      public boolean phantomAlwaysDropExp = false;
@@ -34,7 +34,7 @@ index 262e341a262d22664ef18a9032ab47cf00083d2e..adc1875d9e09ad561b71d1c86fc3ac85
      private void phantomSettings() {
          phantomRidable = getBoolean("mobs.phantom.ridable", phantomRidable);
          phantomRidableInWater = getBoolean("mobs.phantom.ridable-in-water", phantomRidableInWater);
-@@ -2028,6 +2030,13 @@ public class PurpurWorldConfig {
+@@ -2030,6 +2032,13 @@ public class PurpurWorldConfig {
          phantomFlamesOnSwoop = getBoolean("mobs.phantom.flames-on-swoop", phantomFlamesOnSwoop);
          phantomTakeDamageFromWater = getBoolean("mobs.phantom.takes-damage-from-water", phantomTakeDamageFromWater);
          phantomAlwaysDropExp = getBoolean("mobs.phantom.always-drop-exp", phantomAlwaysDropExp);

--- a/patches/server/0259-Configurable-minimum-demand-for-trades.patch
+++ b/patches/server/0259-Configurable-minimum-demand-for-trades.patch
@@ -40,10 +40,10 @@ index 8a9a701baabdaf066cd9b28c05430f673fcafb4e..17cc3237c7fc8ceda136b2371fabf6f0
  
      public ItemStack assemble() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index adc1875d9e09ad561b71d1c86fc3ac85a77492e1..abb66dbcbb02953b01ad468b936170f887185a27 100644
+index b997e952f758f290fc1c67e483aee49992b80d8c..dfae207bd58a9a1aed781f21fa0f2f48bae253bb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2664,6 +2664,7 @@ public class PurpurWorldConfig {
+@@ -2666,6 +2666,7 @@ public class PurpurWorldConfig {
      public boolean villagerTakeDamageFromWater = false;
      public boolean villagerAllowTrading = true;
      public boolean villagerAlwaysDropExp = false;
@@ -51,7 +51,7 @@ index adc1875d9e09ad561b71d1c86fc3ac85a77492e1..abb66dbcbb02953b01ad468b936170f8
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2686,6 +2687,7 @@ public class PurpurWorldConfig {
+@@ -2688,6 +2689,7 @@ public class PurpurWorldConfig {
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
          villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);

--- a/patches/server/0260-Lobotomize-stuck-villagers.patch
+++ b/patches/server/0260-Lobotomize-stuck-villagers.patch
@@ -111,10 +111,10 @@ index f0b910df1ee471b4d72d97c6197ab14f2854976e..6ce32a52d621a0c2629568ea07e445f5
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index abb66dbcbb02953b01ad468b936170f887185a27..1ed73814c1d21e175d4f3195e3ea85b5994f1ea2 100644
+index dfae207bd58a9a1aed781f21fa0f2f48bae253bb..957b62340682c521c3e33145621a3c457cdde492 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2665,6 +2665,8 @@ public class PurpurWorldConfig {
+@@ -2667,6 +2667,8 @@ public class PurpurWorldConfig {
      public boolean villagerAllowTrading = true;
      public boolean villagerAlwaysDropExp = false;
      public int villagerMinimumDemand = 0;
@@ -123,7 +123,7 @@ index abb66dbcbb02953b01ad468b936170f887185a27..1ed73814c1d21e175d4f3195e3ea85b5
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2688,6 +2690,17 @@ public class PurpurWorldConfig {
+@@ -2690,6 +2692,17 @@ public class PurpurWorldConfig {
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
          villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);
          villagerMinimumDemand = getInt("mobs.villager.minimum-demand", villagerMinimumDemand);

--- a/patches/server/0261-Option-for-villager-display-trade-item.patch
+++ b/patches/server/0261-Option-for-villager-display-trade-item.patch
@@ -17,10 +17,10 @@ index 385f3df7044e3f03f17c3ec7484b268004a3def9..90ba6a3abf62e4b272fada96b554ca31
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1ed73814c1d21e175d4f3195e3ea85b5994f1ea2..12669f27505ae513e78880f986116bdafbf67d27 100644
+index 957b62340682c521c3e33145621a3c457cdde492..cf35acf28fd79f81175b7349e6ca3077c893a0af 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2667,6 +2667,7 @@ public class PurpurWorldConfig {
+@@ -2669,6 +2669,7 @@ public class PurpurWorldConfig {
      public int villagerMinimumDemand = 0;
      public boolean villagerLobotomizeEnabled = false;
      public int villagerLobotomizeCheckInterval = 100;
@@ -28,7 +28,7 @@ index 1ed73814c1d21e175d4f3195e3ea85b5994f1ea2..12669f27505ae513e78880f986116bda
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2701,6 +2702,7 @@ public class PurpurWorldConfig {
+@@ -2703,6 +2704,7 @@ public class PurpurWorldConfig {
          }
          villagerLobotomizeEnabled = getBoolean("mobs.villager.lobotomize.enabled", villagerLobotomizeEnabled);
          villagerLobotomizeCheckInterval = getInt("mobs.villager.lobotomize.check-interval", villagerLobotomizeCheckInterval);

--- a/patches/server/0263-MC-238526-Fix-spawner-not-spawning-water-animals-cor.patch
+++ b/patches/server/0263-MC-238526-Fix-spawner-not-spawning-water-animals-cor.patch
@@ -17,10 +17,10 @@ index 18389f46902bb9879ac6d734723e9a720724dc48..b2b8663a9cff08bacdab91c7bb014ba6
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 12669f27505ae513e78880f986116bdafbf67d27..8e99c1cdb378f18d790098bc628d67d0ea0ebd02 100644
+index cf35acf28fd79f81175b7349e6ca3077c893a0af..a1fbc801834fa43a70c7f4be307a75a63b417f94 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -956,8 +956,10 @@ public class PurpurWorldConfig {
+@@ -958,8 +958,10 @@ public class PurpurWorldConfig {
      }
  
      public boolean spawnerDeactivateByRedstone = false;

--- a/patches/server/0265-Anvil-repair-damage-options.patch
+++ b/patches/server/0265-Anvil-repair-damage-options.patch
@@ -64,17 +64,18 @@ index 1b23352a9deae37f9c947fef1b1f8a2875507cfa..ad5aad3682926e2e8965bb87ad8d5381
              return InteractionResult.SUCCESS;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ca6eedfce3e5206c0d98fba4d5555889a4b20efe..9f908b0bf7f8ecc81359410d78df2c62fcef1400 100644
+index 1d688e17467708c3e579efb3594e1bddbf63d776..8f4edc3bc23b3916fa7d18dea110b88b965033b4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -718,8 +718,12 @@ public class PurpurWorldConfig {
-     }
+@@ -719,9 +719,13 @@ public class PurpurWorldConfig {
  
      public boolean anvilAllowColors = false;
+     public boolean anvilColorsUseMiniMessage;
 +    public int anvilRepairIngotsAmount = 0;
 +    public int anvilDamageObsidianAmount = 0;
      private void anvilSettings() {
          anvilAllowColors = getBoolean("blocks.anvil.allow-colors", anvilAllowColors);
+         anvilColorsUseMiniMessage = getBoolean("blocks.anvil.use-mini-message", anvilColorsUseMiniMessage);
 +        anvilRepairIngotsAmount = getInt("blocks.anvil.iron-ingots-used-for-repair", anvilRepairIngotsAmount);
 +        anvilDamageObsidianAmount = getInt("blocks.anvil.obsidian-used-for-damage", anvilDamageObsidianAmount);
      }

--- a/patches/server/0267-Option-to-disable-turtle-egg-trampling-with-feather-.patch
+++ b/patches/server/0267-Option-to-disable-turtle-egg-trampling-with-feather-.patch
@@ -20,10 +20,10 @@ index 5e6df1d6cbaecb986d1b8d382fe673a2cbb76115..6151226a88a9ca44955821521641e788
          // Purpur end
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9f908b0bf7f8ecc81359410d78df2c62fcef1400..78f72206306abc87562d4221bfe2852f46fb5c44 100644
+index 8f4edc3bc23b3916fa7d18dea110b88b965033b4..8c003995aa8c9566f6487c1846362eeab47869d5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -982,12 +982,14 @@ public class PurpurWorldConfig {
+@@ -984,12 +984,14 @@ public class PurpurWorldConfig {
      public boolean turtleEggsBreakFromMinecarts = true;
      public boolean turtleEggsBypassMobGriefing = false;
      public int turtleEggsRandomTickCrackChance = 500;

--- a/patches/server/0269-Config-to-prevent-horses-from-standing-when-hurt.patch
+++ b/patches/server/0269-Config-to-prevent-horses-from-standing-when-hurt.patch
@@ -21,10 +21,10 @@ index 7466c437b2e996f16a08aaefc5c2b7cba216a14c..205ce2bd91a98a0c67d3c5dd640eb88c
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 78f72206306abc87562d4221bfe2852f46fb5c44..a568910fd892383a1f779e47416da66883d7f9bb 100644
+index 8c003995aa8c9566f6487c1846362eeab47869d5..1e4367e3f8236f961e3bd97c74d4c1738b10f25d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1678,6 +1678,7 @@ public class PurpurWorldConfig {
+@@ -1680,6 +1680,7 @@ public class PurpurWorldConfig {
      public int horseBreedingTicks = 6000;
      public boolean horseTakeDamageFromWater = false;
      public boolean horseStandWithRider = true;
@@ -32,7 +32,7 @@ index 78f72206306abc87562d4221bfe2852f46fb5c44..a568910fd892383a1f779e47416da668
      public boolean horseAlwaysDropExp = false;
      private void horseSettings() {
          horseRidableInWater = getBoolean("mobs.horse.ridable-in-water", horseRidableInWater);
-@@ -1697,6 +1698,7 @@ public class PurpurWorldConfig {
+@@ -1699,6 +1700,7 @@ public class PurpurWorldConfig {
          horseBreedingTicks = getInt("mobs.horse.breeding-delay-ticks", horseBreedingTicks);
          horseTakeDamageFromWater = getBoolean("mobs.horse.takes-damage-from-water", horseTakeDamageFromWater);
          horseStandWithRider = getBoolean("mobs.horse.stand-with-rider", horseStandWithRider);

--- a/patches/server/0271-Implement-configurable-search-radius-for-villagers-t.patch
+++ b/patches/server/0271-Implement-configurable-search-radius-for-villagers-t.patch
@@ -18,10 +18,10 @@ index ace39b0585c67b2764d75ff9e64d132347157a51..20668d53625ec88ba3eb2a655ad3f6bc
              AABB axisalignedbb = this.getBoundingBox().inflate(10.0D, 10.0D, 10.0D);
              List<Villager> list = world.getEntitiesOfClass(Villager.class, axisalignedbb);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a568910fd892383a1f779e47416da66883d7f9bb..45d022c879111930bf13521659351580283bb6d9 100644
+index 1e4367e3f8236f961e3bd97c74d4c1738b10f25d..96a866e6d9db3a6b727dd46d340dd2316ba768cd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2680,6 +2680,8 @@ public class PurpurWorldConfig {
+@@ -2682,6 +2682,8 @@ public class PurpurWorldConfig {
      public boolean villagerLobotomizeEnabled = false;
      public int villagerLobotomizeCheckInterval = 100;
      public boolean villagerDisplayTradeItem = true;
@@ -30,7 +30,7 @@ index a568910fd892383a1f779e47416da66883d7f9bb..45d022c879111930bf13521659351580
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2715,6 +2717,8 @@ public class PurpurWorldConfig {
+@@ -2717,6 +2719,8 @@ public class PurpurWorldConfig {
          villagerLobotomizeEnabled = getBoolean("mobs.villager.lobotomize.enabled", villagerLobotomizeEnabled);
          villagerLobotomizeCheckInterval = getInt("mobs.villager.lobotomize.check-interval", villagerLobotomizeCheckInterval);
          villagerDisplayTradeItem = getBoolean("mobs.villager.display-trade-item", villagerDisplayTradeItem);

--- a/patches/server/0272-Stonecutter-damage.patch
+++ b/patches/server/0272-Stonecutter-damage.patch
@@ -95,10 +95,10 @@ index 6ae12d6684620a0e524294b28a5abcbc53392089..fec6308aeb99826040fdf5424362b99e
  
      public static boolean advancementOnlyBroadcastToAffectedPlayer = false;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 45d022c879111930bf13521659351580283bb6d9..ab049201286e1d23c5105d5ea271479a0392bf8a 100644
+index 96a866e6d9db3a6b727dd46d340dd2316ba768cd..8688a072f84c5d9edf9292e415c78375ca5f806d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -977,6 +977,11 @@ public class PurpurWorldConfig {
+@@ -979,6 +979,11 @@ public class PurpurWorldConfig {
          spongeAbsorbsLava = getBoolean("blocks.sponge.absorbs-lava", spongeAbsorbsLava);
      }
  

--- a/patches/server/0273-Configurable-damage-settings-for-magma-blocks.patch
+++ b/patches/server/0273-Configurable-damage-settings-for-magma-blocks.patch
@@ -18,10 +18,10 @@ index d3540a4daaa8021ae009bfd4d9ef4f1172ab4c56..2b250439f263f64db7920536ed6eaf64
              entity.hurt(DamageSource.HOT_FLOOR, 1.0F);
              org.bukkit.craftbukkit.event.CraftEventFactory.blockDamage = null; // CraftBukkit
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ab049201286e1d23c5105d5ea271479a0392bf8a..71462ad26d80b85a1bc3eb911868aa793a12ed94 100644
+index 8688a072f84c5d9edf9292e415c78375ca5f806d..e84ac0cfaead0b464dbdd0c9398f8865a9fc5f8f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -913,6 +913,13 @@ public class PurpurWorldConfig {
+@@ -915,6 +915,13 @@ public class PurpurWorldConfig {
          pistonBlockPushLimit = getInt("blocks.piston.block-push-limit", pistonBlockPushLimit);
      }
  

--- a/patches/server/0274-Add-config-for-snow-on-blue-ice.patch
+++ b/patches/server/0274-Add-config-for-snow-on-blue-ice.patch
@@ -22,10 +22,10 @@ index 14e00c7feb1c051d56a3d27cd00dcef072dd771a..4952fb1aaaafb55baa0fddb389f966a1
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 71462ad26d80b85a1bc3eb911868aa793a12ed94..3f217be05e4e6b9a05a198e87a2395a4d3662779 100644
+index e84ac0cfaead0b464dbdd0c9398f8865a9fc5f8f..8c29da006105a8b8e05bc3dd0f9434d865a1b694 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -892,9 +892,11 @@ public class PurpurWorldConfig {
+@@ -894,9 +894,11 @@ public class PurpurWorldConfig {
  
      public boolean mobsSpawnOnPackedIce = true;
      public boolean mobsSpawnOnBlueIce = true;

--- a/patches/server/0276-Skeletons-eat-wither-roses.patch
+++ b/patches/server/0276-Skeletons-eat-wither-roses.patch
@@ -94,10 +94,10 @@ index 51c548cd84bd83624fbff3f853a8050dc1e71ecd..a5ab36fdd0751cb3b96525d53bbaec33
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3f217be05e4e6b9a05a198e87a2395a4d3662779..4adda9fe137b4e419eec3423f5861f242e46e2fb 100644
+index 8c29da006105a8b8e05bc3dd0f9434d865a1b694..bcc78e0407ac414900e1dfed772235934637c722 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2373,6 +2373,7 @@ public class PurpurWorldConfig {
+@@ -2375,6 +2375,7 @@ public class PurpurWorldConfig {
      public boolean skeletonTakeDamageFromWater = false;
      public boolean skeletonAlwaysDropExp = false;
      public double skeletonHeadVisibilityPercent = 0.5D;
@@ -105,7 +105,7 @@ index 3f217be05e4e6b9a05a198e87a2395a4d3662779..4adda9fe137b4e419eec3423f5861f24
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2386,6 +2387,7 @@ public class PurpurWorldConfig {
+@@ -2388,6 +2389,7 @@ public class PurpurWorldConfig {
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
          skeletonHeadVisibilityPercent = getDouble("mobs.skeleton.head-visibility-percent", skeletonHeadVisibilityPercent);

--- a/patches/server/0277-Enchantment-Table-Persists-Lapis.patch
+++ b/patches/server/0277-Enchantment-Table-Persists-Lapis.patch
@@ -146,10 +146,10 @@ index 2341a5a249d455628165fc6ba508fc6d70c3dbfb..4ccb8a7dc4201a7cffa59e4195765001
 +    // Purpur
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4adda9fe137b4e419eec3423f5861f242e46e2fb..3c05d5a38b5833238d974a95a8e92158d8fb5a0d 100644
+index bcc78e0407ac414900e1dfed772235934637c722..acf5b279e9a1e6275d144dcf67a7ba2bdfc24dcb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1394,6 +1394,11 @@ public class PurpurWorldConfig {
+@@ -1396,6 +1396,11 @@ public class PurpurWorldConfig {
          elderGuardianAlwaysDropExp = getBoolean("mobs.elder_guardian.always-drop-exp", elderGuardianAlwaysDropExp);
      }
  

--- a/patches/server/0280-Config-for-sculk-shrieker-can_summon-state.patch
+++ b/patches/server/0280-Config-for-sculk-shrieker-can_summon-state.patch
@@ -18,10 +18,10 @@ index e0998215841e500e5982a242e9f4e646402e1521..11038ba560439dab04c54c31a32d63be
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3c05d5a38b5833238d974a95a8e92158d8fb5a0d..01884d6fe013faa361cf79f1dd27ac9808d00d20 100644
+index acf5b279e9a1e6275d144dcf67a7ba2bdfc24dcb..9cf54670328fe97d689e1629a4dbfd86fb48e315 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -953,6 +953,11 @@ public class PurpurWorldConfig {
+@@ -955,6 +955,11 @@ public class PurpurWorldConfig {
          fixSandDuping = getBoolean("blocks.sand.fix-duping", fixSandDuping);
      }
  

--- a/patches/server/0281-Config-to-not-let-coral-die.patch
+++ b/patches/server/0281-Config-to-not-let-coral-die.patch
@@ -29,10 +29,10 @@ index 88faea00be60a519f56f975a5311df5e1eb3e6b8..cbb726ac367be81e27d3a86643baf7c4
          int i = aenumdirection.length;
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 01884d6fe013faa361cf79f1dd27ac9808d00d20..9c9f0ae1a8b21dedcbaf46af8e605f62ff00731e 100644
+index 9cf54670328fe97d689e1629a4dbfd86fb48e315..a44638d2c8254ca7c09104206334a834f6d81b1f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -801,6 +801,11 @@ public class PurpurWorldConfig {
+@@ -803,6 +803,11 @@ public class PurpurWorldConfig {
          composterBulkProcess = getBoolean("blocks.composter.sneak-to-bulk-process", composterBulkProcess);
      }
  

--- a/patches/server/0296-Add-skeleton-bow-accuracy-option.patch
+++ b/patches/server/0296-Add-skeleton-bow-accuracy-option.patch
@@ -18,10 +18,10 @@ index e542407894f58fb8c0339a7a6d2e7b2cb5891eb4..0cfe5cb3ce0ac8554bbdb68c66583693
          org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), entityarrow.getPickupItem(), entityarrow, net.minecraft.world.InteractionHand.MAIN_HAND, 0.8F, true); // Paper
          if (event.isCancelled()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9548cd7a28d7d7a1b8ad82e05e4fbe48607ceb31..ac9abf47a0acb7181d42f0838c48c78e0a91745c 100644
+index da66ff573bfd96589d57452382bbbc4336b9eb4b..0bec512881748746ed934f57903ab5a5af2fdc05 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2393,6 +2393,8 @@ public class PurpurWorldConfig {
+@@ -2395,6 +2395,8 @@ public class PurpurWorldConfig {
      public boolean skeletonAlwaysDropExp = false;
      public double skeletonHeadVisibilityPercent = 0.5D;
      public int skeletonFeedWitherRoses = 0;
@@ -30,7 +30,7 @@ index 9548cd7a28d7d7a1b8ad82e05e4fbe48607ceb31..ac9abf47a0acb7181d42f0838c48c78e
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2407,6 +2409,18 @@ public class PurpurWorldConfig {
+@@ -2409,6 +2411,18 @@ public class PurpurWorldConfig {
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
          skeletonHeadVisibilityPercent = getDouble("mobs.skeleton.head-visibility-percent", skeletonHeadVisibilityPercent);
          skeletonFeedWitherRoses = getInt("mobs.skeleton.feed-wither-roses", skeletonFeedWitherRoses);

--- a/patches/server/0298-Allay-respect-item-NBT.patch
+++ b/patches/server/0298-Allay-respect-item-NBT.patch
@@ -52,10 +52,10 @@ index c233533fdacb4f5e635267b5fc9fe21bc8b3c51a..4e77bb2be5a35bc6b002e2eae4af4193
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ac9abf47a0acb7181d42f0838c48c78e0a91745c..cdde362f933a385495ab429b92fa5d1516424ce3 100644
+index 0bec512881748746ed934f57903ab5a5af2fdc05..21c830014e4ff5878c26c9a4268562f40114941d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1039,10 +1039,13 @@ public class PurpurWorldConfig {
+@@ -1041,10 +1041,13 @@ public class PurpurWorldConfig {
      public boolean allayRidable = false;
      public boolean allayRidableInWater = false;
      public boolean allayControllable = true;

--- a/patches/server/0303-Implement-squid-colors-for-rainglow-fabric-mod.patch
+++ b/patches/server/0303-Implement-squid-colors-for-rainglow-fabric-mod.patch
@@ -40,10 +40,10 @@ index b7abcaa32341c292f9f884fa6319fd65596e1b37..5d6cddc221887be20ef75d688817dfe5
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index cdde362f933a385495ab429b92fa5d1516424ce3..df0668c1f35c1acca1de7f81c8afaa06c2e21082 100644
+index 21c830014e4ff5878c26c9a4268562f40114941d..a6356d19f0fc664be523f19c2ea1704191a7a73a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1631,6 +1631,7 @@ public class PurpurWorldConfig {
+@@ -1633,6 +1633,7 @@ public class PurpurWorldConfig {
      public boolean glowSquidsCanFly = false;
      public boolean glowSquidTakeDamageFromWater = false;
      public boolean glowSquidAlwaysDropExp = false;
@@ -51,7 +51,7 @@ index cdde362f933a385495ab429b92fa5d1516424ce3..df0668c1f35c1acca1de7f81c8afaa06
      private void glowSquidSettings() {
          glowSquidRidable = getBoolean("mobs.glow_squid.ridable", glowSquidRidable);
          glowSquidControllable = getBoolean("mobs.glow_squid.controllable", glowSquidControllable);
-@@ -1638,6 +1639,7 @@ public class PurpurWorldConfig {
+@@ -1640,6 +1641,7 @@ public class PurpurWorldConfig {
          glowSquidsCanFly = getBoolean("mobs.glow_squid.can-fly", glowSquidsCanFly);
          glowSquidTakeDamageFromWater = getBoolean("mobs.glow_squid.takes-damage-from-water", glowSquidTakeDamageFromWater);
          glowSquidAlwaysDropExp = getBoolean("mobs.glow_squid.always-drop-exp", glowSquidAlwaysDropExp);


### PR DESCRIPTION
This adds the ability to use minimessage tags in an anvil. 
Adds config option `use-mini-message` and permission `purpur.anvil.minimessage`
If a player has `purpur.anvil.color`, and does not have `purpur.anvil.minimessage`, they can still use legacy formatting with `use-mini-message` enabled