### PR TITLE
Remove unnecessary deprecation

### DIFF
--- a/patches/api/0055-Fire-Immunity-API.patch
+++ b/patches/api/0055-Fire-Immunity-API.patch
@@ -27,25 +27,3 @@ index d8f30fca0b5b9673c5dd8a78e87a378c60d04067..8a980916176b2179168833f1d1487217
 +    void setImmuneToFire(@Nullable Boolean fireImmune);
      // Purpur end
  }
-diff --git a/src/main/java/org/bukkit/entity/Item.java b/src/main/java/org/bukkit/entity/Item.java
-index 05600fc8bf2a61aca8094029bc4c208a710da952..932e65f3aff0d7b15663ef9855b8b74dcb066dd6 100644
---- a/src/main/java/org/bukkit/entity/Item.java
-+++ b/src/main/java/org/bukkit/entity/Item.java
-@@ -1,6 +1,7 @@
- package org.bukkit.entity;
- 
- import java.util.UUID;
-+
- import org.bukkit.inventory.ItemStack;
- import org.jetbrains.annotations.NotNull;
- import org.jetbrains.annotations.Nullable;
-@@ -187,7 +188,9 @@ public interface Item extends Entity, io.papermc.paper.entity.Frictional { // Pa
-      * Set whether or not this item is immune to fire
-      *
-      * @param immuneToFire True to make immune to fire
-+     @deprecated use {@link #setImmuneToFire(Boolean)} instead
-      */
-+    @Deprecated
-     void setImmuneToFire(boolean immuneToFire);
- 
-     /**


### PR DESCRIPTION
Removes unnecessary deprecation notice:
([in implementation](https://github.com/PurpurMC/Purpur/blob/ver/1.19.3/patches/server/0302-Fire-Immunity-API.patch#L88) both method and the overload do the same thing)

![image](https://user-images.githubusercontent.com/19875118/209941786-9fd8dd91-7959-4167-ae5e-d68c3e0cd109.png)
