### PR TITLE
Fix the timeout for alternative keepalive handling

### DIFF
--- a/patches/server/0022-Alternative-Keepalive-Handling.patch
+++ b/patches/server/0022-Alternative-Keepalive-Handling.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Alternative Keepalive Handling
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e6cb6a4776ecf5504f04b83f523be7ed4741b7d9..4fa1b94de393010e0d95b48b6f4343e864b87b31 100644
+index abb1a20156b70781ccfd4ce15ffcfa0228b41a7d..fad849ac28cb67d696fbdc2525fb8c9e8fb9bbae 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -260,6 +260,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      private long keepAliveTime = Util.getMillis();
      private boolean keepAlivePending;
      private long keepAliveChallenge;
-+    private java.util.List<Long> keepAlives = new java.util.ArrayList<>(); // Purpur
++    private it.unimi.dsi.fastutil.longs.LongList keepAlives = new it.unimi.dsi.fastutil.longs.LongArrayList(); // Purpur
      // CraftBukkit start - multithreaded fields
      private final AtomicInteger chatSpamTickCount = new AtomicInteger();
      private final java.util.concurrent.atomic.AtomicInteger tabSpamLimiter = new java.util.concurrent.atomic.AtomicInteger(); // Paper - configurable tab spam limits
@@ -23,7 +23,7 @@ index e6cb6a4776ecf5504f04b83f523be7ed4741b7d9..4fa1b94de393010e0d95b48b6f4343e8
 +        // Purpur start
 +        if (org.purpurmc.purpur.PurpurConfig.useAlternateKeepAlive) {
 +            if (elapsedTime >= 1000L) { // 1 second
-+                if (!processedDisconnect && keepAlives.size() > KEEPALIVE_LIMIT) {
++                if (!processedDisconnect && keepAlives.size() * 1000L >= KEEPALIVE_LIMIT) {
 +                    LOGGER.warn("{} was kicked due to keepalive timeout!", player.getName());
 +                    disconnect(Component.translatable("disconnect.timeout"), org.bukkit.event.player.PlayerKickEvent.Cause.TIMEOUT);
 +                } else {


### PR DESCRIPTION
The timeout for alternative keepalive handling uses KEEPALIVE_LIMIT, but that now uses milliseconds, so a factor 1000 is needed to make it have effect. In addition, >= is the equivalent to vanilla behavior rather than >, which will timeout after at least 30 seconds (instead of after at least 31).

(Also while we're making a change anyway we can replace List<Long> with LongList~)