### PR TITLE
Add option to fix creative mode actions with NetworkItemSerializeEvent

### DIFF
--- a/patches/server/0289-Add-item-packet-serialize-event.patch
+++ b/patches/server/0289-Add-item-packet-serialize-event.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add item packet serialize event
 
 
 diff --git a/src/main/java/net/minecraft/network/FriendlyByteBuf.java b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
-index 32ee4ed11aefd82dca2e3e78b3108f041fdc3695..314318a21b6fa9e827945d8996c6ed0f9679a4eb 100644
+index 32ee4ed11aefd82dca2e3e78b3108f041fdc3695..bbbb6a15c9351c4276ef8df85508fd263f40c610 100644
 --- a/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 +++ b/src/main/java/net/minecraft/network/FriendlyByteBuf.java
 @@ -89,6 +89,8 @@ public class FriendlyByteBuf extends ByteBuf {
@@ -17,7 +17,7 @@ index 32ee4ed11aefd82dca2e3e78b3108f041fdc3695..314318a21b6fa9e827945d8996c6ed0f
      public FriendlyByteBuf(ByteBuf parent) {
          this.source = parent;
      }
-@@ -632,6 +634,13 @@ public class FriendlyByteBuf extends ByteBuf {
+@@ -632,6 +634,17 @@ public class FriendlyByteBuf extends ByteBuf {
              this.writeBoolean(false);
          } else {
              this.writeBoolean(true);
@@ -25,14 +25,18 @@ index 32ee4ed11aefd82dca2e3e78b3108f041fdc3695..314318a21b6fa9e827945d8996c6ed0f
 +            if (hasItemSerializeEvent) {
 +                var event = new org.purpurmc.purpur.event.packet.NetworkItemSerializeEvent(stack.asBukkitCopy());
 +                event.callEvent();
-+                stack = ItemStack.fromBukkitCopy(event.getItemStack());
++                ItemStack newStack = ItemStack.fromBukkitCopy(event.getItemStack());
++                if (org.purpurmc.purpur.PurpurConfig.fixNetworkSerializedItemsInCreative && !ItemStack.matches(stack, newStack)) {
++                    stack.save(newStack.getOrCreateTagElement("Purpur.OriginalItem"));
++                }
++                stack = newStack;
 +            }
 +            // Purpur end
              Item item = stack.getItem();
  
              this.writeId(BuiltInRegistries.ITEM, item);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0aeb570d86bbfd2d056bf9630e8ccaeefd9d5306..cea4447aad2d64db56a76e4ba180dc7326d2e13b 100644
+index 55225d763a737b3859c2e7d6dbd19e5afc16438c..1772800c123353207e3563a7e2c2b70431aec097 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1537,6 +1537,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -43,3 +47,34 @@ index 0aeb570d86bbfd2d056bf9630e8ccaeefd9d5306..cea4447aad2d64db56a76e4ba180dc73
          Iterator iterator = this.getAllLevels().iterator(); // Paper - move down
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 6f5b98ecae60a34284d9679e95bb2ff85567b5bc..f5e1361c04d44ae7f82376aff6e5f01aaf45cfdd 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -3422,6 +3422,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+                     }
+                 }
+             }
++            // Purpur start
++            if (org.purpurmc.purpur.PurpurConfig.fixNetworkSerializedItemsInCreative) {
++                var tag = itemstack.getTagElement("Purpur.OriginalItem");
++                if (tag != null) itemstack = ItemStack.of(tag);
++            }
++            // Purpur end
+ 
+             boolean flag1 = packet.getSlotNum() >= 1 && packet.getSlotNum() <= 45;
+             boolean flag2 = itemstack.isEmpty() || itemstack.getDamageValue() >= 0 && itemstack.getCount() <= 64 && !itemstack.isEmpty();
+diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+index fa038cec55c710f7734df91f9dcb1c49739e5b33..9fa57073a7525e9f251c0eb6872d557a5bc38ab7 100644
+--- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
++++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+@@ -549,4 +549,9 @@ public class PurpurConfig {
+             }
+         });
+     }
++
++    public static boolean fixNetworkSerializedItemsInCreative = false;
++    private static void fixNetworkSerializedCreativeItems() {
++        fixNetworkSerializedItemsInCreative = getBoolean("settings.fix-network-serialized-items-in-creative", fixNetworkSerializedItemsInCreative);
++    }
+ }

--- a/patches/server/0292-Add-an-option-to-fix-MC-3304-projectile-looting.patch
+++ b/patches/server/0292-Add-an-option-to-fix-MC-3304-projectile-looting.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add an option to fix MC-3304 (projectile looting)
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index 9da08e020b4e85bc47423c3b91afbed6a11f87bb..3f8e10c33e0f8739602f8327da3a8f66318c5c94 100644
+index 782cbfc41bcee3b2e890739a6f117904096acf27..ed6a097aa1319e492ff56974fd259c227995523e 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 @@ -72,6 +72,7 @@ public abstract class AbstractArrow extends Projectile {
@@ -104,12 +104,12 @@ index 31918fa2eb38e42a5ea5366e559f25ea9d7d59ae..15d8e9261a89da30529ac347462c5209
              if (context.hasParam(LootContextParams.LOOTING_MOD)) {
                  i = context.getParamOrNull(LootContextParams.LOOTING_MOD);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index fa038cec55c710f7734df91f9dcb1c49739e5b33..f32daa913a2aaa99fd9a021ee3ace02d7a814277 100644
+index 9fa57073a7525e9f251c0eb6872d557a5bc38ab7..29bc829c61c907b8793ae15b65f5e4cb4d099df3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -549,4 +549,9 @@ public class PurpurConfig {
-             }
-         });
+@@ -554,4 +554,9 @@ public class PurpurConfig {
+     private static void fixNetworkSerializedCreativeItems() {
+         fixNetworkSerializedItemsInCreative = getBoolean("settings.fix-network-serialized-items-in-creative", fixNetworkSerializedItemsInCreative);
      }
 +
 +    public static boolean fixProjectileLootingTransfer = false;

--- a/patches/server/0293-Configurable-block-blast-resistance.patch
+++ b/patches/server/0293-Configurable-block-blast-resistance.patch
@@ -44,10 +44,10 @@ index ec6c63075306f9e5389e83641d2c8a82369ddc6b..0f16deddd8cbb506ef7886f57ae640a4
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index f32daa913a2aaa99fd9a021ee3ace02d7a814277..24fc48aeceb0f00517e5b0e37292749445ba03d7 100644
+index 29bc829c61c907b8793ae15b65f5e4cb4d099df3..e91e6c43197b52d6e29779959df066c991d425a1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -554,4 +554,19 @@ public class PurpurConfig {
+@@ -559,4 +559,19 @@ public class PurpurConfig {
      private static void fixProjectileLootingTransfer() {
          fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
      }

--- a/patches/server/0294-Configurable-block-fall-damage-modifiers.patch
+++ b/patches/server/0294-Configurable-block-fall-damage-modifiers.patch
@@ -54,10 +54,10 @@ index c316fb1d3081c1fbf4602dd72e96e57491bc8efd..3b054f2bda6fae31e8ab7bce088e228f
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 24fc48aeceb0f00517e5b0e37292749445ba03d7..933feef6f2dd26ffc8857d1b6689f07032a48a34 100644
+index e91e6c43197b52d6e29779959df066c991d425a1..d0b8a589223e9112bd39c847cbf27678d0701eed 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -569,4 +569,50 @@ public class PurpurConfig {
+@@ -574,4 +574,50 @@ public class PurpurConfig {
              block.explosionResistance = blastResistance.floatValue();
          });
      }

--- a/patches/server/0307-Add-attribute-clamping-and-armor-limit-config.patch
+++ b/patches/server/0307-Add-attribute-clamping-and-armor-limit-config.patch
@@ -36,10 +36,10 @@ index f0703302e7dbbda88de8c648d20d87c55ed9b1e0..a913ebabaa5f443afa987b972355a8f8
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 4df21419fb4a25865f921f2aa7f8d4aa7a5dbb06..c7c0ed8dfe58c841faf684a1fe228eeda6cd57b7 100644
+index 4f8e65aaa424bea999d7db49fd036821622fb674..3e6d3b71931a18263eff11841cb4e916ba44e1b8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -560,6 +560,16 @@ public class PurpurConfig {
+@@ -565,6 +565,16 @@ public class PurpurConfig {
          fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
      }
  


### PR DESCRIPTION
Currently in creative mode, items modified by NetworkItemSerializeEvent will persist even though they're client-sided due to the creative client using creative inventory actions. This pull request fixes that by adding a configuration options to send an additional item tag that stores the original unmodified item (that doesn't exist in the server item). When the creative player sends a creative inventory action to create the item with the tag, the server will convert it to the item stored in the tag.