### PR TITLE
Move PlayerCommandSendEvent listeners check

### DIFF
--- a/patches/server/0049-Skip-events-if-there-s-no-listeners.patch
+++ b/patches/server/0049-Skip-events-if-there-s-no-listeners.patch
@@ -5,17 +5,17 @@ Subject: [PATCH] Skip events if there's no listeners
 
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 7c96f7fc5997761426a0c62cad0cab5cc668f282..98664c95331cee4139711c402dfaf406ee672c22 100644
+index 7c96f7fc5997761426a0c62cad0cab5cc668f282..c3721948ebccdf995f1b3fb10c4bbea1efa08e4c 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
-@@ -415,6 +415,7 @@ public class Commands {
-     }
- 
+@@ -417,6 +417,7 @@ public class Commands {
      private void runSync(ServerPlayer player, Collection<String> bukkit, RootCommandNode<SharedSuggestionProvider> rootcommandnode) {
-+        if (PlayerCommandSendEvent.getHandlerList().getRegisteredListeners().length > 0) { // Purpur - skip all this crap if there's nothing listening
          // Paper end - Async command map building
          new com.destroystokyo.paper.event.brigadier.AsyncPlayerSendCommandsEvent<CommandSourceStack>(player.getBukkitEntity(), (RootCommandNode) rootcommandnode, false).callEvent(); // Paper
++        if (PlayerCommandSendEvent.getHandlerList().getRegisteredListeners().length > 0) { // Purpur - skip all this crap if there's nothing listening
          PlayerCommandSendEvent event = new PlayerCommandSendEvent(player.getBukkitEntity(), new LinkedHashSet<>(bukkit));
+         event.getPlayer().getServer().getPluginManager().callEvent(event);
+ 
 @@ -427,6 +428,7 @@ public class Commands {
              }
          }


### PR DESCRIPTION
So I apologize in advance for the tininess of this pull request that probably will never matter, but I think the PlayerCommandSendEvent listener check should be placed two lines lower because the AsyncPlayerSendCommandsEvent call is unrelated.