### PR TITLE
 Determine lava and water fluid explosion resistance by their block explosion resistance 

### DIFF
--- a/patches/server/0293-Configurable-block-blast-resistance.patch
+++ b/patches/server/0293-Configurable-block-blast-resistance.patch
@@ -17,6 +17,32 @@ index 86d765cd40cda9c8b7f4f7898d604ba2fdefa8fd..37360b896edecf3f2e09f0f7da6a37d6
      protected final boolean isRandomlyTicking;
      protected final SoundType soundType;
      protected final float friction;
+diff --git a/src/main/java/net/minecraft/world/level/material/LavaFluid.java b/src/main/java/net/minecraft/world/level/material/LavaFluid.java
+index 3a04cb4c646c07abf4338c70c865a4c4cb34b1bc..b05b4d3d97bca159c297f150005b5ab5bf6087e0 100644
+--- a/src/main/java/net/minecraft/world/level/material/LavaFluid.java
++++ b/src/main/java/net/minecraft/world/level/material/LavaFluid.java
+@@ -239,7 +239,7 @@ public abstract class LavaFluid extends FlowingFluid {
+ 
+     @Override
+     protected float getExplosionResistance() {
+-        return 100.0F;
++        return Blocks.LAVA.getExplosionResistance(); // Purpur
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/level/material/WaterFluid.java b/src/main/java/net/minecraft/world/level/material/WaterFluid.java
+index ec6c63075306f9e5389e83641d2c8a82369ddc6b..0f16deddd8cbb506ef7886f57ae640a42e841703 100644
+--- a/src/main/java/net/minecraft/world/level/material/WaterFluid.java
++++ b/src/main/java/net/minecraft/world/level/material/WaterFluid.java
+@@ -116,7 +116,7 @@ public abstract class WaterFluid extends FlowingFluid {
+ 
+     @Override
+     protected float getExplosionResistance() {
+-        return 100.0F;
++        return Blocks.WATER.getExplosionResistance(); // Purpur
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 index f32daa913a2aaa99fd9a021ee3ace02d7a814277..24fc48aeceb0f00517e5b0e37292749445ba03d7 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java


### PR DESCRIPTION
The explosion resistances of the water and lava fluids are hardcoded as 100. For reasons I've explained [in the discussion section](https://github.com/PurpurMC/Purpur/discussions/1244), this makes it impossible to make water and lava destructible using Purpur's `blast-resistance-overrides` config and any other method of overriding explosion resistance. 

This PR is simple: it changes the blast resistance overrides patch to ensure that the fluid explosion resistances of water and lava are the same as their block explosion resistances. Because both values are 100 in vanilla, this has no effect for servers that do not modify water/lava explosion resistance. However, making this changeable is required for any server that needs to reduce the protective ability of fluids or permit underwater explosions. 