### PR TITLE
Fix nullable world in Entity constructor (0282)

### DIFF
--- a/patches/server/0282-Add-toggle-for-RNG-manipulation.patch
+++ b/patches/server/0282-Add-toggle-for-RNG-manipulation.patch
@@ -7,7 +7,7 @@ Paper patches RNG maniplulation by using a shared (and locked) random source.
 This comes with a performance gain, but technical players may prefer the ability to manipulate RNG.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f9cf68820e01619a4ec319f18583a24115bfe112..cd97d28e85a6795099ec314e9574aa413ff93156 100644
+index 2988818acd52ae37f4ac4005ae550aefc40fe431..ef8d7c0c922cdc9e4ee857144677990c90c663ba 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -576,7 +576,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -15,7 +15,7 @@ index f9cf68820e01619a4ec319f18583a24115bfe112..cd97d28e85a6795099ec314e9574aa41
          this.stuckSpeedMultiplier = Vec3.ZERO;
          this.nextStep = 1.0F;
 -        this.random = SHARED_RANDOM; // Paper
-+        this.random = world.purpurConfig.entitySharedRandom ? SHARED_RANDOM : RandomSource.create(); // Paper // Purpur
++        this.random = world == null || world.purpurConfig.entitySharedRandom ? SHARED_RANDOM : RandomSource.create(); // Paper // Purpur
          this.remainingFireTicks = -this.getFireImmuneTicks();
          this.fluidHeight = new Object2DoubleArrayMap(2);
          this.fluidOnEyes = new HashSet();


### PR DESCRIPTION
The "world" parameter of the NMS Entity class is nullable, but Purpur disallows it.
This makes the creation of fake entities undoable with Purpur, but doable with Spigot or Paper. Pretty annoying.
This commit fixes it by doing a simple null check.