### PR TITLE
Creeper encircle target

### DIFF
--- a/patches/server/0312-Add-option-to-allow-creeper-to-encircle-target-when-.patch
+++ b/patches/server/0312-Add-option-to-allow-creeper-to-encircle-target-when-.patch
@@ -5,26 +5,18 @@ Subject: [PATCH] Add option to allow creeper to encircle target when fusing.
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java
-index 8562cbfa258499bc04e5ffbcb4402dfc78ed20c3..eb7c2ee2762ced9025983367dc7188d6bc9ee433 100644
+index 8562cbfa258499bc04e5ffbcb4402dfc78ed20c3..00c89879a4f679d814cb5c381e57bc4d3dc5323b 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java
-@@ -4,6 +4,7 @@ import java.util.EnumSet;
- import javax.annotation.Nullable;
- import net.minecraft.world.entity.LivingEntity;
- import net.minecraft.world.entity.monster.Creeper;
-+import net.minecraft.world.phys.Vec3;
- 
- public class SwellGoal extends Goal {
-     private final Creeper creeper;
-@@ -54,6 +55,14 @@ public class SwellGoal extends Goal {
+@@ -54,6 +54,14 @@ public class SwellGoal extends Goal {
              this.creeper.setSwellDir(-1);
          } else {
              this.creeper.setSwellDir(1);
 +            // Purpur start
 +            if (this.creeper.getLevel().purpurConfig.creeperEncircleTarget) {
-+                Vec3 relative = this.creeper.position().subtract(this.target.position());
++                net.minecraft.world.phys.Vec3 relative = this.creeper.position().subtract(this.target.position());
 +                relative = relative.yRot((float) Math.PI / 3).normalize().multiply(2, 2, 2);
-+                Vec3 destination = this.target.position().add(relative);
++                net.minecraft.world.phys.Vec3 destination = this.target.position().add(relative);
 +                this.creeper.getNavigation().moveTo(destination.x, destination.y, destination.z, 1);
 +            }
 +            // Purpur end

--- a/patches/server/0312-Add-option-to-allow-creeper-to-encircle-target-when-.patch
+++ b/patches/server/0312-Add-option-to-allow-creeper-to-encircle-target-when-.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jared Seville <Peashooter101@yahoo.com>
+Date: Sat, 15 Oct 2022 16:01:03 -0700
+Subject: [PATCH] Add option to allow creeper to encircle target when fusing.
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java
+index 8562cbfa258499bc04e5ffbcb4402dfc78ed20c3..eb7c2ee2762ced9025983367dc7188d6bc9ee433 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/SwellGoal.java
+@@ -4,6 +4,7 @@ import java.util.EnumSet;
+ import javax.annotation.Nullable;
+ import net.minecraft.world.entity.LivingEntity;
+ import net.minecraft.world.entity.monster.Creeper;
++import net.minecraft.world.phys.Vec3;
+ 
+ public class SwellGoal extends Goal {
+     private final Creeper creeper;
+@@ -54,6 +55,14 @@ public class SwellGoal extends Goal {
+             this.creeper.setSwellDir(-1);
+         } else {
+             this.creeper.setSwellDir(1);
++            // Purpur start
++            if (this.creeper.getLevel().purpurConfig.creeperEncircleTarget) {
++                Vec3 relative = this.creeper.position().subtract(this.target.position());
++                relative = relative.yRot((float) Math.PI / 3).normalize().multiply(2, 2, 2);
++                Vec3 destination = this.target.position().add(relative);
++                this.creeper.getNavigation().moveTo(destination.x, destination.y, destination.z, 1);
++            }
++            // Purpur end
+         }
+     }
+ }
+diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+index daa437f3aaebed4d917fde65d75a8a941755a764..7e0e602623fb07894a49f127787ed1066113cffc 100644
+--- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
++++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+@@ -1296,6 +1296,7 @@ public class PurpurWorldConfig {
+     public boolean creeperHealthRadius = false;
+     public boolean creeperAlwaysDropExp = false;
+     public double creeperHeadVisibilityPercent = 0.5D;
++    public boolean creeperEncircleTarget = false;
+     private void creeperSettings() {
+         creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
+         creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
+@@ -1314,6 +1315,7 @@ public class PurpurWorldConfig {
+         creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
+         creeperAlwaysDropExp = getBoolean("mobs.creeper.always-drop-exp", creeperAlwaysDropExp);
+         creeperHeadVisibilityPercent = getDouble("mobs.creeper.head-visibility-percent", creeperHeadVisibilityPercent);
++        creeperEncircleTarget = getBoolean("mobs.creeper.creeper-encircle-target", creeperEncircleTarget);
+     }
+ 
+     public boolean dolphinRidable = false;

--- a/patches/server/0312-Add-option-to-allow-creeper-to-encircle-target-when-.patch
+++ b/patches/server/0312-Add-option-to-allow-creeper-to-encircle-target-when-.patch
@@ -32,10 +32,10 @@ index 8562cbfa258499bc04e5ffbcb4402dfc78ed20c3..eb7c2ee2762ced9025983367dc7188d6
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index daa437f3aaebed4d917fde65d75a8a941755a764..7e0e602623fb07894a49f127787ed1066113cffc 100644
+index 33d7c132b19095598eb681da8487a072f1dccab6..c7f0fba9d3d5415e7965501774feaf12d7b1b3a6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1296,6 +1296,7 @@ public class PurpurWorldConfig {
+@@ -1291,6 +1291,7 @@ public class PurpurWorldConfig {
      public boolean creeperHealthRadius = false;
      public boolean creeperAlwaysDropExp = false;
      public double creeperHeadVisibilityPercent = 0.5D;
@@ -43,7 +43,7 @@ index daa437f3aaebed4d917fde65d75a8a941755a764..7e0e602623fb07894a49f127787ed106
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1314,6 +1315,7 @@ public class PurpurWorldConfig {
+@@ -1309,6 +1310,7 @@ public class PurpurWorldConfig {
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
          creeperAlwaysDropExp = getBoolean("mobs.creeper.always-drop-exp", creeperAlwaysDropExp);
          creeperHeadVisibilityPercent = getDouble("mobs.creeper.head-visibility-percent", creeperHeadVisibilityPercent);


### PR DESCRIPTION
Add the option to allow creepers to encircle their target when they are fusing (charging to explode).