### PR TITLE
Fix clickable spark documentation link in timings command

### DIFF
--- a/patches/api/0048-Remove-Timings.patch
+++ b/patches/api/0048-Remove-Timings.patch
@@ -83,7 +83,7 @@ index dd72a34eaa4bedd9ea0b92eaa79091b00eb4dd09..759e9cbcedb50894821dcb6dcc602af4
      }
  
 diff --git a/src/main/java/co/aikar/timings/TimingsCommand.java b/src/main/java/co/aikar/timings/TimingsCommand.java
-index 3132dc98d26c54c5e46162e53aaed195d7335c8d..f744ef6bb38f9fada25720862b83ce37007ce769 100644
+index 3132dc98d26c54c5e46162e53aaed195d7335c8d..b461b5c50f97f11cb9ef68abc520271bb72440fa 100644
 --- a/src/main/java/co/aikar/timings/TimingsCommand.java
 +++ b/src/main/java/co/aikar/timings/TimingsCommand.java
 @@ -44,7 +44,7 @@ public class TimingsCommand extends BukkitCommand {
@@ -101,9 +101,9 @@ index 3132dc98d26c54c5e46162e53aaed195d7335c8d..f744ef6bb38f9fada25720862b83ce37
          }
 +        if (true) {
 +            net.kyori.adventure.text.minimessage.MiniMessage mm = net.kyori.adventure.text.minimessage.MiniMessage.miniMessage();
-+            sender.sendMessage(mm.deserialize("<gold>Purpur has removed timings to save your performance. Please use <grey>/spark</grey> instead"));
++            sender.sendMessage(mm.deserialize("<gold>Purpur has removed timings to save your performance. Please use <click:suggest_command:'/spark'><grey>/spark</grey></click> instead"));
 +            sender.sendMessage(mm.deserialize("<gold>For more information, view its documentation at"));
-+            sender.sendMessage(mm.deserialize("<gold><click:open_url:'url'>https://spark.lucko.me/docs/Command-Usage</click>"));
++            sender.sendMessage(mm.deserialize("<gold><click:open_url:'https://spark.lucko.me/docs/Command-Usage'>https://spark.lucko.me/docs/Command-Usage</click>"));
 +            return true;
 +        }
          if (args.length < 1) {


### PR DESCRIPTION
Title. Makes the link to the spark documentation actually clickable. Also makes the suggested `/spark` command clickable, autofilling it in chat.