### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group = org.purpurmc.purpur
 version = 1.19.2-R0.1-SNAPSHOT
 
-paperCommit = 1c1aeb20e27d4be5134f0abeec45916cfc6952b0
+paperCommit = 25cd3eee99a96b360ab947fb78459045f29b2b78
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/patches/server/0001-Pufferfish-Server-Changes.patch
+++ b/patches/server/0001-Pufferfish-Server-Changes.patch
@@ -113,7 +113,7 @@ index 7b1843e16745ca8db2244e17490d291401f22679..061716934ba0a1f01e4d85d664034f72
                  metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {
                      Map<String, Map<String, Integer>> map = new HashMap<>();
 diff --git a/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java b/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
-index c89f6986eda5a132a948732ea1b6923370685317..a69c13e20040c1561d9c2d4d89ec7d4e635134fc 100644
+index 41b9405d6759d865e0d14dd4f95163e9690e967d..091b1ae822e1c0517e59572e7a9bda11e998c0ee 100644
 --- a/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
 +++ b/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
 @@ -26,7 +26,7 @@ public abstract class AreaMap<E> {
@@ -1459,11 +1459,11 @@ index 63ec2ebb71aa0e0dbb64bbce7cd3c9494e9ce2e7..d03551e81e3ef37935cb1d963aba3df3
              MinecraftTimings.processConfig(this);
          }
      }
-diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 13082cd8de1a79a3b2fac6055bdaa163dbc7897b..0d995a13114e718016518f41d7fcff3042674847 100644
---- a/src/main/java/net/minecraft/server/MCUtil.java
-+++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -208,7 +208,7 @@ public final class MCUtil {
+diff --git a/src/main/java/io/papermc/paper/util/MCUtil.java b/src/main/java/io/papermc/paper/util/MCUtil.java
+index e63dc33250831428c2cef34e02238600231fb815..c8f7aa9e0794713724e1053581c220aa95f1bc90 100644
+--- a/src/main/java/io/papermc/paper/util/MCUtil.java
++++ b/src/main/java/io/papermc/paper/util/MCUtil.java
+@@ -209,7 +209,7 @@ public final class MCUtil {
      }
  
      public static long getCoordinateKey(final Entity entity) {
@@ -1473,7 +1473,7 @@ index 13082cd8de1a79a3b2fac6055bdaa163dbc7897b..0d995a13114e718016518f41d7fcff30
  
      public static long getCoordinateKey(final ChunkPos pair) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ce81ba5345c8d2fde8a2534b9673275c7e86af8b..af9da39dffda01325af2ab3dd8b5e1efb18e013a 100644
+index 6dc6c3bccb4ba34268a87b0754c87eb1e0df4135..409a544a8cefcfd139bff9b5016fb7a587568a70 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -298,6 +298,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -1503,7 +1503,7 @@ index ce81ba5345c8d2fde8a2534b9673275c7e86af8b..af9da39dffda01325af2ab3dd8b5e1ef
      }
  
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 2932d2bb797a49e904cebec4285d24d69b429cd9..d4efadbc87ee0b6cb8564c57fc9dcbb48367a767 100644
+index ff3eced0e20c39b825586897ee2fed01dd471d88..5c54a5da7fb50cd97799c5fa280a24d5c6117244 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -226,6 +226,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -1524,7 +1524,7 @@ index 2932d2bb797a49e904cebec4285d24d69b429cd9..d4efadbc87ee0b6cb8564c57fc9dcbb4
          }
      }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 971405224418fee037030a4c465b5f4bb9cd2c3b..9ce60dd72dee4d3ceef38f425b13aed18fd5e002 100644
+index 9ad7c417616e68b1d14a702aca38b2582feb896c..2e811de518dbc63e791508d060c9db64de48fdbb 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -334,7 +334,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1576,7 +1576,7 @@ index 971405224418fee037030a4c465b5f4bb9cd2c3b..9ce60dd72dee4d3ceef38f425b13aed1
              return this.scaledRange(i);
          }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 6d1f929eb717f62f0d7ebb9e9b52c3788061e240..7266e6703d5cd0fea90ec88c74a7d4567f2420ae 100644
+index be97d38f45046a7f6d2337d879651f04cf9ff825..0b75caca3f77980505d0689601d920fb50f7ac4d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -75,6 +75,9 @@ public class ServerChunkCache extends ChunkSource {
@@ -1692,7 +1692,7 @@ index 3b144c820531122eb37d41be06c182b5f5dc0724..1eb912ad97f9663bf6bd336ad739f255
                          this.wasOnGround = this.entity.isOnGround();
                          this.teleportDelay = 0;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f1a1c58fd70610c7fe29d5890cdf161346f34cb9..e802ee2b2dc458f52dbce9746fc9891eebb6dcc1 100644
+index 8b3e703ebb497b9166bd211b4247a78891b61aeb..94f4a5bfd2af8389a99f80bab4eceac1f075512e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -727,7 +727,20 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1881,7 +1881,7 @@ index 540bc9500c35c0db719b00aa26f6fb3a1b08ed9f..806cb760822a99316b08ad95ff8922df
      int LARGE_MAX_STACK_SIZE = 64;
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a1421689445b9df3f25889845c21cf37a439afe2..d96422f871c18303ce7ff7a182c685b0ddbfa04d 100644
+index f2908cf61ff28bef44fcf46b15cf585e942fd7ce..23ef9124bada519ab5ea3869b97d96679ad8f689 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -291,7 +291,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -2074,7 +2074,7 @@ index a1421689445b9df3f25889845c21cf37a439afe2..d96422f871c18303ce7ff7a182c685b0
              if (vec3d.length() > 0.0D) {
                  if (k1 > 0) {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
-index 12cf4d3dfbd2c4f4a1815f5e26e59ae8667f7b47..bbe9568b8df69f5f1ef08dc02dc8ee6a5c63f13c 100644
+index 72516335570d7137a62ec8667a6e8f06f024692f..b44322c337bcded94c60e1761a3891013ae1dd1a 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityType.java
 @@ -305,6 +305,8 @@ public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T> {
@@ -2800,7 +2800,7 @@ index 468c635d31cfa8051666bbefce8df4b448e9ed93..17e869074b8cf29a8c3280499a27e951
          final String id;
          private final GameRules.Category category;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index d89471935b2b5888cb5d1f6829ae479003451fda..0277633fd328ef9993fea4ac29df83b5b00c0f42 100644
+index 596fb8ee21ba8450db13a11890d241ef3974d81d..791411866cabc2c237f40d54250d5a34653ceaa0 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -271,6 +271,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -2952,7 +2952,7 @@ index d89471935b2b5888cb5d1f6829ae479003451fda..0277633fd328ef9993fea4ac29df83b5
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index df83b6f0e217eec4c9e9707be0030c129fdeb545..386ed2c102aaa3ec68e828e20fff6bfe0d8f7877 100644
+index 272bdc088f440cf94850dff6e626331b4b5d6539..eceae1230e672d95491405f3f7c550c90ea9b138 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -415,12 +415,12 @@ public final class NaturalSpawner {
@@ -3234,7 +3234,7 @@ index d559f93a9a09bac414dd5d58afccad42c127f09b..13e749a3c40f0b2cc002f13675a9a56e
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 258d00692fa50e0932747a7a2f0ddae5ab659040..f5adadb2e29ed8b52a502489ba06df4551cd06dc 100644
+index 7350b73f4af4ae347532dc579ab151447c298e09..05f9a828e7c243520b87a77fb34598709aa3525b 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -88,6 +88,18 @@ public class LevelChunk extends ChunkAccess {
@@ -3506,7 +3506,7 @@ index b1992ed5136cc7dcf04219868b94b3c37ae36b4b..5b5339cba819368f4d6b7eaf404fa59b
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 111f8276f26350a5c62a7b8577b4598978b5355d..b8efe50c860a7537f345f46f3b3d68906ad54006 100644
+index 4212568bf8de6988c71f43d3e2152fa0fe51d0d7..85d94f47792bbd63c4c4ee8fa4a88abc4c440286 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -248,7 +248,7 @@ import javax.annotation.Nullable; // Paper

--- a/patches/server/0079-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
+++ b/patches/server/0079-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
@@ -39,19 +39,11 @@ diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/ma
 index 8401577ee010c211c99c174bc70536d606a09b1d..500b702e2d2b6ba4df07d1fb3e85d632feece76c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -44,6 +44,7 @@ import net.minecraft.network.syncher.EntityDataAccessor;
- import net.minecraft.network.syncher.EntityDataSerializers;
- import net.minecraft.network.syncher.SynchedEntityData;
- import net.minecraft.resources.ResourceLocation;
-+import net.minecraft.server.MCUtil;
- import net.minecraft.server.level.ServerChunkCache;
- import net.minecraft.server.level.ServerLevel;
- import net.minecraft.server.level.ServerPlayer;
 @@ -411,6 +412,7 @@ public abstract class LivingEntity extends Entity {
                      double d1 = this.level.getWorldBorder().getDamagePerBlock();
  
                      if (d1 > 0.0D) {
-+                        if (level.purpurConfig.teleportIfOutsideBorder && this instanceof ServerPlayer) { ((ServerPlayer) this).teleport(MCUtil.toLocation(level, ((ServerLevel) level).getSharedSpawnPos())); return; } // Purpur
++                        if (level.purpurConfig.teleportIfOutsideBorder && this instanceof ServerPlayer) { ((ServerPlayer) this).teleport(io.papermc.paper.util.MCUtil.toLocation(level, ((ServerLevel) level).getSharedSpawnPos())); return; } // Purpur
                          this.hurt(DamageSource.IN_WALL, (float) Math.max(1, Mth.floor(-d0 * d1)));
                      }
                  }

--- a/patches/server/0135-Fix-stuck-in-portals.patch
+++ b/patches/server/0135-Fix-stuck-in-portals.patch
@@ -12,7 +12,7 @@ index a82c8bf74a943adfd7ccf16b1c8787c31af060e6..83ab6eb805c5d6f2fff9da91e4e0d74f
                  playerlist.sendPlayerPermissionLevel(this);
                  worldserver1.removePlayerImmediately(this, Entity.RemovalReason.CHANGED_DIMENSION);
                  this.unsetRemoved();
-+                this.portalPos = net.minecraft.server.MCUtil.toBlockPosition(exit); // Purpur
++                this.portalPos = io.papermc.paper.util.MCUtil.toBlockPosition(exit); // Purpur
  
                  // CraftBukkit end
                  this.setLevel(worldserver);

--- a/patches/server/0277-Enchantment-Table-Persists-Lapis.patch
+++ b/patches/server/0277-Enchantment-Table-Persists-Lapis.patch
@@ -103,7 +103,7 @@ index f4ee3ce287528337a0f9a3b612c157254f895a58..37a888e5db65b927094b43775ae9d409
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/EnchantmentTableBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/EnchantmentTableBlockEntity.java
-index 2341a5a249d455628165fc6ba508fc6d70c3dbfb..4ccb8a7dc4201a7cffa59e419576500189042ac6 100644
+index 65e1381bb2d10bd212463feb602c60f8fdb9ade1..b7370e64fd0d50e8725d7d5afc30af2e8bc8455d 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/EnchantmentTableBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/EnchantmentTableBlockEntity.java
 @@ -24,6 +24,7 @@ public class EnchantmentTableBlockEntity extends BlockEntity implements Nameable
@@ -124,7 +124,7 @@ index 2341a5a249d455628165fc6ba508fc6d70c3dbfb..4ccb8a7dc4201a7cffa59e4195765001
  
 @@ -44,6 +46,7 @@ public class EnchantmentTableBlockEntity extends BlockEntity implements Nameable
          if (nbt.contains("CustomName", 8)) {
-             this.name = net.minecraft.server.MCUtil.getBaseComponentFromNbt("CustomName", nbt); // Paper - Catch ParseException
+             this.name = io.papermc.paper.util.MCUtil.getBaseComponentFromNbt("CustomName", nbt); // Paper - Catch ParseException
          }
 +        this.lapis = nbt.getInt("Purpur.Lapis"); // Purpur
  

--- a/patches/server/0282-Add-local-difficulty-api.patch
+++ b/patches/server/0282-Add-local-difficulty-api.patch
@@ -14,7 +14,7 @@ index 72ed25022d5ea1074304be3c72b23882b8f0f88a..68eb990c7d461c611310419c1eefaed7
  
 +    // Purpur start
 +    public float getLocalDifficultyAt(Location location) {
-+        return getHandle().getCurrentDifficultyAt(net.minecraft.server.MCUtil.toBlockPosition(location)).getEffectiveDifficulty();
++        return getHandle().getCurrentDifficultyAt(io.papermc.paper.util.MCUtil.toBlockPosition(location)).getEffectiveDifficulty();
 +    }
 +    // Purpur end
 +

--- a/patches/server/0288-Remove-Timings.patch
+++ b/patches/server/0288-Remove-Timings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove Timings
 
 
 diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java
-index 8dc1d2d15d571d1603a41dee13681a87841f5e23..54ec7955ba394e82663b08972dd89f69a23593ac 100644
+index e5d9c6f2cbe11c2ded6d8ad111fa6a8b2086dfba..830d863cd9665d58875bfa5ca2bcd22f89ab2d49 100644
 --- a/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java
 +++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/ChunkHolderManager.java
-@@ -901,9 +901,9 @@ public final class ChunkHolderManager {
+@@ -915,9 +915,9 @@ public final class ChunkHolderManager {
      }
  
      public boolean processTicketUpdates() {
@@ -21,10 +21,10 @@ index 8dc1d2d15d571d1603a41dee13681a87841f5e23..54ec7955ba394e82663b08972dd89f69
  
      private static final ThreadLocal<List<ChunkProgressionTask>> CURRENT_TICKET_UPDATE_SCHEDULING = new ThreadLocal<>();
 diff --git a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
-index 4ce6df7082d4f7ed3651e3d57e379f95dd05715e..cfc355829df3e5b51c2ff524bb3730360fee15a2 100644
+index 8013dd333e27aa5fd0beb431fa32491eec9f5246..e42eb93fd9f6f51ff5bb4b14a2304d4ffcdd8441 100644
 --- a/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
 +++ b/src/main/java/io/papermc/paper/chunk/system/scheduling/NewChunkHolder.java
-@@ -1748,7 +1748,7 @@ public final class NewChunkHolder {
+@@ -1750,7 +1750,7 @@ public final class NewChunkHolder {
          boolean canSavePOI = !(chunk instanceof LevelChunk levelChunk && levelChunk.mustNotSave) && (poi != null && poi.isDirty());
          boolean canSaveEntities = entities != null;
  
@@ -33,14 +33,14 @@ index 4ce6df7082d4f7ed3651e3d57e379f95dd05715e..cfc355829df3e5b51c2ff524bb373036
              if (canSaveChunk) {
                  canSaveChunk = this.saveChunk(chunk, unloading);
              }
-@@ -1762,7 +1762,7 @@ public final class NewChunkHolder {
+@@ -1764,7 +1764,7 @@ public final class NewChunkHolder {
                      this.lastEntityUnload = null;
                  }
              }
 -        }
 +        //} // Purpur
  
-         return executedUnloadTask | canSaveChunk | canSaveEntities | canSavePOI;
+         return executedUnloadTask | canSaveChunk | canSaveEntities | canSavePOI ? new SaveStat(executedUnloadTask || canSaveChunk, canSaveEntities, canSavePOI): null;
      }
 diff --git a/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java b/src/main/java/io/papermc/paper/configuration/GlobalConfiguration.java
 index d03551e81e3ef37935cb1d963aba3df316f48ef5..04ca6d27a13706fbddc708df0fcca42b4098bcba 100644
@@ -88,7 +88,7 @@ index 8bc0cb9ad5bb4e76d962ff54305e2c08e279a17b..e8efbbeece7e866c6c4d7489677d2d9e
                      PacketUtils.LOGGER.debug("Ignoring packet due to disconnection: {}", packet);
                  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index bc80783d36d46fb138bfa6f2e5e84679db0a68c1..7063ef7d547714d6647290e36da3a07b3b946871 100644
+index 13d86c1fba2377808a5ef1e2820db445383af156..8569938bfc2b71ea32301ad78f64e5017149f5d7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1408,15 +1408,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -249,7 +249,7 @@ index 00a50196f6a4768d84acfbbeec79a0753308f091..30093cd8bd35f0bbc8f26eca370622ee
                  i = this.context.runTopCommand(function, source);
              } finally {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 96c51b1f5103567c29d7da93f654cc5ddfea6a4d..c8b068ab73c8997fbd07e27ccd2dff77fef6bfe1 100644
+index cd04f57fee33097a45bcf670c25c6baf9b76851c..8b8655300fa81de8352dfec92c088f4f45511f21 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -523,7 +523,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -271,7 +271,7 @@ index 96c51b1f5103567c29d7da93f654cc5ddfea6a4d..c8b068ab73c8997fbd07e27ccd2dff77
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 9976630fad886392057f642e84f919f0b95cc040..91640a6f9770eeb300e0d56d8fe93264c087f0be 100644
+index 8d19dcf7a91d1e9c17d03e6e339885d99647ec92..6d819e330f55ddf7e2ccf2f615543f4c9eca1f71 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -608,15 +608,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -354,7 +354,7 @@ index 9976630fad886392057f642e84f919f0b95cc040..91640a6f9770eeb300e0d56d8fe93264
  
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 7266e6703d5cd0fea90ec88c74a7d4567f2420ae..157efbbc57f1b5d92f296a70823c75b6d01ac065 100644
+index 0b75caca3f77980505d0689601d920fb50f7ac4d..2af21158dfb44a49f15c07d765a09335f76ed3dd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -449,10 +449,10 @@ public class ServerChunkCache extends ChunkSource {
@@ -477,7 +477,7 @@ index 7266e6703d5cd0fea90ec88c74a7d4567f2420ae..157efbbc57f1b5d92f296a70823c75b6
              // Paper end - use set of chunks requiring updates, rather than iterating every single one loaded
              // Paper start - controlled flush for entity tracker packets
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index a1af2d00d03e3326f6acd46dfaa6cdafac841727..4ced6723e65b84f7357acb54e9851e7af3347f11 100644
+index 71ff2cfc4aba6da71911ea717e3557647c41c210..550c3566b14aace0dbd4e77876abc2bb663bcf5c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -686,7 +686,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -687,13 +687,13 @@ index 799c279e63f23227cb473f7828aeaf7afb0de355..3503b7defe826db564370dbab78a8c91
      }
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ae888c565e39fab22224cba96a0d8836a747738a..3fb2323c89d04f1a545897a1e67f6f637f5ab9c1 100644
+index eb3d0956a43f96d495ce6712f413e84acbc0fa1c..755d15af7cc0e47c1700db55f51e8169a521bfb8 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1287,7 +1287,7 @@ public abstract class PlayerList {
  
      public void saveAll(int interval) {
-         net.minecraft.server.MCUtil.ensureMain("Save Players" , () -> { // Paper - Ensure main
+         io.papermc.paper.util.MCUtil.ensureMain("Save Players" , () -> { // Paper - Ensure main
 -        MinecraftTimings.savePlayers.startTiming(); // Paper
 +        //MinecraftTimings.savePlayers.startTiming(); // Paper // Purpur
          int numSaved = 0;
@@ -758,7 +758,7 @@ index fcdb9bde8e1605e30dde3e580491522d4b62cdc0..7094701d213c73ba47ace806962244c1
  
      }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 0c9f7f9ed3e24ddc6b963063723feb56422843c5..93711ef7df591ab0f50b8f0f7798f938eeb0f3b3 100644
+index 09ae98db728bade8121587e9ded6f3ab98f3bb30..5e3acd365d9aca4271a590564e3eaad0d268bf11 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -994,15 +994,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -790,7 +790,7 @@ index 0c9f7f9ed3e24ddc6b963063723feb56422843c5..93711ef7df591ab0f50b8f0f7798f938
          co.aikar.timings.TimingHistory.tileEntityTicks += this.blockEntityTickers.size(); // Paper
          gameprofilerfiller.pop();
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 386ed2c102aaa3ec68e828e20fff6bfe0d8f7877..c1541119630315521e75c1ba70ac99cd866afd71 100644
+index eceae1230e672d95491405f3f7c550c90ea9b138..724f034d92f9f3f1021802e2bc2a845146c45efa 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -132,7 +132,7 @@ public final class NaturalSpawner {
@@ -812,7 +812,7 @@ index 386ed2c102aaa3ec68e828e20fff6bfe0d8f7877..c1541119630315521e75c1ba70ac99cd
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index b89dad36bf09fdab340efc83d09992b707cd321a..994ef28e4ad685405a2b045e29550563b0914ccc 100644
+index d9638971ac4d8dfaf4351cebb5ff6ea16327091e..434e33aa5c1c9722ea065627f1559c833954a342 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -930,7 +930,7 @@ public class LevelChunk extends ChunkAccess {
@@ -833,7 +833,7 @@ index b89dad36bf09fdab340efc83d09992b707cd321a..994ef28e4ad685405a2b045e29550563
              }
          }
      }
-@@ -1295,7 +1295,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -1312,7 +1312,7 @@ public class LevelChunk extends ChunkAccess {
                          ProfilerFiller gameprofilerfiller = LevelChunk.this.level.getProfiler();
  
                          gameprofilerfiller.push(this::getType);
@@ -842,7 +842,7 @@ index b89dad36bf09fdab340efc83d09992b707cd321a..994ef28e4ad685405a2b045e29550563
                          BlockState iblockdata = LevelChunk.this.getBlockState(blockposition);
  
                          if (this.blockEntity.getType().isValid(iblockdata)) {
-@@ -1317,7 +1317,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -1334,7 +1334,7 @@ public class LevelChunk extends ChunkAccess {
                          // Paper end
                          // Spigot start
                      } finally {

--- a/patches/server/0289-Remove-Mojang-Profiler.patch
+++ b/patches/server/0289-Remove-Mojang-Profiler.patch
@@ -39,7 +39,7 @@ index edd378813873ed367784379b0f1666d1ccf2194d..eb4dac2239592d680ef31edf47f1ab66
  
          return b0;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7063ef7d547714d6647290e36da3a07b3b946871..60bed3f87016b29508ea1a94db65a1f60d960de1 100644
+index 8569938bfc2b71ea32301ad78f64e5017149f5d7..0168d31480ded035584157c747f60df7f712f250 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -328,13 +328,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -371,7 +371,7 @@ index 30093cd8bd35f0bbc8f26eca370622ee12a046b6..2986f110348b376bcdc64fa39b688855
  
                  ++j;
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 91640a6f9770eeb300e0d56d8fe93264c087f0be..5258688cf1c980b95308b6d105dbf104b0276932 100644
+index 6d819e330f55ddf7e2ccf2f615543f4c9eca1f71..2182ee049defee88067aa61cee42d3a0122061b7 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -606,20 +606,20 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -400,7 +400,7 @@ index 91640a6f9770eeb300e0d56d8fe93264c087f0be..5258688cf1c980b95308b6d105dbf104
  
      public boolean hasWork() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 157efbbc57f1b5d92f296a70823c75b6d01ac065..cd5533c3c53215c9cc4be0b9097d76efbf5bd0c1 100644
+index 2af21158dfb44a49f15c07d765a09335f76ed3dd..9d13ef8c597b9ca11280ad1d3249d13bbab4ac6f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -430,16 +430,16 @@ public class ServerChunkCache extends ChunkSource {
@@ -538,7 +538,7 @@ index 157efbbc57f1b5d92f296a70823c75b6d01ac065..cd5533c3c53215c9cc4be0b9097d76ef
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4ced6723e65b84f7357acb54e9851e7af3347f11..d418144bc7471b2c00ad272652b035d79974ef75 100644
+index 550c3566b14aace0dbd4e77876abc2bb663bcf5c..c888e654ab9449bfdc7dfe16078eb0786ae6c15e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -653,12 +653,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -754,7 +754,7 @@ index 4ced6723e65b84f7357acb54e9851e7af3347f11..d418144bc7471b2c00ad272652b035d7
  
                  while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 450363d62b3d8c4bd97de46ca481fd22921863bc..4b0b9bb2fda98c51852cb5d503f217f4cda8580b 100644
+index 99ae8f9179a85d11abc797cdf3e5a9846082d82e..2f6bb9c37818824779170c784132673d43b70979 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1157,7 +1157,7 @@ public class ServerPlayer extends Player {
@@ -1013,7 +1013,7 @@ index 5725c6593480fada65facc29664a00a8cc073512..ccb1f998ae3122d1856d77149ff7e7df
              };
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0ffaccb3e6ae2a400f1def283b62024e8bfc05e4..bef8f4d080fb6067f87b9df986ac33f7003c2a84 100644
+index cd97d28e85a6795099ec314e9574aa413ff93156..30cbbdd312d7cc34db7b281524adb5aa7563746b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -821,7 +821,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -1408,7 +1408,7 @@ index 0cc0d719e95e108263683b7a40f4ce3a8ca9465b..872ec431ae6beb0ef603d833f38aedb9
  
      public Set<WrappedGoal> getAvailableGoals() {
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index c1781c92ff59f0c9eb47cbbef01e3252c5e1a1bf..c06057cf9609e001f4512c247f355ded0ff2e8ce 100644
+index 1d9d502e071324f50c8b7655790091c0c55263ba..2289ebc669078e8db054a0ecf7092b736bb99f12 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 @@ -170,12 +170,12 @@ public abstract class PathNavigation {
@@ -1682,7 +1682,7 @@ index 01477e7240f9e33d08d416a7d40ee10f3e5d4abf..c9def2202d7c2a523858ec124df2beaf
              }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 93711ef7df591ab0f50b8f0f7798f938eeb0f3b3..cf8693d02de53f1e02d55936f889c5724889e3f5 100644
+index 5e3acd365d9aca4271a590564e3eaad0d268bf11..0bb14272d024af90e7aef40f2f694e184af607d3 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -712,9 +712,9 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -1746,7 +1746,7 @@ index 93711ef7df591ab0f50b8f0f7798f938eeb0f3b3..cf8693d02de53f1e02d55936f889c572
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index c1541119630315521e75c1ba70ac99cd866afd71..b82541194979094f90b929cfdfb2b4c1fe0d2ad1 100644
+index 724f034d92f9f3f1021802e2bc2a845146c45efa..e882996b64178d2e22aeaf6f6a16a05eb715362d 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -131,7 +131,7 @@ public final class NaturalSpawner {
@@ -1768,10 +1768,10 @@ index c1541119630315521e75c1ba70ac99cd866afd71..b82541194979094f90b929cfdfb2b4c1
  
      // Paper start
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 994ef28e4ad685405a2b045e29550563b0914ccc..4672b4dad9a7bfeda4ddf6c5938afd52d0310884 100644
+index 434e33aa5c1c9722ea065627f1559c833954a342..7bae0525cc48d531de5a949f038417e098a59443 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -1292,9 +1292,9 @@ public class LevelChunk extends ChunkAccess {
+@@ -1309,9 +1309,9 @@ public class LevelChunk extends ChunkAccess {
  
                  if (LevelChunk.this.isTicking(blockposition)) {
                      try {
@@ -1783,7 +1783,7 @@ index 994ef28e4ad685405a2b045e29550563b0914ccc..4672b4dad9a7bfeda4ddf6c5938afd52
                          //this.blockEntity.tickTimer.startTiming(); // Spigot // Purpur
                          BlockState iblockdata = LevelChunk.this.getBlockState(blockposition);
  
-@@ -1306,7 +1306,7 @@ public class LevelChunk extends ChunkAccess {
+@@ -1323,7 +1323,7 @@ public class LevelChunk extends ChunkAccess {
                              LevelChunk.LOGGER.warn("Block entity {} @ {} state {} invalid for ticking:", new Object[]{LogUtils.defer(this::getType), LogUtils.defer(this::getPos), iblockdata});
                          }
  

--- a/patches/server/0291-Add-Bee-API.patch
+++ b/patches/server/0291-Add-Bee-API.patch
@@ -12,7 +12,7 @@ index fb14d13e2812c5a2841b43dadea782536bd3c94f..b934d7d0317e6a94171ea484c72c8b15
                  if (optional.isPresent()) {
                      Bee.this.savedFlowerPos = (BlockPos) optional.get();
                      Bee.this.navigation.moveTo((double) Bee.this.savedFlowerPos.getX() + 0.5D, (double) Bee.this.savedFlowerPos.getY() + 0.5D, (double) Bee.this.savedFlowerPos.getZ() + 0.5D, 1.2000000476837158D);
-+                    new org.purpurmc.purpur.event.entity.BeeFoundFlowerEvent((org.bukkit.entity.Bee) Bee.this.getBukkitEntity(), net.minecraft.server.MCUtil.toLocation(Bee.this.level, Bee.this.savedFlowerPos)).callEvent(); // Purpur
++                    new org.purpurmc.purpur.event.entity.BeeFoundFlowerEvent((org.bukkit.entity.Bee) Bee.this.getBukkitEntity(), io.papermc.paper.util.MCUtil.toLocation(Bee.this.level, Bee.this.savedFlowerPos)).callEvent(); // Purpur
                      return true;
                  } else {
                      Bee.this.remainingCooldownBeforeLocatingNewFlower = Mth.nextInt(Bee.this.random, 20, 60);
@@ -20,7 +20,7 @@ index fb14d13e2812c5a2841b43dadea782536bd3c94f..b934d7d0317e6a94171ea484c72c8b15
              this.pollinating = false;
              Bee.this.navigation.stop();
              Bee.this.remainingCooldownBeforeLocatingNewFlower = 200;
-+            new org.purpurmc.purpur.event.entity.BeeStopPollinatingEvent((org.bukkit.entity.Bee) Bee.this.getBukkitEntity(), Bee.this.savedFlowerPos == null ? null : net.minecraft.server.MCUtil.toLocation(Bee.this.level, Bee.this.savedFlowerPos), Bee.this.hasNectar()).callEvent(); // Purpur
++            new org.purpurmc.purpur.event.entity.BeeStopPollinatingEvent((org.bukkit.entity.Bee) Bee.this.getBukkitEntity(), Bee.this.savedFlowerPos == null ? null : io.papermc.paper.util.MCUtil.toLocation(Bee.this.level, Bee.this.savedFlowerPos), Bee.this.hasNectar()).callEvent(); // Purpur
          }
  
          @Override
@@ -28,7 +28,7 @@ index fb14d13e2812c5a2841b43dadea782536bd3c94f..b934d7d0317e6a94171ea484c72c8b15
                              this.setWantedPos();
                          }
  
-+                        if (this.successfulPollinatingTicks == 0) new org.purpurmc.purpur.event.entity.BeeStartedPollinatingEvent((org.bukkit.entity.Bee) Bee.this.getBukkitEntity(), net.minecraft.server.MCUtil.toLocation(Bee.this.level, Bee.this.savedFlowerPos)).callEvent(); // Purpur
++                        if (this.successfulPollinatingTicks == 0) new org.purpurmc.purpur.event.entity.BeeStartedPollinatingEvent((org.bukkit.entity.Bee) Bee.this.getBukkitEntity(), io.papermc.paper.util.MCUtil.toLocation(Bee.this.level, Bee.this.savedFlowerPos)).callEvent(); // Purpur
                          ++this.successfulPollinatingTicks;
                          if (Bee.this.random.nextFloat() < 0.05F && this.successfulPollinatingTicks > this.lastSoundPlayedTick + 60) {
                              this.lastSoundPlayedTick = this.successfulPollinatingTicks;

--- a/patches/server/0292-Debug-Marker-API.patch
+++ b/patches/server/0292-Debug-Marker-API.patch
@@ -57,7 +57,7 @@ index 68eb990c7d461c611310419c1eefaed79a7c8538..dabf1649f5bf14ec17dad6d43dcd7e2b
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -2238,6 +2238,42 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public float getLocalDifficultyAt(Location location) {
-         return getHandle().getCurrentDifficultyAt(net.minecraft.server.MCUtil.toBlockPosition(location)).getEffectiveDifficulty();
+         return getHandle().getCurrentDifficultyAt(io.papermc.paper.util.MCUtil.toBlockPosition(location)).getEffectiveDifficulty();
      }
 +
 +    @Override
@@ -77,7 +77,7 @@ index 68eb990c7d461c611310419c1eefaed79a7c8538..dabf1649f5bf14ec17dad6d43dcd7e2b
 +
 +    @Override
 +    public void sendBlockHighlight(Location location, int duration, String text, int argb) {
-+        net.minecraft.network.protocol.game.DebugPackets.sendGameTestAddMarker(getHandle(), net.minecraft.server.MCUtil.toBlockPosition(location), text, argb, duration);
++        net.minecraft.network.protocol.game.DebugPackets.sendGameTestAddMarker(getHandle(), io.papermc.paper.util.MCUtil.toBlockPosition(location), text, argb, duration);
 +    }
 +
 +    @Override
@@ -126,7 +126,7 @@ index 98ba88906a817bbfedd0e326b0faf59ea4cdcb66..fc20789aae6f30cc5ae71a7ae391a6b2
 +    public void sendBlockHighlight(Location location, int duration, String text, int argb) {
 +        if (this.getHandle().connection == null) return;
 +        FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
-+        buf.writeBlockPos(net.minecraft.server.MCUtil.toBlockPosition(location));
++        buf.writeBlockPos(io.papermc.paper.util.MCUtil.toBlockPosition(location));
 +        buf.writeInt(argb);
 +        buf.writeUtf(text);
 +        buf.writeInt(duration);


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
https://github.com/PaperMC/Paper/commit/519cb4b Move classes added to net.minecraft.server to paper packages (#8500)
https://github.com/PaperMC/Paper/commit/fc5ae5b Fix incorrect handling of mustNotSave
https://github.com/PaperMC/Paper/commit/25cd3ee Add dirty flag to chunk tick lists