### PR TITLE
Fix NPE when no world given to explosions

### DIFF
--- a/patches/server/0308-Config-to-remove-explosion-radius-clamp.patch
+++ b/patches/server/0308-Config-to-remove-explosion-radius-clamp.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Config to remove explosion radius clamp
 Co-authored-by: Encode42 <me@encode42.dev>
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 1e2304347fc369e5d9fe5d4c3cca8856766f5c1a..84b230d979a91dd776e180e5b828b26bdc98ef12 100644
+index 1e2304347fc369e5d9fe5d4c3cca8856766f5c1a..d5aeaac49fcbc32d5276168d910f9e298ae97fd7 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -98,7 +98,7 @@ public class EnderDragon extends Mob implements Enemy {
@@ -22,12 +22,12 @@ index 1e2304347fc369e5d9fe5d4c3cca8856766f5c1a..84b230d979a91dd776e180e5b828b26b
  
      public EnderDragon(EntityType<? extends EnderDragon> entitytypes, Level world) {
          super(EntityType.ENDER_DRAGON, world);
-+        this.explosionSource = new Explosion(this.level, this, null, null, Double.NaN, Double.NaN, Double.NaN, Float.NaN, true, Explosion.BlockInteraction.DESTROY); // Purpur - moved instantiation from field
++        this.explosionSource = new Explosion(world, this, null, null, Double.NaN, Double.NaN, Double.NaN, Float.NaN, true, Explosion.BlockInteraction.DESTROY); // Purpur - moved instantiation from field
          this.subEntities = new EnderDragonPart[]{this.head, this.neck, this.body, this.tail1, this.tail2, this.tail3, this.wing1, this.wing2};
          this.setHealth(this.getMaxHealth());
          this.noPhysics = true;
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index c0d39afe5b80159ed9aaca4ddd4763d707882f2e..3c9e0cee78deeae6b47a186f1bfc47f3956ec9c7 100644
+index de6050c867ac55dd6f0d8243289296781add7157..f74fad1a124daa888e0a05a8a707c4fd3384a6b9 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -86,7 +86,7 @@ public class Explosion {
@@ -35,7 +35,7 @@ index c0d39afe5b80159ed9aaca4ddd4763d707882f2e..3c9e0cee78deeae6b47a186f1bfc47f3
          this.level = world;
          this.source = entity;
 -        this.radius = (float) Math.max(power, 0.0); // CraftBukkit - clamp bad values
-+        this.radius = (float) (world.purpurConfig.explosionClampRadius ? Math.max(power, 0.0) : power); // CraftBukkit - clamp bad values // Purpur
++        this.radius = (float) (world == null || world.purpurConfig.explosionClampRadius ? Math.max(power, 0.0) : power); // CraftBukkit - clamp bad values // Purpur
          this.x = x;
          this.y = y;
          this.z = z;
@@ -44,7 +44,7 @@ index c0d39afe5b80159ed9aaca4ddd4763d707882f2e..3c9e0cee78deeae6b47a186f1bfc47f3
      public void explode() {
          // CraftBukkit start
 -        if (this.radius < 0.1F) {
-+        if (this.level.purpurConfig.explosionClampRadius && this.radius < 0.1F) { // Purpur
++        if ((this.level == null || this.level.purpurConfig.explosionClampRadius) && this.radius < 0.1F) { // Purpur
              return;
          }
          // CraftBukkit end


### PR DESCRIPTION
Fixes compatibility issues when plugins somehow create explosions without a world object like BONNePlayground/DragonFights#18