### PR TITLE
[ci-skip] Small change to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,11 @@ blank_issues_enabled: false
 contact_links:
   - name: Feature Request
     url: https://github.com/PurpurMC/Purpur/discussions/new?category=feature-requests
+  - name: Exploit Report
+    url: https://purpurmc.org/discord
+    about: |
+      Since GitHub does not allow private issues, exploit reports are currently handled through our Discord.
+      To report an exploit, contact a moderator on the Purpur Discord.
     about: Suggest an idea for Purpur
   - name: Purpur Discord
     url: https://purpurmc.org/discord

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,12 +2,12 @@ blank_issues_enabled: false
 contact_links:
   - name: Feature Request
     url: https://github.com/PurpurMC/Purpur/discussions/new?category=feature-requests
+    about: Suggest an idea for Purpur
   - name: Exploit Report
     url: https://purpurmc.org/discord
     about: |
       Since GitHub does not allow private issues, exploit reports are currently handled through our Discord.
       To report an exploit, contact a moderator on the Purpur Discord.
-    about: Suggest an idea for Purpur
   - name: Purpur Discord
     url: https://purpurmc.org/discord
     about: If you are having issues with Spark profiling or have other minor issues, come join our Discord server for help!


### PR DESCRIPTION
Adds an explanation how to report exploits, just like Paper has. But for our security role/channel system.