### PR TITLE
Fix the Optional type server status version being compared to null

### DIFF
--- a/patches/server/0028-Fix-outdated-server-showing-in-ping-before-server-fu.patch
+++ b/patches/server/0028-Fix-outdated-server-showing-in-ping-before-server-fu.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Fix 'outdated server' showing in ping before server fully
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
-index 2c13147bc063a09bb7907d6f90c3a1e811a09eb1..c71c4e0bf946c2ce5cd99a0cd312c82060c1661f 100644
+index 2c13147bc063a09bb7907d6f90c3a1e811a09eb1..3edb0c392cec7fdabebad81da1a8b06a700fbfca 100644
 --- a/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerStatusPacketListenerImpl.java
 @@ -153,6 +153,7 @@ public class ServerStatusPacketListenerImpl implements ServerStatusPacketListene
              this.connection.send(new ClientboundStatusResponsePacket(ping));
              // CraftBukkit end
              */
-+            if (MinecraftServer.getServer().getStatus().version() == null) return; // Purpur - do not respond to pings before we know the protocol version
++            if (MinecraftServer.getServer().getStatus().version().isEmpty()) return; // Purpur - do not respond to pings before we know the protocol version
              com.destroystokyo.paper.network.StandardPaperServerListPingEventImpl.processRequest(MinecraftServer.getServer(), this.connection);
              // Paper end
          }


### PR DESCRIPTION
The server status version (`MinecraftServer.getServer().getStatus().version()`) used to be a nullable class field, but it is now an Optional record field. Therefore, the comparison to null should be replaced with `isEmpty()`. In its current state, with the null check, this patch does nothing anymore (because the version will never be null).

To verify the status will in fact be an empty Optional, see `net.minecraft.network.protocol.status#CODEC`, which uses `optionalFieldOf`, which returns a `com.mojang.serialization.codecs.OptionalFieldCodec` for which the `decode` method never returns null, but an empty Optional in the corresponding scenarios instead.