### PR TITLE
Add option to disable scissor damage in liquid

### DIFF
--- a/patches/server/0134-Dont-run-with-scissors.patch
+++ b/patches/server/0134-Dont-run-with-scissors.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Dont run with scissors!
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e28bc6ad060b487b2223379e0187c082c0e69f7f..fb4852272753747ba925962e51cff848fd1af9e3 100644
+index e28bc6ad060b487b2223379e0187c082c0e69f7f..e3b9bea53438316ad23ebd072e476c7e14c11f92 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1686,6 +1686,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -13,7 +13,7 @@ index e28bc6ad060b487b2223379e0187c082c0e69f7f..fb4852272753747ba925962e51cff848
                                  }
  
 +                                // Purpur Start
-+                                if (this.player.level.purpurConfig.dontRunWithScissors && this.player.isSprinting() && (isScissor(this.player.getItemInHand(InteractionHand.MAIN_HAND)) || isScissor(this.player.getItemInHand(InteractionHand.OFF_HAND))) && (int) (Math.random() * 10) == 0) {
++                                if (this.player.level.purpurConfig.dontRunWithScissors && this.player.isSprinting() && !(this.player.level.purpurConfig.ignoreScissorsInWater && (this.player.isInWater() || this.player.isInLava())) && (isScissor(this.player.getItemInHand(InteractionHand.MAIN_HAND)) || isScissor(this.player.getItemInHand(InteractionHand.OFF_HAND))) && (int) (Math.random() * 10) == 0) {
 +                                    this.player.hurt(this.player.damageSources().magic(), (float) this.player.level.purpurConfig.scissorsRunningDamage);
 +                                    if (!org.purpurmc.purpur.PurpurConfig.dontRunWithScissors.isBlank()) this.player.sendActionBarMessage(org.purpurmc.purpur.PurpurConfig.dontRunWithScissors);
 +                                }
@@ -61,23 +61,25 @@ index 5b0625955e2a65f689c8a128d73170bc1f0c8025..c8097ec7887ac8e689b6843d9ff7744d
  
      public static String serverModName = "Purpur";
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d7a87f582ba3f9f1af1605313208212011c53c58..8d0e2bb1f4e58339768cb1dad878142e33ad84bd 100644
+index 91aefbfb74acb1eb94751507cee98e7291fd2b82..b51cada14cf31c6d5644a5286bb5798dd1ffc4bf 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -199,6 +199,8 @@ public class PurpurWorldConfig {
+@@ -199,6 +199,9 @@ public class PurpurWorldConfig {
      public List<Item> itemImmuneToExplosion = new ArrayList<>();
      public List<Item> itemImmuneToFire = new ArrayList<>();
      public List<Item> itemImmuneToLightning = new ArrayList<>();
 +    public boolean dontRunWithScissors = false;
++    public boolean ignoreScissorsInWater = true;
 +    public double scissorsRunningDamage = 1D;
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -236,6 +238,8 @@ public class PurpurWorldConfig {
+@@ -236,6 +239,9 @@ public class PurpurWorldConfig {
              Item item = BuiltInRegistries.ITEM.get(new ResourceLocation(key.toString()));
              if (item != Items.AIR) itemImmuneToLightning.add(item);
          });
 +        dontRunWithScissors = getBoolean("gameplay-mechanics.item.shears.damage-if-sprinting", dontRunWithScissors);
++        ignoreScissorsInWater = getBoolean("gameplay-mechanics.item.shears.ignore-in-liquid", ignoreScissorsInWater);
 +        scissorsRunningDamage = getDouble("gameplay-mechanics.item.shears.sprinting-damage", scissorsRunningDamage);
      }
  

--- a/patches/server/0134-Dont-run-with-scissors.patch
+++ b/patches/server/0134-Dont-run-with-scissors.patch
@@ -69,7 +69,7 @@ index 91aefbfb74acb1eb94751507cee98e7291fd2b82..b51cada14cf31c6d5644a5286bb5798d
      public List<Item> itemImmuneToFire = new ArrayList<>();
      public List<Item> itemImmuneToLightning = new ArrayList<>();
 +    public boolean dontRunWithScissors = false;
-+    public boolean ignoreScissorsInWater = true;
++    public boolean ignoreScissorsInWater = false;
 +    public double scissorsRunningDamage = 1D;
      private void itemSettings() {
          itemImmuneToCactus.clear();

--- a/patches/server/0134-Dont-run-with-scissors.patch
+++ b/patches/server/0134-Dont-run-with-scissors.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Dont run with scissors!
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e28bc6ad060b487b2223379e0187c082c0e69f7f..e3b9bea53438316ad23ebd072e476c7e14c11f92 100644
+index e28bc6ad060b487b2223379e0187c082c0e69f7f..2bfa3ee8fba634c33545b68dbd5d49fa1984ed55 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1686,6 +1686,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -13,7 +13,7 @@ index e28bc6ad060b487b2223379e0187c082c0e69f7f..e3b9bea53438316ad23ebd072e476c7e
                                  }
  
 +                                // Purpur Start
-+                                if (this.player.level.purpurConfig.dontRunWithScissors && this.player.isSprinting() && !(this.player.level.purpurConfig.ignoreScissorsInWater && (this.player.isInWater() || this.player.isInLava())) && (isScissor(this.player.getItemInHand(InteractionHand.MAIN_HAND)) || isScissor(this.player.getItemInHand(InteractionHand.OFF_HAND))) && (int) (Math.random() * 10) == 0) {
++                                if (this.player.level.purpurConfig.dontRunWithScissors && this.player.isSprinting() && !(this.player.level.purpurConfig.ignoreScissorsInWater && this.player.isInWater()) && !(this.player.level.purpurConfig.ignoreScissorsInLava && this.player.isInLava()) && (isScissor(this.player.getItemInHand(InteractionHand.MAIN_HAND)) || isScissor(this.player.getItemInHand(InteractionHand.OFF_HAND))) && (int) (Math.random() * 10) == 0) {
 +                                    this.player.hurt(this.player.damageSources().magic(), (float) this.player.level.purpurConfig.scissorsRunningDamage);
 +                                    if (!org.purpurmc.purpur.PurpurConfig.dontRunWithScissors.isBlank()) this.player.sendActionBarMessage(org.purpurmc.purpur.PurpurConfig.dontRunWithScissors);
 +                                }
@@ -61,25 +61,27 @@ index 5b0625955e2a65f689c8a128d73170bc1f0c8025..c8097ec7887ac8e689b6843d9ff7744d
  
      public static String serverModName = "Purpur";
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 91aefbfb74acb1eb94751507cee98e7291fd2b82..b51cada14cf31c6d5644a5286bb5798dd1ffc4bf 100644
+index 91aefbfb74acb1eb94751507cee98e7291fd2b82..5161f70dbb5eda657b0738065777bd158b5ed633 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -199,6 +199,9 @@ public class PurpurWorldConfig {
+@@ -199,6 +199,10 @@ public class PurpurWorldConfig {
      public List<Item> itemImmuneToExplosion = new ArrayList<>();
      public List<Item> itemImmuneToFire = new ArrayList<>();
      public List<Item> itemImmuneToLightning = new ArrayList<>();
 +    public boolean dontRunWithScissors = false;
 +    public boolean ignoreScissorsInWater = false;
++    public boolean ignoreScissorsInLava = false;
 +    public double scissorsRunningDamage = 1D;
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -236,6 +239,9 @@ public class PurpurWorldConfig {
+@@ -236,6 +240,10 @@ public class PurpurWorldConfig {
              Item item = BuiltInRegistries.ITEM.get(new ResourceLocation(key.toString()));
              if (item != Items.AIR) itemImmuneToLightning.add(item);
          });
 +        dontRunWithScissors = getBoolean("gameplay-mechanics.item.shears.damage-if-sprinting", dontRunWithScissors);
-+        ignoreScissorsInWater = getBoolean("gameplay-mechanics.item.shears.ignore-in-liquid", ignoreScissorsInWater);
++        ignoreScissorsInWater = getBoolean("gameplay-mechanics.item.shears.ignore-in-water", ignoreScissorsInWater);
++        ignoreScissorsInLava = getBoolean("gameplay-mechanics.item.shears.ignore-in-lava", ignoreScissorsInLava);
 +        scissorsRunningDamage = getDouble("gameplay-mechanics.item.shears.sprinting-damage", scissorsRunningDamage);
      }
  

--- a/patches/server/0135-One-Punch-Man.patch
+++ b/patches/server/0135-One-Punch-Man.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] One Punch Man!
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 41b03010c42d4692187803e3debc01c5182bac3a..4ce236340a5d22a3017f1c8ff71e85f44d204234 100644
+index 11f7902e30771d5c279e0116b813295a5daf3510..999d5fce5a4647a235717fe6f436b04add0bd26a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -2235,6 +2235,20 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -30,10 +30,10 @@ index 41b03010c42d4692187803e3debc01c5182bac3a..4ce236340a5d22a3017f1c8ff71e85f4
                  if (human) {
                      // PAIL: Be sure to drag all this code from the EntityHuman subclass each update.
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 0eef3049df089ec17c213e4a4ab4c23815775dc4..0de6977b939349f8d2a6a481db5dd049acf97d69 100644
+index b51cada14cf31c6d5644a5286bb5798dd1ffc4bf..2344192aca59ec3fa8ccd04ca7822de3e4cf3be8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -344,6 +344,7 @@ public class PurpurWorldConfig {
+@@ -346,6 +346,7 @@ public class PurpurWorldConfig {
      public boolean teleportIfOutsideBorder = false;
      public boolean totemOfUndyingWorksInInventory = false;
      public boolean playerFixStuckPortal = false;
@@ -41,7 +41,7 @@ index 0eef3049df089ec17c213e4a4ab4c23815775dc4..0de6977b939349f8d2a6a481db5dd049
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -362,6 +363,7 @@ public class PurpurWorldConfig {
+@@ -364,6 +365,7 @@ public class PurpurWorldConfig {
          teleportIfOutsideBorder = getBoolean("gameplay-mechanics.player.teleport-if-outside-border", teleportIfOutsideBorder);
          totemOfUndyingWorksInInventory = getBoolean("gameplay-mechanics.player.totem-of-undying-works-in-inventory", totemOfUndyingWorksInInventory);
          playerFixStuckPortal = getBoolean("gameplay-mechanics.player.fix-stuck-in-portal", playerFixStuckPortal);

--- a/patches/server/0135-One-Punch-Man.patch
+++ b/patches/server/0135-One-Punch-Man.patch
@@ -30,10 +30,10 @@ index 11f7902e30771d5c279e0116b813295a5daf3510..999d5fce5a4647a235717fe6f436b04a
                  if (human) {
                      // PAIL: Be sure to drag all this code from the EntityHuman subclass each update.
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b51cada14cf31c6d5644a5286bb5798dd1ffc4bf..2344192aca59ec3fa8ccd04ca7822de3e4cf3be8 100644
+index 5161f70dbb5eda657b0738065777bd158b5ed633..462361b4f7599f0289bf7587a9f23d1d0e787913 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -346,6 +346,7 @@ public class PurpurWorldConfig {
+@@ -348,6 +348,7 @@ public class PurpurWorldConfig {
      public boolean teleportIfOutsideBorder = false;
      public boolean totemOfUndyingWorksInInventory = false;
      public boolean playerFixStuckPortal = false;
@@ -41,7 +41,7 @@ index b51cada14cf31c6d5644a5286bb5798dd1ffc4bf..2344192aca59ec3fa8ccd04ca7822de3
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -364,6 +365,7 @@ public class PurpurWorldConfig {
+@@ -366,6 +367,7 @@ public class PurpurWorldConfig {
          teleportIfOutsideBorder = getBoolean("gameplay-mechanics.player.teleport-if-outside-border", teleportIfOutsideBorder);
          totemOfUndyingWorksInInventory = getBoolean("gameplay-mechanics.player.totem-of-undying-works-in-inventory", totemOfUndyingWorksInInventory);
          playerFixStuckPortal = getBoolean("gameplay-mechanics.player.fix-stuck-in-portal", playerFixStuckPortal);

--- a/patches/server/0136-Configurable-Ender-Pearl-cooldown-damage-and-Endermi.patch
+++ b/patches/server/0136-Configurable-Ender-Pearl-cooldown-damage-and-Endermi.patch
@@ -43,12 +43,12 @@ index 749ab72edc0d2e9c6f1161415ab8d59d3d6ca976..897c202c0905040072a06fdfa2032a7f
                  // Paper end
                  if (user instanceof net.minecraft.server.level.ServerPlayer) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 2344192aca59ec3fa8ccd04ca7822de3e4cf3be8..42a1c4793431bea10051ef8a4685e37b4467dc62 100644
+index 462361b4f7599f0289bf7587a9f23d1d0e787913..0ee53ad66d1e2dbf16fb0d982cc2ed845e58fa28 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -202,6 +202,10 @@ public class PurpurWorldConfig {
-     public boolean dontRunWithScissors = false;
-     public boolean ignoreScissorsInWater = true;
+@@ -203,6 +203,10 @@ public class PurpurWorldConfig {
+     public boolean ignoreScissorsInWater = false;
+     public boolean ignoreScissorsInLava = false;
      public double scissorsRunningDamage = 1D;
 +    public float enderPearlDamage = 5.0F;
 +    public int enderPearlCooldown = 20;
@@ -57,9 +57,9 @@ index 2344192aca59ec3fa8ccd04ca7822de3e4cf3be8..42a1c4793431bea10051ef8a4685e37b
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -242,6 +246,10 @@ public class PurpurWorldConfig {
-         dontRunWithScissors = getBoolean("gameplay-mechanics.item.shears.damage-if-sprinting", dontRunWithScissors);
-         ignoreScissorsInWater = getBoolean("gameplay-mechanics.item.shears.ignore-in-liquid", ignoreScissorsInWater);
+@@ -244,6 +248,10 @@ public class PurpurWorldConfig {
+         ignoreScissorsInWater = getBoolean("gameplay-mechanics.item.shears.ignore-in-water", ignoreScissorsInWater);
+         ignoreScissorsInLava = getBoolean("gameplay-mechanics.item.shears.ignore-in-lava", ignoreScissorsInLava);
          scissorsRunningDamage = getDouble("gameplay-mechanics.item.shears.sprinting-damage", scissorsRunningDamage);
 +        enderPearlDamage = (float) getDouble("gameplay-mechanics.item.ender-pearl.damage", enderPearlDamage);
 +        enderPearlCooldown = getInt("gameplay-mechanics.item.ender-pearl.cooldown", enderPearlCooldown);

--- a/patches/server/0136-Configurable-Ender-Pearl-cooldown-damage-and-Endermi.patch
+++ b/patches/server/0136-Configurable-Ender-Pearl-cooldown-damage-and-Endermi.patch
@@ -43,12 +43,12 @@ index 749ab72edc0d2e9c6f1161415ab8d59d3d6ca976..897c202c0905040072a06fdfa2032a7f
                  // Paper end
                  if (user instanceof net.minecraft.server.level.ServerPlayer) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 0de6977b939349f8d2a6a481db5dd049acf97d69..3afce466836c9c9961fdabd749903869dd5ace91 100644
+index 2344192aca59ec3fa8ccd04ca7822de3e4cf3be8..42a1c4793431bea10051ef8a4685e37b4467dc62 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -201,6 +201,10 @@ public class PurpurWorldConfig {
-     public List<Item> itemImmuneToLightning = new ArrayList<>();
+@@ -202,6 +202,10 @@ public class PurpurWorldConfig {
      public boolean dontRunWithScissors = false;
+     public boolean ignoreScissorsInWater = true;
      public double scissorsRunningDamage = 1D;
 +    public float enderPearlDamage = 5.0F;
 +    public int enderPearlCooldown = 20;
@@ -57,9 +57,9 @@ index 0de6977b939349f8d2a6a481db5dd049acf97d69..3afce466836c9c9961fdabd749903869
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -240,6 +244,10 @@ public class PurpurWorldConfig {
-         });
+@@ -242,6 +246,10 @@ public class PurpurWorldConfig {
          dontRunWithScissors = getBoolean("gameplay-mechanics.item.shears.damage-if-sprinting", dontRunWithScissors);
+         ignoreScissorsInWater = getBoolean("gameplay-mechanics.item.shears.ignore-in-liquid", ignoreScissorsInWater);
          scissorsRunningDamage = getDouble("gameplay-mechanics.item.shears.sprinting-damage", scissorsRunningDamage);
 +        enderPearlDamage = (float) getDouble("gameplay-mechanics.item.ender-pearl.damage", enderPearlDamage);
 +        enderPearlCooldown = getInt("gameplay-mechanics.item.ender-pearl.cooldown", enderPearlCooldown);

--- a/patches/server/0137-Config-to-ignore-nearby-mobs-when-sleeping.patch
+++ b/patches/server/0137-Config-to-ignore-nearby-mobs-when-sleeping.patch
@@ -18,10 +18,10 @@ index bc2c592a416c64619527bf5d1040f4a2523b2bfb..64dc052f41e0ef96753e0ffd3d6517fc
                          }
                      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 42a1c4793431bea10051ef8a4685e37b4467dc62..9c1a4235ae1d7ee220bf6da00da19ff6f5dde0e5 100644
+index 0ee53ad66d1e2dbf16fb0d982cc2ed845e58fa28..c4c5b70736f0a38e5d1b4a14640e64512a26a3ce 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -355,6 +355,7 @@ public class PurpurWorldConfig {
+@@ -357,6 +357,7 @@ public class PurpurWorldConfig {
      public boolean totemOfUndyingWorksInInventory = false;
      public boolean playerFixStuckPortal = false;
      public boolean creativeOnePunch = false;
@@ -29,7 +29,7 @@ index 42a1c4793431bea10051ef8a4685e37b4467dc62..9c1a4235ae1d7ee220bf6da00da19ff6
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -374,6 +375,7 @@ public class PurpurWorldConfig {
+@@ -376,6 +377,7 @@ public class PurpurWorldConfig {
          totemOfUndyingWorksInInventory = getBoolean("gameplay-mechanics.player.totem-of-undying-works-in-inventory", totemOfUndyingWorksInInventory);
          playerFixStuckPortal = getBoolean("gameplay-mechanics.player.fix-stuck-in-portal", playerFixStuckPortal);
          creativeOnePunch = getBoolean("gameplay-mechanics.player.one-punch-in-creative", creativeOnePunch);

--- a/patches/server/0137-Config-to-ignore-nearby-mobs-when-sleeping.patch
+++ b/patches/server/0137-Config-to-ignore-nearby-mobs-when-sleeping.patch
@@ -18,10 +18,10 @@ index bc2c592a416c64619527bf5d1040f4a2523b2bfb..64dc052f41e0ef96753e0ffd3d6517fc
                          }
                      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3afce466836c9c9961fdabd749903869dd5ace91..dde6bec7a83f7c11d234b09937680c02e4b8dd69 100644
+index 42a1c4793431bea10051ef8a4685e37b4467dc62..9c1a4235ae1d7ee220bf6da00da19ff6f5dde0e5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -353,6 +353,7 @@ public class PurpurWorldConfig {
+@@ -355,6 +355,7 @@ public class PurpurWorldConfig {
      public boolean totemOfUndyingWorksInInventory = false;
      public boolean playerFixStuckPortal = false;
      public boolean creativeOnePunch = false;
@@ -29,7 +29,7 @@ index 3afce466836c9c9961fdabd749903869dd5ace91..dde6bec7a83f7c11d234b09937680c02
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -372,6 +373,7 @@ public class PurpurWorldConfig {
+@@ -374,6 +375,7 @@ public class PurpurWorldConfig {
          totemOfUndyingWorksInInventory = getBoolean("gameplay-mechanics.player.totem-of-undying-works-in-inventory", totemOfUndyingWorksInInventory);
          playerFixStuckPortal = getBoolean("gameplay-mechanics.player.fix-stuck-in-portal", playerFixStuckPortal);
          creativeOnePunch = getBoolean("gameplay-mechanics.player.one-punch-in-creative", creativeOnePunch);

--- a/patches/server/0139-Config-Enderman-aggressiveness-towards-Endermites.patch
+++ b/patches/server/0139-Config-Enderman-aggressiveness-towards-Endermites.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config Enderman aggressiveness towards Endermites
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
-index 9e60e5d8a2005669c3187cdd84d8d7ef8f5da6be..38a483298b73c31d0c3d292a4c796c7b938c6961 100644
+index e7308cf659fba62669753ea53e52f40fb96976b1..c702f4b6534d0bf2e9d763bedbf58bf2a3190b5d 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 @@ -128,7 +128,7 @@ public class EnderMan extends Monster implements NeutralMob {
@@ -18,10 +18,10 @@ index 9e60e5d8a2005669c3187cdd84d8d7ef8f5da6be..38a483298b73c31d0c3d292a4c796c7b
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index dde6bec7a83f7c11d234b09937680c02e4b8dd69..fb0a15654b5545ff74116215d5a52f782a1ff4b8 100644
+index 9c1a4235ae1d7ee220bf6da00da19ff6f5dde0e5..0bd55ebc3025b7997f9b429298c0bc877bd1ca4e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -993,6 +993,8 @@ public class PurpurWorldConfig {
+@@ -995,6 +995,8 @@ public class PurpurWorldConfig {
      public boolean endermanDespawnEvenWithBlock = false;
      public boolean endermanBypassMobGriefing = false;
      public boolean endermanTakeDamageFromWater = true;
@@ -30,7 +30,7 @@ index dde6bec7a83f7c11d234b09937680c02e4b8dd69..fb0a15654b5545ff74116215d5a52f78
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1002,11 +1004,17 @@ public class PurpurWorldConfig {
+@@ -1004,11 +1006,17 @@ public class PurpurWorldConfig {
              set("mobs.enderman.attributes.max-health", null);
              set("mobs.enderman.attributes.max_health", oldValue);
          }

--- a/patches/server/0139-Config-Enderman-aggressiveness-towards-Endermites.patch
+++ b/patches/server/0139-Config-Enderman-aggressiveness-towards-Endermites.patch
@@ -18,10 +18,10 @@ index e7308cf659fba62669753ea53e52f40fb96976b1..c702f4b6534d0bf2e9d763bedbf58bf2
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9c1a4235ae1d7ee220bf6da00da19ff6f5dde0e5..0bd55ebc3025b7997f9b429298c0bc877bd1ca4e 100644
+index c4c5b70736f0a38e5d1b4a14640e64512a26a3ce..4f098761f1f7b753ab8d9f96458a5f344e93aa42 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -995,6 +995,8 @@ public class PurpurWorldConfig {
+@@ -997,6 +997,8 @@ public class PurpurWorldConfig {
      public boolean endermanDespawnEvenWithBlock = false;
      public boolean endermanBypassMobGriefing = false;
      public boolean endermanTakeDamageFromWater = true;
@@ -30,7 +30,7 @@ index 9c1a4235ae1d7ee220bf6da00da19ff6f5dde0e5..0bd55ebc3025b7997f9b429298c0bc87
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1004,11 +1006,17 @@ public class PurpurWorldConfig {
+@@ -1006,11 +1008,17 @@ public class PurpurWorldConfig {
              set("mobs.enderman.attributes.max-health", null);
              set("mobs.enderman.attributes.max_health", oldValue);
          }

--- a/patches/server/0140-Config-to-ignore-Dragon-Head-wearers-and-stare-aggro.patch
+++ b/patches/server/0140-Config-to-ignore-Dragon-Head-wearers-and-stare-aggro.patch
@@ -20,10 +20,10 @@ index c702f4b6534d0bf2e9d763bedbf58bf2a3190b5d..60720f0bad840d35c9d0f1fc327f6069
          } else {
              Vec3 vec3d = player.getViewVector(1.0F).normalize();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 0bd55ebc3025b7997f9b429298c0bc877bd1ca4e..4ee90abf7a96ccf38c95fe6f5d688f4abeab3341 100644
+index 4f098761f1f7b753ab8d9f96458a5f344e93aa42..5668ee41a5f904169b6bcf24bf73ec0227876510 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -997,6 +997,8 @@ public class PurpurWorldConfig {
+@@ -999,6 +999,8 @@ public class PurpurWorldConfig {
      public boolean endermanTakeDamageFromWater = true;
      public boolean endermanAggroEndermites = true;
      public boolean endermanAggroEndermitesOnlyIfPlayerSpawned = false;
@@ -32,7 +32,7 @@ index 0bd55ebc3025b7997f9b429298c0bc877bd1ca4e..4ee90abf7a96ccf38c95fe6f5d688f4a
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1017,6 +1019,8 @@ public class PurpurWorldConfig {
+@@ -1019,6 +1021,8 @@ public class PurpurWorldConfig {
          endermanTakeDamageFromWater = getBoolean("mobs.enderman.takes-damage-from-water", endermanTakeDamageFromWater);
          endermanAggroEndermites = getBoolean("mobs.enderman.aggressive-towards-endermites", endermanAggroEndermites);
          endermanAggroEndermitesOnlyIfPlayerSpawned = getBoolean("mobs.enderman.aggressive-towards-endermites-only-spawned-by-player-thrown-ender-pearls", endermanAggroEndermitesOnlyIfPlayerSpawned);

--- a/patches/server/0140-Config-to-ignore-Dragon-Head-wearers-and-stare-aggro.patch
+++ b/patches/server/0140-Config-to-ignore-Dragon-Head-wearers-and-stare-aggro.patch
@@ -7,7 +7,7 @@ Prevents Enderman from becoming aggresive towards players that are wearing a Dra
 Adds functionality to a useless item!
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
-index 38a483298b73c31d0c3d292a4c796c7b938c6961..2ac667ec7bdc59363af0bd2209f6e456372d73e7 100644
+index c702f4b6534d0bf2e9d763bedbf58bf2a3190b5d..60720f0bad840d35c9d0f1fc327f6069b348a41a 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 @@ -265,7 +265,7 @@ public class EnderMan extends Monster implements NeutralMob {
@@ -20,10 +20,10 @@ index 38a483298b73c31d0c3d292a4c796c7b938c6961..2ac667ec7bdc59363af0bd2209f6e456
          } else {
              Vec3 vec3d = player.getViewVector(1.0F).normalize();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index fb0a15654b5545ff74116215d5a52f782a1ff4b8..7be8a006914ac746e92f683b785eef4a5de308e2 100644
+index 0bd55ebc3025b7997f9b429298c0bc877bd1ca4e..4ee90abf7a96ccf38c95fe6f5d688f4abeab3341 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -995,6 +995,8 @@ public class PurpurWorldConfig {
+@@ -997,6 +997,8 @@ public class PurpurWorldConfig {
      public boolean endermanTakeDamageFromWater = true;
      public boolean endermanAggroEndermites = true;
      public boolean endermanAggroEndermitesOnlyIfPlayerSpawned = false;
@@ -32,7 +32,7 @@ index fb0a15654b5545ff74116215d5a52f782a1ff4b8..7be8a006914ac746e92f683b785eef4a
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1015,6 +1017,8 @@ public class PurpurWorldConfig {
+@@ -1017,6 +1019,8 @@ public class PurpurWorldConfig {
          endermanTakeDamageFromWater = getBoolean("mobs.enderman.takes-damage-from-water", endermanTakeDamageFromWater);
          endermanAggroEndermites = getBoolean("mobs.enderman.aggressive-towards-endermites", endermanAggroEndermites);
          endermanAggroEndermitesOnlyIfPlayerSpawned = getBoolean("mobs.enderman.aggressive-towards-endermites-only-spawned-by-player-thrown-ender-pearls", endermanAggroEndermitesOnlyIfPlayerSpawned);

--- a/patches/server/0142-Config-to-disable-Llama-caravans.patch
+++ b/patches/server/0142-Config-to-disable-Llama-caravans.patch
@@ -32,10 +32,10 @@ index 185749df0c7c08f625145a29810ffed6042550bb..3f3e6633a3de2ceb5a082777a24ff045
          this.caravanHead.caravanTail = this;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f33da6d29aa673ba011e6e257b94b1e2e5c095f0..a439a642084b9808f130b857ab9312f3caaa4e70 100644
+index 8223228a721ce26eb2a7a955cb6eff40040d464f..92b0823f51e81bd9fb6b402d840be3d45483d99a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1329,6 +1329,7 @@ public class PurpurWorldConfig {
+@@ -1331,6 +1331,7 @@ public class PurpurWorldConfig {
      public double llamaMovementSpeedMax = 0.175D;
      public int llamaBreedingTicks = 6000;
      public boolean llamaTakeDamageFromWater = false;
@@ -43,7 +43,7 @@ index f33da6d29aa673ba011e6e257b94b1e2e5c095f0..a439a642084b9808f130b857ab9312f3
      private void llamaSettings() {
          llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
          llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
-@@ -1348,6 +1349,7 @@ public class PurpurWorldConfig {
+@@ -1350,6 +1351,7 @@ public class PurpurWorldConfig {
          llamaMovementSpeedMax = getDouble("mobs.llama.attributes.movement_speed.max", llamaMovementSpeedMax);
          llamaBreedingTicks = getInt("mobs.llama.breeding-delay-ticks", llamaBreedingTicks);
          llamaTakeDamageFromWater = getBoolean("mobs.llama.takes-damage-from-water", llamaTakeDamageFromWater);

--- a/patches/server/0142-Config-to-disable-Llama-caravans.patch
+++ b/patches/server/0142-Config-to-disable-Llama-caravans.patch
@@ -32,10 +32,10 @@ index 185749df0c7c08f625145a29810ffed6042550bb..3f3e6633a3de2ceb5a082777a24ff045
          this.caravanHead.caravanTail = this;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ab07a785f7017882f3ee31ee32625fae8392c7c5..e8c890ee982489206b5e8d36786c48bdcf66968f 100644
+index f33da6d29aa673ba011e6e257b94b1e2e5c095f0..a439a642084b9808f130b857ab9312f3caaa4e70 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1327,6 +1327,7 @@ public class PurpurWorldConfig {
+@@ -1329,6 +1329,7 @@ public class PurpurWorldConfig {
      public double llamaMovementSpeedMax = 0.175D;
      public int llamaBreedingTicks = 6000;
      public boolean llamaTakeDamageFromWater = false;
@@ -43,7 +43,7 @@ index ab07a785f7017882f3ee31ee32625fae8392c7c5..e8c890ee982489206b5e8d36786c48bd
      private void llamaSettings() {
          llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
          llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
-@@ -1346,6 +1347,7 @@ public class PurpurWorldConfig {
+@@ -1348,6 +1349,7 @@ public class PurpurWorldConfig {
          llamaMovementSpeedMax = getDouble("mobs.llama.attributes.movement_speed.max", llamaMovementSpeedMax);
          llamaBreedingTicks = getInt("mobs.llama.breeding-delay-ticks", llamaBreedingTicks);
          llamaTakeDamageFromWater = getBoolean("mobs.llama.takes-damage-from-water", llamaTakeDamageFromWater);

--- a/patches/server/0143-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0143-Config-to-make-Creepers-explode-on-death.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Config to make Creepers explode on death
 Creepers exploded after being killed in the alpha days. This brings that back.
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Creeper.java b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
-index 7a16984f0eb5f48e16dd718f44e39c7cc4a28d9a..1d099bfb7b35062178d65a0808ba99b0da5ef885 100644
+index 8db007569fc8a5085071813e1476a27d0f1cff7c..8568be97dcd5bb269e0204faf8b42dc8cb152282 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Creeper.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
 @@ -63,6 +63,7 @@ public class Creeper extends Monster implements PowerableMob {
@@ -50,10 +50,10 @@ index 7a16984f0eb5f48e16dd718f44e39c7cc4a28d9a..1d099bfb7b35062178d65a0808ba99b0
  
      private void spawnLingeringCloud() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1c6bb583b73a02957cb85fa9ecd0b1edc53c3d0d..bd298eed71a02ccfbbd97ce573ebc9c6976f1943 100644
+index a439a642084b9808f130b857ab9312f3caaa4e70..9aa82342b58e31b1a10895262ca5b72a1ae19472 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -847,6 +847,7 @@ public class PurpurWorldConfig {
+@@ -849,6 +849,7 @@ public class PurpurWorldConfig {
      public boolean creeperAllowGriefing = true;
      public boolean creeperBypassMobGriefing = false;
      public boolean creeperTakeDamageFromWater = false;
@@ -61,7 +61,7 @@ index 1c6bb583b73a02957cb85fa9ecd0b1edc53c3d0d..bd298eed71a02ccfbbd97ce573ebc9c6
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -861,6 +862,7 @@ public class PurpurWorldConfig {
+@@ -863,6 +864,7 @@ public class PurpurWorldConfig {
          creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
          creeperBypassMobGriefing = getBoolean("mobs.creeper.bypass-mob-griefing", creeperBypassMobGriefing);
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);

--- a/patches/server/0143-Config-to-make-Creepers-explode-on-death.patch
+++ b/patches/server/0143-Config-to-make-Creepers-explode-on-death.patch
@@ -50,10 +50,10 @@ index 8db007569fc8a5085071813e1476a27d0f1cff7c..8568be97dcd5bb269e0204faf8b42dc8
  
      private void spawnLingeringCloud() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a439a642084b9808f130b857ab9312f3caaa4e70..9aa82342b58e31b1a10895262ca5b72a1ae19472 100644
+index 92b0823f51e81bd9fb6b402d840be3d45483d99a..01622381405083485521fea827c67fd7c2bf66a4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -849,6 +849,7 @@ public class PurpurWorldConfig {
+@@ -851,6 +851,7 @@ public class PurpurWorldConfig {
      public boolean creeperAllowGriefing = true;
      public boolean creeperBypassMobGriefing = false;
      public boolean creeperTakeDamageFromWater = false;
@@ -61,7 +61,7 @@ index a439a642084b9808f130b857ab9312f3caaa4e70..9aa82342b58e31b1a10895262ca5b72a
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -863,6 +864,7 @@ public class PurpurWorldConfig {
+@@ -865,6 +866,7 @@ public class PurpurWorldConfig {
          creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
          creeperBypassMobGriefing = getBoolean("mobs.creeper.bypass-mob-griefing", creeperBypassMobGriefing);
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);

--- a/patches/server/0144-Configurable-ravager-griefable-blocks-list.patch
+++ b/patches/server/0144-Configurable-ravager-griefable-blocks-list.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable ravager griefable blocks list
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Ravager.java b/src/main/java/net/minecraft/world/entity/monster/Ravager.java
-index b1ef22e46db43f0c5b8bf3d2463850bba025d086..39f6b2a5fc0a37a96098a75f1972e7316572216f 100644
+index 1c28e0f5b96114b2886fcf670ce5ce23526868f3..ee24dd327182387f6547532963972846acfb4da3 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Ravager.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Ravager.java
 @@ -205,7 +205,7 @@ public class Ravager extends Raider {
@@ -31,10 +31,10 @@ index f0fbd16c9b9c3772492c32b3924e99e147e412f0..c0c3bba1555e356c0af7e79e1ecb2aa0
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index bd298eed71a02ccfbbd97ce573ebc9c6976f1943..dcc2339369f233c8d02e7c4f8caf8624b89ea49d 100644
+index 9aa82342b58e31b1a10895262ca5b72a1ae19472..f6d8046230298070e6063470e86bcebb7fc475c2 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1699,6 +1699,7 @@ public class PurpurWorldConfig {
+@@ -1701,6 +1701,7 @@ public class PurpurWorldConfig {
      public double ravagerMaxHealth = 100.0D;
      public boolean ravagerBypassMobGriefing = false;
      public boolean ravagerTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index bd298eed71a02ccfbbd97ce573ebc9c6976f1943..dcc2339369f233c8d02e7c4f8caf8624
      private void ravagerSettings() {
          ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
          ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
-@@ -1711,6 +1712,23 @@ public class PurpurWorldConfig {
+@@ -1713,6 +1714,23 @@ public class PurpurWorldConfig {
          ravagerMaxHealth = getDouble("mobs.ravager.attributes.max_health", ravagerMaxHealth);
          ravagerBypassMobGriefing = getBoolean("mobs.ravager.bypass-mob-griefing", ravagerBypassMobGriefing);
          ravagerTakeDamageFromWater = getBoolean("mobs.ravager.takes-damage-from-water", ravagerTakeDamageFromWater);

--- a/patches/server/0144-Configurable-ravager-griefable-blocks-list.patch
+++ b/patches/server/0144-Configurable-ravager-griefable-blocks-list.patch
@@ -31,10 +31,10 @@ index f0fbd16c9b9c3772492c32b3924e99e147e412f0..c0c3bba1555e356c0af7e79e1ecb2aa0
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9aa82342b58e31b1a10895262ca5b72a1ae19472..f6d8046230298070e6063470e86bcebb7fc475c2 100644
+index 01622381405083485521fea827c67fd7c2bf66a4..657200645df0547912abe0dd5700c1677e203b60 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1701,6 +1701,7 @@ public class PurpurWorldConfig {
+@@ -1703,6 +1703,7 @@ public class PurpurWorldConfig {
      public double ravagerMaxHealth = 100.0D;
      public boolean ravagerBypassMobGriefing = false;
      public boolean ravagerTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index 9aa82342b58e31b1a10895262ca5b72a1ae19472..f6d8046230298070e6063470e86bcebb
      private void ravagerSettings() {
          ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
          ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
-@@ -1713,6 +1714,23 @@ public class PurpurWorldConfig {
+@@ -1715,6 +1716,23 @@ public class PurpurWorldConfig {
          ravagerMaxHealth = getDouble("mobs.ravager.attributes.max_health", ravagerMaxHealth);
          ravagerBypassMobGriefing = getBoolean("mobs.ravager.bypass-mob-griefing", ravagerBypassMobGriefing);
          ravagerTakeDamageFromWater = getBoolean("mobs.ravager.takes-damage-from-water", ravagerTakeDamageFromWater);

--- a/patches/server/0145-Sneak-to-bulk-process-composter.patch
+++ b/patches/server/0145-Sneak-to-bulk-process-composter.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Sneak to bulk process composter
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 58b093bb1de78ee3b3b2ea364aa50474883f443a..2fd89736091bda7005ef27e42a2aad0df27fa3b5 100644
+index 0a3eb5e929c605d9eb7369de8ade8b49951f5d37..b69277b2ce0b5e4fd5cc5c21d07f529a16d21cc6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -568,7 +568,7 @@ public class ServerPlayerGameMode {
@@ -102,10 +102,10 @@ index ae90e86327957bb784e2d81694ee7eea288bb455..c5e4bc4bbeacd4875996ba54e795689f
          int i = (Integer) state.getValue(ComposterBlock.LEVEL);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index dcc2339369f233c8d02e7c4f8caf8624b89ea49d..13025266f375a3cf4af4ba352ce64b9a412e4bcf 100644
+index f6d8046230298070e6063470e86bcebb7fc475c2..6689f56dbc373c8d0425b805d3c6671fb53d475b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -481,6 +481,11 @@ public class PurpurWorldConfig {
+@@ -483,6 +483,11 @@ public class PurpurWorldConfig {
          chestOpenWithBlockOnTop = getBoolean("blocks.chest.open-with-solid-block-on-top", chestOpenWithBlockOnTop);
      }
  

--- a/patches/server/0145-Sneak-to-bulk-process-composter.patch
+++ b/patches/server/0145-Sneak-to-bulk-process-composter.patch
@@ -102,10 +102,10 @@ index ae90e86327957bb784e2d81694ee7eea288bb455..c5e4bc4bbeacd4875996ba54e795689f
          int i = (Integer) state.getValue(ComposterBlock.LEVEL);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f6d8046230298070e6063470e86bcebb7fc475c2..6689f56dbc373c8d0425b805d3c6671fb53d475b 100644
+index 657200645df0547912abe0dd5700c1677e203b60..ee0638c946845efeec8b933d2835ce2e996bb72c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -483,6 +483,11 @@ public class PurpurWorldConfig {
+@@ -485,6 +485,11 @@ public class PurpurWorldConfig {
          chestOpenWithBlockOnTop = getBoolean("blocks.chest.open-with-solid-block-on-top", chestOpenWithBlockOnTop);
      }
  

--- a/patches/server/0146-Config-for-skipping-night.patch
+++ b/patches/server/0146-Config-for-skipping-night.patch
@@ -18,10 +18,10 @@ index e017da4617a62169d8888b8f86e6b3abc0ad1ba0..53f1e0b0f982054c9056f0fe27931bb7
              j = this.levelData.getDayTime() + 24000L;
              TimeSkipEvent event = new TimeSkipEvent(this.getWorld(), TimeSkipEvent.SkipReason.NIGHT_SKIP, (j - j % 24000L) - this.getDayTime());
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 13025266f375a3cf4af4ba352ce64b9a412e4bcf..8ae7369fa0d951a6562b2484a5f6e9be28d9a73d 100644
+index 6689f56dbc373c8d0425b805d3c6671fb53d475b..ae11a9dc4cd9bbce54ffdc0e65a98e8df3e45a73 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -356,6 +356,7 @@ public class PurpurWorldConfig {
+@@ -358,6 +358,7 @@ public class PurpurWorldConfig {
      public boolean playerFixStuckPortal = false;
      public boolean creativeOnePunch = false;
      public boolean playerSleepNearMonsters = false;
@@ -29,7 +29,7 @@ index 13025266f375a3cf4af4ba352ce64b9a412e4bcf..8ae7369fa0d951a6562b2484a5f6e9be
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -376,6 +377,7 @@ public class PurpurWorldConfig {
+@@ -378,6 +379,7 @@ public class PurpurWorldConfig {
          playerFixStuckPortal = getBoolean("gameplay-mechanics.player.fix-stuck-in-portal", playerFixStuckPortal);
          creativeOnePunch = getBoolean("gameplay-mechanics.player.one-punch-in-creative", creativeOnePunch);
          playerSleepNearMonsters = getBoolean("gameplay-mechanics.player.sleep-ignore-nearby-mobs", playerSleepNearMonsters);

--- a/patches/server/0146-Config-for-skipping-night.patch
+++ b/patches/server/0146-Config-for-skipping-night.patch
@@ -18,10 +18,10 @@ index e017da4617a62169d8888b8f86e6b3abc0ad1ba0..53f1e0b0f982054c9056f0fe27931bb7
              j = this.levelData.getDayTime() + 24000L;
              TimeSkipEvent event = new TimeSkipEvent(this.getWorld(), TimeSkipEvent.SkipReason.NIGHT_SKIP, (j - j % 24000L) - this.getDayTime());
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6689f56dbc373c8d0425b805d3c6671fb53d475b..ae11a9dc4cd9bbce54ffdc0e65a98e8df3e45a73 100644
+index ee0638c946845efeec8b933d2835ce2e996bb72c..12fa98f0a2e2579e7ca4c749b53302dfcd2294a6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -358,6 +358,7 @@ public class PurpurWorldConfig {
+@@ -360,6 +360,7 @@ public class PurpurWorldConfig {
      public boolean playerFixStuckPortal = false;
      public boolean creativeOnePunch = false;
      public boolean playerSleepNearMonsters = false;
@@ -29,7 +29,7 @@ index 6689f56dbc373c8d0425b805d3c6671fb53d475b..ae11a9dc4cd9bbce54ffdc0e65a98e8d
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -378,6 +379,7 @@ public class PurpurWorldConfig {
+@@ -380,6 +381,7 @@ public class PurpurWorldConfig {
          playerFixStuckPortal = getBoolean("gameplay-mechanics.player.fix-stuck-in-portal", playerFixStuckPortal);
          creativeOnePunch = getBoolean("gameplay-mechanics.player.one-punch-in-creative", creativeOnePunch);
          playerSleepNearMonsters = getBoolean("gameplay-mechanics.player.sleep-ignore-nearby-mobs", playerSleepNearMonsters);

--- a/patches/server/0147-Add-config-for-villager-trading.patch
+++ b/patches/server/0147-Add-config-for-villager-trading.patch
@@ -31,10 +31,10 @@ index 64c8890a54a10abd454a62671fbabfcf9720b7c0..e06f3ee85dde587f1146d4a3d70e8a2e
                      this.openTradingScreen(player, this.getDisplayName(), 1);
                  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f875df82b1b92ddcf8a23a021b7d77a4a5802ce9..7c2f2b5bc48d1c1d34ad9b1b265be97f1423c36e 100644
+index ae11a9dc4cd9bbce54ffdc0e65a98e8df3e45a73..15a8218d23f1a3cd7f18129057d9a2b8d94f5d44 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2117,6 +2117,7 @@ public class PurpurWorldConfig {
+@@ -2119,6 +2119,7 @@ public class PurpurWorldConfig {
      public boolean villagerClericFarmersThrowWarts = true;
      public boolean villagerBypassMobGriefing = false;
      public boolean villagerTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index f875df82b1b92ddcf8a23a021b7d77a4a5802ce9..7c2f2b5bc48d1c1d34ad9b1b265be97f
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2135,6 +2136,7 @@ public class PurpurWorldConfig {
+@@ -2137,6 +2138,7 @@ public class PurpurWorldConfig {
          villagerClericFarmersThrowWarts = getBoolean("mobs.villager.cleric-wart-farmers-throw-warts-at-villagers", villagerClericFarmersThrowWarts);
          villagerBypassMobGriefing = getBoolean("mobs.villager.bypass-mob-griefing", villagerBypassMobGriefing);
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
@@ -50,7 +50,7 @@ index f875df82b1b92ddcf8a23a021b7d77a4a5802ce9..7c2f2b5bc48d1c1d34ad9b1b265be97f
      }
  
      public boolean vindicatorRidable = false;
-@@ -2164,6 +2166,7 @@ public class PurpurWorldConfig {
+@@ -2166,6 +2168,7 @@ public class PurpurWorldConfig {
      public boolean wanderingTraderFollowEmeraldBlock = false;
      public boolean wanderingTraderCanBeLeashed = false;
      public boolean wanderingTraderTakeDamageFromWater = false;
@@ -58,7 +58,7 @@ index f875df82b1b92ddcf8a23a021b7d77a4a5802ce9..7c2f2b5bc48d1c1d34ad9b1b265be97f
      private void wanderingTraderSettings() {
          wanderingTraderRidable = getBoolean("mobs.wandering_trader.ridable", wanderingTraderRidable);
          wanderingTraderRidableInWater = getBoolean("mobs.wandering_trader.ridable-in-water", wanderingTraderRidableInWater);
-@@ -2177,6 +2180,7 @@ public class PurpurWorldConfig {
+@@ -2179,6 +2182,7 @@ public class PurpurWorldConfig {
          wanderingTraderFollowEmeraldBlock = getBoolean("mobs.wandering_trader.follow-emerald-blocks", wanderingTraderFollowEmeraldBlock);
          wanderingTraderCanBeLeashed = getBoolean("mobs.wandering_trader.can-be-leashed", wanderingTraderCanBeLeashed);
          wanderingTraderTakeDamageFromWater = getBoolean("mobs.wandering_trader.takes-damage-from-water", wanderingTraderTakeDamageFromWater);

--- a/patches/server/0147-Add-config-for-villager-trading.patch
+++ b/patches/server/0147-Add-config-for-villager-trading.patch
@@ -31,10 +31,10 @@ index 64c8890a54a10abd454a62671fbabfcf9720b7c0..e06f3ee85dde587f1146d4a3d70e8a2e
                      this.openTradingScreen(player, this.getDisplayName(), 1);
                  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ae11a9dc4cd9bbce54ffdc0e65a98e8df3e45a73..15a8218d23f1a3cd7f18129057d9a2b8d94f5d44 100644
+index 12fa98f0a2e2579e7ca4c749b53302dfcd2294a6..442554da3ea74845e9e7a97dea9f497caa48e78a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2119,6 +2119,7 @@ public class PurpurWorldConfig {
+@@ -2121,6 +2121,7 @@ public class PurpurWorldConfig {
      public boolean villagerClericFarmersThrowWarts = true;
      public boolean villagerBypassMobGriefing = false;
      public boolean villagerTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index ae11a9dc4cd9bbce54ffdc0e65a98e8df3e45a73..15a8218d23f1a3cd7f18129057d9a2b8
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2137,6 +2138,7 @@ public class PurpurWorldConfig {
+@@ -2139,6 +2140,7 @@ public class PurpurWorldConfig {
          villagerClericFarmersThrowWarts = getBoolean("mobs.villager.cleric-wart-farmers-throw-warts-at-villagers", villagerClericFarmersThrowWarts);
          villagerBypassMobGriefing = getBoolean("mobs.villager.bypass-mob-griefing", villagerBypassMobGriefing);
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
@@ -50,7 +50,7 @@ index ae11a9dc4cd9bbce54ffdc0e65a98e8df3e45a73..15a8218d23f1a3cd7f18129057d9a2b8
      }
  
      public boolean vindicatorRidable = false;
-@@ -2166,6 +2168,7 @@ public class PurpurWorldConfig {
+@@ -2168,6 +2170,7 @@ public class PurpurWorldConfig {
      public boolean wanderingTraderFollowEmeraldBlock = false;
      public boolean wanderingTraderCanBeLeashed = false;
      public boolean wanderingTraderTakeDamageFromWater = false;
@@ -58,7 +58,7 @@ index ae11a9dc4cd9bbce54ffdc0e65a98e8df3e45a73..15a8218d23f1a3cd7f18129057d9a2b8
      private void wanderingTraderSettings() {
          wanderingTraderRidable = getBoolean("mobs.wandering_trader.ridable", wanderingTraderRidable);
          wanderingTraderRidableInWater = getBoolean("mobs.wandering_trader.ridable-in-water", wanderingTraderRidableInWater);
-@@ -2179,6 +2182,7 @@ public class PurpurWorldConfig {
+@@ -2181,6 +2184,7 @@ public class PurpurWorldConfig {
          wanderingTraderFollowEmeraldBlock = getBoolean("mobs.wandering_trader.follow-emerald-blocks", wanderingTraderFollowEmeraldBlock);
          wanderingTraderCanBeLeashed = getBoolean("mobs.wandering_trader.can-be-leashed", wanderingTraderCanBeLeashed);
          wanderingTraderTakeDamageFromWater = getBoolean("mobs.wandering_trader.takes-damage-from-water", wanderingTraderTakeDamageFromWater);

--- a/patches/server/0150-Break-individual-slabs-when-sneaking.patch
+++ b/patches/server/0150-Break-individual-slabs-when-sneaking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Break individual slabs when sneaking
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 2fd89736091bda7005ef27e42a2aad0df27fa3b5..0034831358550491d57360966b1458b34b0908e2 100644
+index b69277b2ce0b5e4fd5cc5c21d07f529a16d21cc6..9564cfd3ff593662cf5755ae1d83dee4b627cdf9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -389,6 +389,7 @@ public class ServerPlayerGameMode {
@@ -47,10 +47,10 @@ index 18b603d646081926343dea108b55d641df1c2c34..03ad3e45fc6d48091ac0c0ba5dc3d014
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 899e320cb3b9fddea44b1844da8ed5103f383196..8a7599c50a07c661f693f43f060c4333486d311e 100644
+index ee79c13757da2cbcce75556be22cab1ddacb674b..902d1d59db95abaeda7130ae6217c06dafca4a3f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -607,6 +607,11 @@ public class PurpurWorldConfig {
+@@ -609,6 +609,11 @@ public class PurpurWorldConfig {
          signRightClickEdit = getBoolean("blocks.sign.right-click-edit", signRightClickEdit);
      }
  

--- a/patches/server/0150-Break-individual-slabs-when-sneaking.patch
+++ b/patches/server/0150-Break-individual-slabs-when-sneaking.patch
@@ -47,10 +47,10 @@ index 18b603d646081926343dea108b55d641df1c2c34..03ad3e45fc6d48091ac0c0ba5dc3d014
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ee79c13757da2cbcce75556be22cab1ddacb674b..902d1d59db95abaeda7130ae6217c06dafca4a3f 100644
+index b3c02579993969be9297ff2eb51b727ae3d824c1..32a269954a183fdd2377cc59bec2f13833f8de55 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -609,6 +609,11 @@ public class PurpurWorldConfig {
+@@ -611,6 +611,11 @@ public class PurpurWorldConfig {
          signRightClickEdit = getBoolean("blocks.sign.right-click-edit", signRightClickEdit);
      }
  

--- a/patches/server/0151-Config-to-disable-hostile-mob-spawn-on-ice.patch
+++ b/patches/server/0151-Config-to-disable-hostile-mob-spawn-on-ice.patch
@@ -24,10 +24,10 @@ index 55c245d0dfa369dc6de2197ae37335fba4fae4ae..c9b40515f4c2ff1eedfc9510930c3bae
              return false;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 902d1d59db95abaeda7130ae6217c06dafca4a3f..ccb63c1c181498b3d0d505777a0451d033ec49e5 100644
+index 32a269954a183fdd2377cc59bec2f13833f8de55..0d0a8eb08605326e990787c8da2df8e16bdf730c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -569,6 +569,13 @@ public class PurpurWorldConfig {
+@@ -571,6 +571,13 @@ public class PurpurWorldConfig {
          furnaceUseLavaFromUnderneath = getBoolean("blocks.furnace.use-lava-from-underneath", furnaceUseLavaFromUnderneath);
      }
  

--- a/patches/server/0151-Config-to-disable-hostile-mob-spawn-on-ice.patch
+++ b/patches/server/0151-Config-to-disable-hostile-mob-spawn-on-ice.patch
@@ -24,10 +24,10 @@ index 55c245d0dfa369dc6de2197ae37335fba4fae4ae..c9b40515f4c2ff1eedfc9510930c3bae
              return false;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 8a7599c50a07c661f693f43f060c4333486d311e..45dbcd413f1711aa3ec2d9e97283a1b46f0a5956 100644
+index 902d1d59db95abaeda7130ae6217c06dafca4a3f..ccb63c1c181498b3d0d505777a0451d033ec49e5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -567,6 +567,13 @@ public class PurpurWorldConfig {
+@@ -569,6 +569,13 @@ public class PurpurWorldConfig {
          furnaceUseLavaFromUnderneath = getBoolean("blocks.furnace.use-lava-from-underneath", furnaceUseLavaFromUnderneath);
      }
  

--- a/patches/server/0153-Option-to-make-doors-require-redstone.patch
+++ b/patches/server/0153-Option-to-make-doors-require-redstone.patch
@@ -67,10 +67,10 @@ index 5ba56ee7d5dd210770e6703be559055d218028d5..b5e90dc00240bccf1a6eca342729a4f4
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 98f74f037c88e147edef3604e896378677e82ba0..abab51201f9741dfdf1689d274d7cf401dec7278 100644
+index e51d792b29c759d036d0c46448810e5164ba4408..4bd1a59451a7a2dc9ddaacaf2296963e8f5c3903 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -506,6 +506,16 @@ public class PurpurWorldConfig {
+@@ -508,6 +508,16 @@ public class PurpurWorldConfig {
          dispenserPlaceAnvils = getBoolean("blocks.dispenser.place-anvils", dispenserPlaceAnvils);
      }
  

--- a/patches/server/0153-Option-to-make-doors-require-redstone.patch
+++ b/patches/server/0153-Option-to-make-doors-require-redstone.patch
@@ -67,10 +67,10 @@ index 5ba56ee7d5dd210770e6703be559055d218028d5..b5e90dc00240bccf1a6eca342729a4f4
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e51d792b29c759d036d0c46448810e5164ba4408..4bd1a59451a7a2dc9ddaacaf2296963e8f5c3903 100644
+index 61e6cb61771294c7e69d64ec93bf5fa6092da402..f00fcbf7d1b81436268c39d4774b411f3e058e51 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -508,6 +508,16 @@ public class PurpurWorldConfig {
+@@ -510,6 +510,16 @@ public class PurpurWorldConfig {
          dispenserPlaceAnvils = getBoolean("blocks.dispenser.place-anvils", dispenserPlaceAnvils);
      }
  

--- a/patches/server/0155-Configurable-sponge-absorption.patch
+++ b/patches/server/0155-Configurable-sponge-absorption.patch
@@ -43,10 +43,10 @@ index 7304b2659eb45bc4bc9fa7c43e6ca07221d0fc73..d96e3fbc0fd4275c29e7e6154ef66e9e
              }
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index abab51201f9741dfdf1689d274d7cf401dec7278..47cd5e9f266bb881bbe4fffa610c14664ce8c088 100644
+index 4bd1a59451a7a2dc9ddaacaf2296963e8f5c3903..377d8e70a6eee67a63f04ed48f0c9d45c56f9136 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -636,6 +636,13 @@ public class PurpurWorldConfig {
+@@ -638,6 +638,13 @@ public class PurpurWorldConfig {
          spawnerDeactivateByRedstone = getBoolean("blocks.spawner.deactivate-by-redstone", spawnerDeactivateByRedstone);
      }
  

--- a/patches/server/0155-Configurable-sponge-absorption.patch
+++ b/patches/server/0155-Configurable-sponge-absorption.patch
@@ -43,10 +43,10 @@ index 7304b2659eb45bc4bc9fa7c43e6ca07221d0fc73..d96e3fbc0fd4275c29e7e6154ef66e9e
              }
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4bd1a59451a7a2dc9ddaacaf2296963e8f5c3903..377d8e70a6eee67a63f04ed48f0c9d45c56f9136 100644
+index f00fcbf7d1b81436268c39d4774b411f3e058e51..651ce073ba2aabdb8bf90fb6abbd772a71de009c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -638,6 +638,13 @@ public class PurpurWorldConfig {
+@@ -640,6 +640,13 @@ public class PurpurWorldConfig {
          spawnerDeactivateByRedstone = getBoolean("blocks.spawner.deactivate-by-redstone", spawnerDeactivateByRedstone);
      }
  

--- a/patches/server/0156-Projectile-offset-config.patch
+++ b/patches/server/0156-Projectile-offset-config.patch
@@ -96,10 +96,10 @@ index 41bd45c0720751f348b5cf6eaecac4397a439857..60512d08a45670a164a9b93191aafa40
                                  entitythrowntrident.pickup = AbstractArrow.Pickup.CREATIVE_ONLY;
                              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 377d8e70a6eee67a63f04ed48f0c9d45c56f9136..837ab09a0cf680a1c10b01baee008e828b4ba859 100644
+index 651ce073ba2aabdb8bf90fb6abbd772a71de009c..b8729b006e2e55b9c914b88d7e1c5b80a96ce171 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -426,6 +426,23 @@ public class PurpurWorldConfig {
+@@ -428,6 +428,23 @@ public class PurpurWorldConfig {
          //}
      }
  

--- a/patches/server/0156-Projectile-offset-config.patch
+++ b/patches/server/0156-Projectile-offset-config.patch
@@ -96,10 +96,10 @@ index 41bd45c0720751f348b5cf6eaecac4397a439857..60512d08a45670a164a9b93191aafa40
                                  entitythrowntrident.pickup = AbstractArrow.Pickup.CREATIVE_ONLY;
                              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 47cd5e9f266bb881bbe4fffa610c14664ce8c088..7dd8b7e559cc3414298af214d59f08bcdc338186 100644
+index 377d8e70a6eee67a63f04ed48f0c9d45c56f9136..837ab09a0cf680a1c10b01baee008e828b4ba859 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -424,6 +424,23 @@ public class PurpurWorldConfig {
+@@ -426,6 +426,23 @@ public class PurpurWorldConfig {
          //}
      }
  

--- a/patches/server/0157-Config-for-powered-rail-activation-distance.patch
+++ b/patches/server/0157-Config-for-powered-rail-activation-distance.patch
@@ -18,10 +18,10 @@ index 7fddb6fa8fd30ef88346a59f7867aae792f13772..40893e71fe8447b695350273bef9623b
          } else {
              int j = pos.getX();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 837ab09a0cf680a1c10b01baee008e828b4ba859..f2ce8669089dded3396c4e866447903abe44d3f4 100644
+index b8729b006e2e55b9c914b88d7e1c5b80a96ce171..9d2b7b8dbcb109f28722ba511d074f93c45f855f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -619,6 +619,11 @@ public class PurpurWorldConfig {
+@@ -621,6 +621,11 @@ public class PurpurWorldConfig {
          powderSnowBypassMobGriefing = getBoolean("blocks.powder_snow.bypass-mob-griefing", powderSnowBypassMobGriefing);
      }
  

--- a/patches/server/0157-Config-for-powered-rail-activation-distance.patch
+++ b/patches/server/0157-Config-for-powered-rail-activation-distance.patch
@@ -18,10 +18,10 @@ index 7fddb6fa8fd30ef88346a59f7867aae792f13772..40893e71fe8447b695350273bef9623b
          } else {
              int j = pos.getX();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7dd8b7e559cc3414298af214d59f08bcdc338186..05348bd6e516284bdec1bb1675bfcf242dcad2e7 100644
+index 837ab09a0cf680a1c10b01baee008e828b4ba859..f2ce8669089dded3396c4e866447903abe44d3f4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -617,6 +617,11 @@ public class PurpurWorldConfig {
+@@ -619,6 +619,11 @@ public class PurpurWorldConfig {
          powderSnowBypassMobGriefing = getBoolean("blocks.powder_snow.bypass-mob-griefing", powderSnowBypassMobGriefing);
      }
  

--- a/patches/server/0158-Piglin-portal-spawn-modifier.patch
+++ b/patches/server/0158-Piglin-portal-spawn-modifier.patch
@@ -31,10 +31,10 @@ index 2c085c4a154cb0f8a1d38453f43474a764398784..589b437e7c97c846410f293e2f014bdc
                  pos = pos.below();
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 05348bd6e516284bdec1bb1675bfcf242dcad2e7..deb9b89415088a57b7a658d8017ace00155f0956 100644
+index f2ce8669089dded3396c4e866447903abe44d3f4..a4e0a1f609624255aa12577f7fc4cfec6d829640 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1643,6 +1643,7 @@ public class PurpurWorldConfig {
+@@ -1645,6 +1645,7 @@ public class PurpurWorldConfig {
      public double piglinMaxHealth = 16.0D;
      public boolean piglinBypassMobGriefing = false;
      public boolean piglinTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index 05348bd6e516284bdec1bb1675bfcf242dcad2e7..deb9b89415088a57b7a658d8017ace00
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -1655,6 +1656,7 @@ public class PurpurWorldConfig {
+@@ -1657,6 +1658,7 @@ public class PurpurWorldConfig {
          piglinMaxHealth = getDouble("mobs.piglin.attributes.max_health", piglinMaxHealth);
          piglinBypassMobGriefing = getBoolean("mobs.piglin.bypass-mob-griefing", piglinBypassMobGriefing);
          piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);

--- a/patches/server/0158-Piglin-portal-spawn-modifier.patch
+++ b/patches/server/0158-Piglin-portal-spawn-modifier.patch
@@ -31,10 +31,10 @@ index 2c085c4a154cb0f8a1d38453f43474a764398784..589b437e7c97c846410f293e2f014bdc
                  pos = pos.below();
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f2ce8669089dded3396c4e866447903abe44d3f4..a4e0a1f609624255aa12577f7fc4cfec6d829640 100644
+index 9d2b7b8dbcb109f28722ba511d074f93c45f855f..0c37f3a761d602b9a2a1041b1f2d4e56df372d18 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1645,6 +1645,7 @@ public class PurpurWorldConfig {
+@@ -1647,6 +1647,7 @@ public class PurpurWorldConfig {
      public double piglinMaxHealth = 16.0D;
      public boolean piglinBypassMobGriefing = false;
      public boolean piglinTakeDamageFromWater = false;
@@ -42,7 +42,7 @@ index f2ce8669089dded3396c4e866447903abe44d3f4..a4e0a1f609624255aa12577f7fc4cfec
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -1657,6 +1658,7 @@ public class PurpurWorldConfig {
+@@ -1659,6 +1660,7 @@ public class PurpurWorldConfig {
          piglinMaxHealth = getDouble("mobs.piglin.attributes.max_health", piglinMaxHealth);
          piglinBypassMobGriefing = getBoolean("mobs.piglin.bypass-mob-griefing", piglinBypassMobGriefing);
          piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);

--- a/patches/server/0160-Config-for-wither-explosion-radius.patch
+++ b/patches/server/0160-Config-for-wither-explosion-radius.patch
@@ -18,10 +18,10 @@ index 093a00e52062868b4fbf358b307513d0f599f69d..ba753735f3cbb2cb3d0a491d1bd94a04
  
              if (!event.isCancelled()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index be9fb06b266a3cce69cd5650f52a0df05e4dd750..be3c63b843cc24314becf29d4c27273866c776b4 100644
+index a4e0a1f609624255aa12577f7fc4cfec6d829640..defe343856dab9ede37576c3e43fcac283367ff3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2284,6 +2284,7 @@ public class PurpurWorldConfig {
+@@ -2286,6 +2286,7 @@ public class PurpurWorldConfig {
      public boolean witherBypassMobGriefing = false;
      public boolean witherTakeDamageFromWater = false;
      public boolean witherCanRideVehicles = false;
@@ -29,7 +29,7 @@ index be9fb06b266a3cce69cd5650f52a0df05e4dd750..be3c63b843cc24314becf29d4c272738
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2304,6 +2305,7 @@ public class PurpurWorldConfig {
+@@ -2306,6 +2307,7 @@ public class PurpurWorldConfig {
          witherBypassMobGriefing = getBoolean("mobs.wither.bypass-mob-griefing", witherBypassMobGriefing);
          witherTakeDamageFromWater = getBoolean("mobs.wither.takes-damage-from-water", witherTakeDamageFromWater);
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);

--- a/patches/server/0160-Config-for-wither-explosion-radius.patch
+++ b/patches/server/0160-Config-for-wither-explosion-radius.patch
@@ -18,10 +18,10 @@ index 093a00e52062868b4fbf358b307513d0f599f69d..ba753735f3cbb2cb3d0a491d1bd94a04
  
              if (!event.isCancelled()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a4e0a1f609624255aa12577f7fc4cfec6d829640..defe343856dab9ede37576c3e43fcac283367ff3 100644
+index 0c37f3a761d602b9a2a1041b1f2d4e56df372d18..f46420e65ff6d5863815d9c2d7a8bccd48481d4c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2286,6 +2286,7 @@ public class PurpurWorldConfig {
+@@ -2288,6 +2288,7 @@ public class PurpurWorldConfig {
      public boolean witherBypassMobGriefing = false;
      public boolean witherTakeDamageFromWater = false;
      public boolean witherCanRideVehicles = false;
@@ -29,7 +29,7 @@ index a4e0a1f609624255aa12577f7fc4cfec6d829640..defe343856dab9ede37576c3e43fcac2
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2306,6 +2307,7 @@ public class PurpurWorldConfig {
+@@ -2308,6 +2309,7 @@ public class PurpurWorldConfig {
          witherBypassMobGriefing = getBoolean("mobs.wither.bypass-mob-griefing", witherBypassMobGriefing);
          witherTakeDamageFromWater = getBoolean("mobs.wither.takes-damage-from-water", witherTakeDamageFromWater);
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);

--- a/patches/server/0162-Config-for-changing-the-blocks-that-turn-into-dirt-p.patch
+++ b/patches/server/0162-Config-for-changing-the-blocks-that-turn-into-dirt-p.patch
@@ -18,10 +18,10 @@ index c7195f2e12bbd6545f7bffcc2b4ba5cc3d48df20..5e730bc9c8ff94b16ac2bf8567dda8ae
              Runnable afterAction = null; // Paper
              if (blockState2 != null && level.getBlockState(blockPos.above()).isAir()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index defe343856dab9ede37576c3e43fcac283367ff3..07360d2bc81d7ed5adf54590c9bb68c7b3c9f914 100644
+index f46420e65ff6d5863815d9c2d7a8bccd48481d4c..d7352f1f2477b03d51181dba4ca1759745d67596 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -448,6 +448,21 @@ public class PurpurWorldConfig {
+@@ -450,6 +450,21 @@ public class PurpurWorldConfig {
          snowballDamage = getInt("gameplay-mechanics.projectile-damage.snowball", snowballDamage);
      }
  

--- a/patches/server/0162-Config-for-changing-the-blocks-that-turn-into-dirt-p.patch
+++ b/patches/server/0162-Config-for-changing-the-blocks-that-turn-into-dirt-p.patch
@@ -18,10 +18,10 @@ index c7195f2e12bbd6545f7bffcc2b4ba5cc3d48df20..5e730bc9c8ff94b16ac2bf8567dda8ae
              Runnable afterAction = null; // Paper
              if (blockState2 != null && level.getBlockState(blockPos.above()).isAir()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 319a58d0cfeae9395d0f41a6f4a97ca89b3c4df5..86f5341479c71833124902e14683f03faddaad44 100644
+index defe343856dab9ede37576c3e43fcac283367ff3..07360d2bc81d7ed5adf54590c9bb68c7b3c9f914 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -446,6 +446,21 @@ public class PurpurWorldConfig {
+@@ -448,6 +448,21 @@ public class PurpurWorldConfig {
          snowballDamage = getInt("gameplay-mechanics.projectile-damage.snowball", snowballDamage);
      }
  

--- a/patches/server/0163-Configurable-piston-push-limit.patch
+++ b/patches/server/0163-Configurable-piston-push-limit.patch
@@ -36,10 +36,10 @@ index 744d91546d1a810f60a43c15ed74b4158f341a4a..354538daefa603f6df5a139b6bff87db
                      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 86f5341479c71833124902e14683f03faddaad44..ce92ab1a31c000a66b8bf45651563f2e8c0c5a9b 100644
+index 07360d2bc81d7ed5adf54590c9bb68c7b3c9f914..9493183f9fec2fa52be61bd8ed44dfd1ec1d5dc3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -627,6 +627,11 @@ public class PurpurWorldConfig {
+@@ -629,6 +629,11 @@ public class PurpurWorldConfig {
          lavaSpeedNotNether = getInt("blocks.lava.speed.not-nether", lavaSpeedNotNether);
      }
  

--- a/patches/server/0163-Configurable-piston-push-limit.patch
+++ b/patches/server/0163-Configurable-piston-push-limit.patch
@@ -36,10 +36,10 @@ index 744d91546d1a810f60a43c15ed74b4158f341a4a..354538daefa603f6df5a139b6bff87db
                      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 07360d2bc81d7ed5adf54590c9bb68c7b3c9f914..9493183f9fec2fa52be61bd8ed44dfd1ec1d5dc3 100644
+index d7352f1f2477b03d51181dba4ca1759745d67596..6b8f31ba8d91c44174f96a0fa28f196d72fb198d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -629,6 +629,11 @@ public class PurpurWorldConfig {
+@@ -631,6 +631,11 @@ public class PurpurWorldConfig {
          lavaSpeedNotNether = getInt("blocks.lava.speed.not-nether", lavaSpeedNotNether);
      }
  

--- a/patches/server/0167-Config-for-health-to-impact-Creeper-explosion-radius.patch
+++ b/patches/server/0167-Config-for-health-to-impact-Creeper-explosion-radius.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Config for health to impact Creeper explosion radius
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Creeper.java b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
-index 1d099bfb7b35062178d65a0808ba99b0da5ef885..415f5fc5c6b1f780a28917c21d0856ee598c59fc 100644
+index 8568be97dcd5bb269e0204faf8b42dc8cb152282..30df0e74950c6629fce06923a4a7d57341606fd6 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Creeper.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Creeper.java
 @@ -370,9 +370,10 @@ public class Creeper extends Monster implements PowerableMob {
@@ -21,10 +21,10 @@ index 1d099bfb7b35062178d65a0808ba99b0da5ef885..415f5fc5c6b1f780a28917c21d0856ee
              if (!event.isCancelled()) {
                  this.dead = true;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 8c4b7ad4af57e2547b0e01032e8b6a8341cdb2ba..68c392bcb3a8a553986f9d13bb19d8b982e481ce 100644
+index 37e8271a49b08886b5a1fcaaf2b8331337da60e2..7ebb87d6ba54610c8d7ff42e8198f04e96586d5d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -939,6 +939,7 @@ public class PurpurWorldConfig {
+@@ -941,6 +941,7 @@ public class PurpurWorldConfig {
      public boolean creeperBypassMobGriefing = false;
      public boolean creeperTakeDamageFromWater = false;
      public boolean creeperExplodeWhenKilled = false;
@@ -32,7 +32,7 @@ index 8c4b7ad4af57e2547b0e01032e8b6a8341cdb2ba..68c392bcb3a8a553986f9d13bb19d8b9
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -954,6 +955,7 @@ public class PurpurWorldConfig {
+@@ -956,6 +957,7 @@ public class PurpurWorldConfig {
          creeperBypassMobGriefing = getBoolean("mobs.creeper.bypass-mob-griefing", creeperBypassMobGriefing);
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);

--- a/patches/server/0167-Config-for-health-to-impact-Creeper-explosion-radius.patch
+++ b/patches/server/0167-Config-for-health-to-impact-Creeper-explosion-radius.patch
@@ -21,10 +21,10 @@ index 8568be97dcd5bb269e0204faf8b42dc8cb152282..30df0e74950c6629fce06923a4a7d573
              if (!event.isCancelled()) {
                  this.dead = true;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 37e8271a49b08886b5a1fcaaf2b8331337da60e2..7ebb87d6ba54610c8d7ff42e8198f04e96586d5d 100644
+index c4189d8f5a0fb7a53a6f0119d37aa297ffea2f7b..2dcb16f02e7d7edac0cc01d4da791af8e6e8960a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -941,6 +941,7 @@ public class PurpurWorldConfig {
+@@ -943,6 +943,7 @@ public class PurpurWorldConfig {
      public boolean creeperBypassMobGriefing = false;
      public boolean creeperTakeDamageFromWater = false;
      public boolean creeperExplodeWhenKilled = false;
@@ -32,7 +32,7 @@ index 37e8271a49b08886b5a1fcaaf2b8331337da60e2..7ebb87d6ba54610c8d7ff42e8198f04e
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -956,6 +957,7 @@ public class PurpurWorldConfig {
+@@ -958,6 +959,7 @@ public class PurpurWorldConfig {
          creeperBypassMobGriefing = getBoolean("mobs.creeper.bypass-mob-griefing", creeperBypassMobGriefing);
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);

--- a/patches/server/0168-Iron-golem-calm-anger-options.patch
+++ b/patches/server/0168-Iron-golem-calm-anger-options.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Iron golem calm anger options
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/IronGolem.java b/src/main/java/net/minecraft/world/entity/animal/IronGolem.java
-index 782949596cd160847a0332f48372d186a5e71eab..bb7376bff9c4c90f3e10ae8b8f29ecdf0b51a3db 100644
+index f25f7db029c0c21f31693349ef567dddeace3db1..6b651c0c4a4d13f9b9cac5aab1ab843077c4cac0 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/IronGolem.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/IronGolem.java
 @@ -100,6 +100,7 @@ public class IronGolem extends AbstractGolem implements NeutralMob {
@@ -26,10 +26,10 @@ index 782949596cd160847a0332f48372d186a5e71eab..bb7376bff9c4c90f3e10ae8b8f29ecdf
              }
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 68c392bcb3a8a553986f9d13bb19d8b982e481ce..e44f013dc36128facd1ef8ba40a2da1c30f6ccab 100644
+index 7ebb87d6ba54610c8d7ff42e8198f04e96586d5d..6ef0087566b56ac1c1a884ec064d045369339a3f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1397,6 +1397,8 @@ public class PurpurWorldConfig {
+@@ -1399,6 +1399,8 @@ public class PurpurWorldConfig {
      public boolean ironGolemCanSwim = false;
      public double ironGolemMaxHealth = 100.0D;
      public boolean ironGolemTakeDamageFromWater = false;
@@ -38,7 +38,7 @@ index 68c392bcb3a8a553986f9d13bb19d8b982e481ce..e44f013dc36128facd1ef8ba40a2da1c
      private void ironGolemSettings() {
          ironGolemRidable = getBoolean("mobs.iron_golem.ridable", ironGolemRidable);
          ironGolemRidableInWater = getBoolean("mobs.iron_golem.ridable-in-water", ironGolemRidableInWater);
-@@ -1409,6 +1411,8 @@ public class PurpurWorldConfig {
+@@ -1411,6 +1413,8 @@ public class PurpurWorldConfig {
          }
          ironGolemMaxHealth = getDouble("mobs.iron_golem.attributes.max_health", ironGolemMaxHealth);
          ironGolemTakeDamageFromWater = getBoolean("mobs.iron_golem.takes-damage-from-water", ironGolemTakeDamageFromWater);

--- a/patches/server/0168-Iron-golem-calm-anger-options.patch
+++ b/patches/server/0168-Iron-golem-calm-anger-options.patch
@@ -26,10 +26,10 @@ index f25f7db029c0c21f31693349ef567dddeace3db1..6b651c0c4a4d13f9b9cac5aab1ab8430
              }
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7ebb87d6ba54610c8d7ff42e8198f04e96586d5d..6ef0087566b56ac1c1a884ec064d045369339a3f 100644
+index 2dcb16f02e7d7edac0cc01d4da791af8e6e8960a..18fc3911cedf5f093fc9c79f4d054f9e09b35be1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1399,6 +1399,8 @@ public class PurpurWorldConfig {
+@@ -1401,6 +1401,8 @@ public class PurpurWorldConfig {
      public boolean ironGolemCanSwim = false;
      public double ironGolemMaxHealth = 100.0D;
      public boolean ironGolemTakeDamageFromWater = false;
@@ -38,7 +38,7 @@ index 7ebb87d6ba54610c8d7ff42e8198f04e96586d5d..6ef0087566b56ac1c1a884ec064d0453
      private void ironGolemSettings() {
          ironGolemRidable = getBoolean("mobs.iron_golem.ridable", ironGolemRidable);
          ironGolemRidableInWater = getBoolean("mobs.iron_golem.ridable-in-water", ironGolemRidableInWater);
-@@ -1411,6 +1413,8 @@ public class PurpurWorldConfig {
+@@ -1413,6 +1415,8 @@ public class PurpurWorldConfig {
          }
          ironGolemMaxHealth = getDouble("mobs.iron_golem.attributes.max_health", ironGolemMaxHealth);
          ironGolemTakeDamageFromWater = getBoolean("mobs.iron_golem.takes-damage-from-water", ironGolemTakeDamageFromWater);

--- a/patches/server/0169-Breedable-parrots.patch
+++ b/patches/server/0169-Breedable-parrots.patch
@@ -50,10 +50,10 @@ index f7efb2088c554782fd169b901b4ef3fca3b2c0f9..629ced06cc17ebd6a359b74858d073e1
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6ef0087566b56ac1c1a884ec064d045369339a3f..583f4be0600a32f0098096bf6f70dbfff4108837 100644
+index 18fc3911cedf5f093fc9c79f4d054f9e09b35be1..bd399e23d226448159315e4996f931b11302217f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1569,6 +1569,7 @@ public class PurpurWorldConfig {
+@@ -1571,6 +1571,7 @@ public class PurpurWorldConfig {
      public double parrotMaxY = 320D;
      public double parrotMaxHealth = 6.0D;
      public boolean parrotTakeDamageFromWater = false;
@@ -61,7 +61,7 @@ index 6ef0087566b56ac1c1a884ec064d045369339a3f..583f4be0600a32f0098096bf6f70dbff
      private void parrotSettings() {
          parrotRidable = getBoolean("mobs.parrot.ridable", parrotRidable);
          parrotRidableInWater = getBoolean("mobs.parrot.ridable-in-water", parrotRidableInWater);
-@@ -1581,6 +1582,7 @@ public class PurpurWorldConfig {
+@@ -1583,6 +1584,7 @@ public class PurpurWorldConfig {
          }
          parrotMaxHealth = getDouble("mobs.parrot.attributes.max_health", parrotMaxHealth);
          parrotTakeDamageFromWater = getBoolean("mobs.parrot.takes-damage-from-water", parrotTakeDamageFromWater);

--- a/patches/server/0169-Breedable-parrots.patch
+++ b/patches/server/0169-Breedable-parrots.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Breedable parrots
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Parrot.java b/src/main/java/net/minecraft/world/entity/animal/Parrot.java
-index 9228dc98360ff34e4cdd105be36ed249c5b67067..6c57b093366019f78627f75bab2d710c6556c030 100644
+index f7efb2088c554782fd169b901b4ef3fca3b2c0f9..629ced06cc17ebd6a359b74858d073e12c6a3b88 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Parrot.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Parrot.java
 @@ -228,6 +228,7 @@ public class Parrot extends ShoulderRidingEntity implements VariantHolder<Parrot
@@ -50,10 +50,10 @@ index 9228dc98360ff34e4cdd105be36ed249c5b67067..6c57b093366019f78627f75bab2d710c
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e44f013dc36128facd1ef8ba40a2da1c30f6ccab..44ac29b4c92fd533e084567caf8f36e81b9dc853 100644
+index 6ef0087566b56ac1c1a884ec064d045369339a3f..583f4be0600a32f0098096bf6f70dbfff4108837 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1567,6 +1567,7 @@ public class PurpurWorldConfig {
+@@ -1569,6 +1569,7 @@ public class PurpurWorldConfig {
      public double parrotMaxY = 320D;
      public double parrotMaxHealth = 6.0D;
      public boolean parrotTakeDamageFromWater = false;
@@ -61,7 +61,7 @@ index e44f013dc36128facd1ef8ba40a2da1c30f6ccab..44ac29b4c92fd533e084567caf8f36e8
      private void parrotSettings() {
          parrotRidable = getBoolean("mobs.parrot.ridable", parrotRidable);
          parrotRidableInWater = getBoolean("mobs.parrot.ridable-in-water", parrotRidableInWater);
-@@ -1579,6 +1580,7 @@ public class PurpurWorldConfig {
+@@ -1581,6 +1582,7 @@ public class PurpurWorldConfig {
          }
          parrotMaxHealth = getDouble("mobs.parrot.attributes.max_health", parrotMaxHealth);
          parrotTakeDamageFromWater = getBoolean("mobs.parrot.takes-damage-from-water", parrotTakeDamageFromWater);

--- a/patches/server/0170-Configurable-powered-rail-boost-modifier.patch
+++ b/patches/server/0170-Configurable-powered-rail-boost-modifier.patch
@@ -18,10 +18,10 @@ index 14083c591edb9a7b1eae7bd21705a7f5f0c3cbfa..cd8239423d964ef9b708d283a329986c
                  Vec3 vec3d5 = this.getDeltaMovement();
                  double d21 = vec3d5.x;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 44ac29b4c92fd533e084567caf8f36e81b9dc853..49a41a94f064fbca3f286c628cb2a9cca0864be7 100644
+index 583f4be0600a32f0098096bf6f70dbfff4108837..679e3eb08ced66228aac8703ddd5e4bdde446a2d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -273,6 +273,7 @@ public class PurpurWorldConfig {
+@@ -275,6 +275,7 @@ public class PurpurWorldConfig {
      public boolean minecartControllableFallDamage = true;
      public double minecartControllableBaseSpeed = 0.1D;
      public Map<Block, Double> minecartControllableBlockSpeeds = new HashMap<>();
@@ -29,7 +29,7 @@ index 44ac29b4c92fd533e084567caf8f36e81b9dc853..49a41a94f064fbca3f286c628cb2a9cc
      private void minecartSettings() {
          if (PurpurConfig.version < 12) {
              boolean oldBool = getBoolean("gameplay-mechanics.controllable-minecarts.place-anywhere", minecartPlaceAnywhere);
-@@ -325,6 +326,7 @@ public class PurpurWorldConfig {
+@@ -327,6 +328,7 @@ public class PurpurWorldConfig {
              set("gameplay-mechanics.minecart.controllable.block-speed.grass_block", 0.3D);
              set("gameplay-mechanics.minecart.controllable.block-speed.stone", 0.5D);
          }

--- a/patches/server/0170-Configurable-powered-rail-boost-modifier.patch
+++ b/patches/server/0170-Configurable-powered-rail-boost-modifier.patch
@@ -18,10 +18,10 @@ index 14083c591edb9a7b1eae7bd21705a7f5f0c3cbfa..cd8239423d964ef9b708d283a329986c
                  Vec3 vec3d5 = this.getDeltaMovement();
                  double d21 = vec3d5.x;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 583f4be0600a32f0098096bf6f70dbfff4108837..679e3eb08ced66228aac8703ddd5e4bdde446a2d 100644
+index bd399e23d226448159315e4996f931b11302217f..9993e555c7fb706e73ca3258724fed2953735ae3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -275,6 +275,7 @@ public class PurpurWorldConfig {
+@@ -277,6 +277,7 @@ public class PurpurWorldConfig {
      public boolean minecartControllableFallDamage = true;
      public double minecartControllableBaseSpeed = 0.1D;
      public Map<Block, Double> minecartControllableBlockSpeeds = new HashMap<>();
@@ -29,7 +29,7 @@ index 583f4be0600a32f0098096bf6f70dbfff4108837..679e3eb08ced66228aac8703ddd5e4bd
      private void minecartSettings() {
          if (PurpurConfig.version < 12) {
              boolean oldBool = getBoolean("gameplay-mechanics.controllable-minecarts.place-anywhere", minecartPlaceAnywhere);
-@@ -327,6 +328,7 @@ public class PurpurWorldConfig {
+@@ -329,6 +330,7 @@ public class PurpurWorldConfig {
              set("gameplay-mechanics.minecart.controllable.block-speed.grass_block", 0.3D);
              set("gameplay-mechanics.minecart.controllable.block-speed.stone", 0.5D);
          }

--- a/patches/server/0171-Add-config-change-multiplier-critical-damage-value.patch
+++ b/patches/server/0171-Add-config-change-multiplier-critical-damage-value.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add config change multiplier critical damage value
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 150aaa68340f25c39a9b10eda43e9941a22d0aae..97b6ab27109b1bd7614ff3cc1322452608587ad9 100644
+index dc395219fddf7f994200bc943768d9348201e656..4ec3fd47de4d22aa76a742a1fc1edff6fe95c82c 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -1306,7 +1306,7 @@ public abstract class Player extends LivingEntity {
@@ -18,10 +18,10 @@ index 150aaa68340f25c39a9b10eda43e9941a22d0aae..97b6ab27109b1bd7614ff3cc13224526
  
                      f += f1;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 49a41a94f064fbca3f286c628cb2a9cca0864be7..779f0658d3b7a9672f3e5bcc8268541ad3a07079 100644
+index 679e3eb08ced66228aac8703ddd5e4bdde446a2d..0ab51df5c4ef2c38f2baf0fa880fef7dfbeb067a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -372,6 +372,7 @@ public class PurpurWorldConfig {
+@@ -374,6 +374,7 @@ public class PurpurWorldConfig {
      public boolean creativeOnePunch = false;
      public boolean playerSleepNearMonsters = false;
      public boolean playersSkipNight = true;
@@ -29,7 +29,7 @@ index 49a41a94f064fbca3f286c628cb2a9cca0864be7..779f0658d3b7a9672f3e5bcc8268541a
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -393,6 +394,7 @@ public class PurpurWorldConfig {
+@@ -395,6 +396,7 @@ public class PurpurWorldConfig {
          creativeOnePunch = getBoolean("gameplay-mechanics.player.one-punch-in-creative", creativeOnePunch);
          playerSleepNearMonsters = getBoolean("gameplay-mechanics.player.sleep-ignore-nearby-mobs", playerSleepNearMonsters);
          playersSkipNight = getBoolean("gameplay-mechanics.player.can-skip-night", playersSkipNight);

--- a/patches/server/0171-Add-config-change-multiplier-critical-damage-value.patch
+++ b/patches/server/0171-Add-config-change-multiplier-critical-damage-value.patch
@@ -18,10 +18,10 @@ index dc395219fddf7f994200bc943768d9348201e656..4ec3fd47de4d22aa76a742a1fc1edff6
  
                      f += f1;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 679e3eb08ced66228aac8703ddd5e4bdde446a2d..0ab51df5c4ef2c38f2baf0fa880fef7dfbeb067a 100644
+index 9993e555c7fb706e73ca3258724fed2953735ae3..783f3a8684740e91e479c4c1cb9c95807ab856db 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -374,6 +374,7 @@ public class PurpurWorldConfig {
+@@ -376,6 +376,7 @@ public class PurpurWorldConfig {
      public boolean creativeOnePunch = false;
      public boolean playerSleepNearMonsters = false;
      public boolean playersSkipNight = true;
@@ -29,7 +29,7 @@ index 679e3eb08ced66228aac8703ddd5e4bdde446a2d..0ab51df5c4ef2c38f2baf0fa880fef7d
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -395,6 +396,7 @@ public class PurpurWorldConfig {
+@@ -397,6 +398,7 @@ public class PurpurWorldConfig {
          creativeOnePunch = getBoolean("gameplay-mechanics.player.one-punch-in-creative", creativeOnePunch);
          playerSleepNearMonsters = getBoolean("gameplay-mechanics.player.sleep-ignore-nearby-mobs", playerSleepNearMonsters);
          playersSkipNight = getBoolean("gameplay-mechanics.player.can-skip-night", playersSkipNight);

--- a/patches/server/0172-Option-to-disable-dragon-egg-teleporting.patch
+++ b/patches/server/0172-Option-to-disable-dragon-egg-teleporting.patch
@@ -19,10 +19,10 @@ index 7e1edcc7b9f170b7c649437c2f0dd78c0bab9be4..5f8ac1fdac2c334951261f2b9702f5e7
              BlockPos blockposition1 = pos.offset(world.random.nextInt(16) - world.random.nextInt(16), world.random.nextInt(8) - world.random.nextInt(8), world.random.nextInt(16) - world.random.nextInt(16));
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 779f0658d3b7a9672f3e5bcc8268541ad3a07079..a4cad3dd976320c16520ebef4de977391b613809 100644
+index 0ab51df5c4ef2c38f2baf0fa880fef7dfbeb067a..2ff72c0f5dd714887972ad8281ec3a9402ad4fed 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -554,6 +554,11 @@ public class PurpurWorldConfig {
+@@ -556,6 +556,11 @@ public class PurpurWorldConfig {
          });
      }
  

--- a/patches/server/0172-Option-to-disable-dragon-egg-teleporting.patch
+++ b/patches/server/0172-Option-to-disable-dragon-egg-teleporting.patch
@@ -19,10 +19,10 @@ index 7e1edcc7b9f170b7c649437c2f0dd78c0bab9be4..5f8ac1fdac2c334951261f2b9702f5e7
              BlockPos blockposition1 = pos.offset(world.random.nextInt(16) - world.random.nextInt(16), world.random.nextInt(8) - world.random.nextInt(8), world.random.nextInt(16) - world.random.nextInt(16));
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 0ab51df5c4ef2c38f2baf0fa880fef7dfbeb067a..2ff72c0f5dd714887972ad8281ec3a9402ad4fed 100644
+index 783f3a8684740e91e479c4c1cb9c95807ab856db..fbdf0001682aab5a8e8f636ccb19c78beda44f66 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -556,6 +556,11 @@ public class PurpurWorldConfig {
+@@ -558,6 +558,11 @@ public class PurpurWorldConfig {
          });
      }
  

--- a/patches/server/0175-ShulkerBox-allow-oversized-stacks.patch
+++ b/patches/server/0175-ShulkerBox-allow-oversized-stacks.patch
@@ -9,7 +9,7 @@ creating an itemstack using the TileEntity's NBT data (how it handles it for
 creative players) instead of routing it through the LootableBuilder.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 0034831358550491d57360966b1458b34b0908e2..88c8f2c53c024021e7bad1e4666e3438b53ab588 100644
+index 9564cfd3ff593662cf5755ae1d83dee4b627cdf9..49335b4fc2a9caab1418531a814210bf52b3cc43 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -420,7 +420,7 @@ public class ServerPlayerGameMode {
@@ -35,10 +35,10 @@ index c89978ecbc5a13dda6f76ea6d1cc3056efc9a174..39868ad3ee4bb573a4dd562894d93f64
                  blockEntity.saveToItem(itemStack);
                  if (shulkerBoxBlockEntity.hasCustomName()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a4cad3dd976320c16520ebef4de977391b613809..26d97b1a483f4fd7a301b2bc7eb7c897fc9c0a62 100644
+index 2ff72c0f5dd714887972ad8281ec3a9402ad4fed..2ce00a53aa6e7ffa571e39dd708e8c2f1a06b9ca 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -674,6 +674,11 @@ public class PurpurWorldConfig {
+@@ -676,6 +676,11 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0175-ShulkerBox-allow-oversized-stacks.patch
+++ b/patches/server/0175-ShulkerBox-allow-oversized-stacks.patch
@@ -35,10 +35,10 @@ index c89978ecbc5a13dda6f76ea6d1cc3056efc9a174..39868ad3ee4bb573a4dd562894d93f64
                  blockEntity.saveToItem(itemStack);
                  if (shulkerBoxBlockEntity.hasCustomName()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 2ff72c0f5dd714887972ad8281ec3a9402ad4fed..2ce00a53aa6e7ffa571e39dd708e8c2f1a06b9ca 100644
+index fbdf0001682aab5a8e8f636ccb19c78beda44f66..db08680cbf624a7115c26294812cfebf6b0d84bb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -676,6 +676,11 @@ public class PurpurWorldConfig {
+@@ -678,6 +678,11 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0176-Bee-can-work-when-raining-or-at-night.patch
+++ b/patches/server/0176-Bee-can-work-when-raining-or-at-night.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Bee can work when raining or at night
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Bee.java b/src/main/java/net/minecraft/world/entity/animal/Bee.java
-index 04656231fa0f96eaeb9ae463695ede400b07df09..575dbcf7a5399d7c9067b02337b1dbe294772109 100644
+index f379f4c45c5aaf8aa8d166148cdc07517c84649a..9d087295d63115d9b916e052b419789c0aa9fc63 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Bee.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Bee.java
 @@ -410,7 +410,7 @@ public class Bee extends Animal implements NeutralMob, FlyingAnimal {
@@ -31,10 +31,10 @@ index a16a1df28258d605cf5908dbe19bda5d71ad4f45..7b82842b97ce795745cf6ee6399f618c
              return false;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 26d97b1a483f4fd7a301b2bc7eb7c897fc9c0a62..b2d0cc6032c65e3f70904bb8cd052f7fcf8cb81b 100644
+index 2ce00a53aa6e7ffa571e39dd708e8c2f1a06b9ca..b06a572269c3ff5fa5a4c02059cf85060d6a9d79 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -782,6 +782,8 @@ public class PurpurWorldConfig {
+@@ -784,6 +784,8 @@ public class PurpurWorldConfig {
      public double beeMaxHealth = 10.0D;
      public int beeBreedingTicks = 6000;
      public boolean beeTakeDamageFromWater = false;
@@ -43,7 +43,7 @@ index 26d97b1a483f4fd7a301b2bc7eb7c897fc9c0a62..b2d0cc6032c65e3f70904bb8cd052f7f
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -795,6 +797,8 @@ public class PurpurWorldConfig {
+@@ -797,6 +799,8 @@ public class PurpurWorldConfig {
          beeMaxHealth = getDouble("mobs.bee.attributes.max_health", beeMaxHealth);
          beeBreedingTicks = getInt("mobs.bee.breeding-delay-ticks", beeBreedingTicks);
          beeTakeDamageFromWater = getBoolean("mobs.bee.takes-damage-from-water", beeTakeDamageFromWater);

--- a/patches/server/0176-Bee-can-work-when-raining-or-at-night.patch
+++ b/patches/server/0176-Bee-can-work-when-raining-or-at-night.patch
@@ -31,10 +31,10 @@ index a16a1df28258d605cf5908dbe19bda5d71ad4f45..7b82842b97ce795745cf6ee6399f618c
              return false;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 2ce00a53aa6e7ffa571e39dd708e8c2f1a06b9ca..b06a572269c3ff5fa5a4c02059cf85060d6a9d79 100644
+index db08680cbf624a7115c26294812cfebf6b0d84bb..cbcbd108222b560ac3a483e5ebcfbc7a4ae3c23f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -784,6 +784,8 @@ public class PurpurWorldConfig {
+@@ -786,6 +786,8 @@ public class PurpurWorldConfig {
      public double beeMaxHealth = 10.0D;
      public int beeBreedingTicks = 6000;
      public boolean beeTakeDamageFromWater = false;
@@ -43,7 +43,7 @@ index 2ce00a53aa6e7ffa571e39dd708e8c2f1a06b9ca..b06a572269c3ff5fa5a4c02059cf8506
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -797,6 +799,8 @@ public class PurpurWorldConfig {
+@@ -799,6 +801,8 @@ public class PurpurWorldConfig {
          beeMaxHealth = getDouble("mobs.bee.attributes.max_health", beeMaxHealth);
          beeBreedingTicks = getInt("mobs.bee.breeding-delay-ticks", beeBreedingTicks);
          beeTakeDamageFromWater = getBoolean("mobs.bee.takes-damage-from-water", beeTakeDamageFromWater);

--- a/patches/server/0178-Config-MobEffect-by-world.patch
+++ b/patches/server/0178-Config-MobEffect-by-world.patch
@@ -40,10 +40,10 @@ index 2cc714585fc3790b70a7ad1ab8034543462e2b3b..22d7f04cefafa0115a4504e373807877
  
                  ((ServerPlayer) entityhuman).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) entityhuman).getBukkitEntity().getScaledHealth(), entityhuman.getFoodData().foodLevel, entityhuman.getFoodData().saturationLevel));
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b06a572269c3ff5fa5a4c02059cf85060d6a9d79..759a67a94f5f5818bf2236b9619de4debc87fb86 100644
+index cbcbd108222b560ac3a483e5ebcfbc7a4ae3c23f..d3835f73e52ae3204276bf8716404a66fccdb21d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -331,6 +331,21 @@ public class PurpurWorldConfig {
+@@ -333,6 +333,21 @@ public class PurpurWorldConfig {
          poweredRailBoostModifier = getDouble("gameplay-mechanics.minecart.powered-rail.boost-modifier", poweredRailBoostModifier);
      }
  

--- a/patches/server/0178-Config-MobEffect-by-world.patch
+++ b/patches/server/0178-Config-MobEffect-by-world.patch
@@ -40,10 +40,10 @@ index 2cc714585fc3790b70a7ad1ab8034543462e2b3b..22d7f04cefafa0115a4504e373807877
  
                  ((ServerPlayer) entityhuman).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) entityhuman).getBukkitEntity().getScaledHealth(), entityhuman.getFoodData().foodLevel, entityhuman.getFoodData().saturationLevel));
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b2d0cc6032c65e3f70904bb8cd052f7fcf8cb81b..5075b3c255fed29b6c43ce32d3504fbad9014dcc 100644
+index b06a572269c3ff5fa5a4c02059cf85060d6a9d79..759a67a94f5f5818bf2236b9619de4debc87fb86 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -329,6 +329,21 @@ public class PurpurWorldConfig {
+@@ -331,6 +331,21 @@ public class PurpurWorldConfig {
          poweredRailBoostModifier = getDouble("gameplay-mechanics.minecart.powered-rail.boost-modifier", poweredRailBoostModifier);
      }
  

--- a/patches/server/0179-Beacon-Activation-Range-Configurable.patch
+++ b/patches/server/0179-Beacon-Activation-Range-Configurable.patch
@@ -26,10 +26,10 @@ index ef740d1ad6352ca4af299001a081b720bc472d2e..c787019b5cbadec81dd33ef4021708b9
          } else {
              return effectRange;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5075b3c255fed29b6c43ce32d3504fbad9014dcc..175975ca0da583645394fa1ff0d76bc548b2c245 100644
+index 759a67a94f5f5818bf2236b9619de4debc87fb86..81fc5dcc391f8e1fe8c37ec91030813aea6431eb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -521,6 +521,17 @@ public class PurpurWorldConfig {
+@@ -523,6 +523,17 @@ public class PurpurWorldConfig {
          anvilColorsUseMiniMessage = getBoolean("blocks.anvil.use-mini-message", anvilColorsUseMiniMessage);
      }
  

--- a/patches/server/0179-Beacon-Activation-Range-Configurable.patch
+++ b/patches/server/0179-Beacon-Activation-Range-Configurable.patch
@@ -26,10 +26,10 @@ index ef740d1ad6352ca4af299001a081b720bc472d2e..c787019b5cbadec81dd33ef4021708b9
          } else {
              return effectRange;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 759a67a94f5f5818bf2236b9619de4debc87fb86..81fc5dcc391f8e1fe8c37ec91030813aea6431eb 100644
+index d3835f73e52ae3204276bf8716404a66fccdb21d..757bd64bbdf4ac2abadef4edd0dd0ef0bbe20e08 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -523,6 +523,17 @@ public class PurpurWorldConfig {
+@@ -525,6 +525,17 @@ public class PurpurWorldConfig {
          anvilColorsUseMiniMessage = getBoolean("blocks.anvil.use-mini-message", anvilColorsUseMiniMessage);
      }
  

--- a/patches/server/0180-Add-toggle-for-sand-duping-fix.patch
+++ b/patches/server/0180-Add-toggle-for-sand-duping-fix.patch
@@ -27,10 +27,10 @@ index ce2c3c146ef64400e00084bd2245d2b87a67fbc2..b0dd274fde1ce23a984de9492d7605ff
              }
              // Paper end - fix sand duping
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 175975ca0da583645394fa1ff0d76bc548b2c245..b6669a8fd4e20c178e9b5d5f0343588e432a718b 100644
+index 81fc5dcc391f8e1fe8c37ec91030813aea6431eb..41eb254be9de5464d5835037b659b47d5c452904 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -700,6 +700,11 @@ public class PurpurWorldConfig {
+@@ -702,6 +702,11 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0180-Add-toggle-for-sand-duping-fix.patch
+++ b/patches/server/0180-Add-toggle-for-sand-duping-fix.patch
@@ -27,10 +27,10 @@ index ce2c3c146ef64400e00084bd2245d2b87a67fbc2..b0dd274fde1ce23a984de9492d7605ff
              }
              // Paper end - fix sand duping
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 81fc5dcc391f8e1fe8c37ec91030813aea6431eb..41eb254be9de5464d5835037b659b47d5c452904 100644
+index 757bd64bbdf4ac2abadef4edd0dd0ef0bbe20e08..532e7e8fabf89c45707cc5c256f81fd0d4081b1f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -702,6 +702,11 @@ public class PurpurWorldConfig {
+@@ -704,6 +704,11 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0181-Add-toggle-for-end-portal-safe-teleporting.patch
+++ b/patches/server/0181-Add-toggle-for-end-portal-safe-teleporting.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add toggle for end portal safe teleporting
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 97046a3764bd5ec09be3e9212568a03ca42fd307..51bb177a52ea52d642ec3300ccd6fd28b3b66bb3 100644
+index 89ad0987084828037154d88d80788a8479f3732a..6f876403388f95a5b52f00985df2cde2f4d991f8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2962,7 +2962,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -45,10 +45,10 @@ index f80f6da484f4144e743079e5104bf503419074b2..2deddc746e43896584bd65ba8e7971a8
              entity.portalWorld = ((ServerLevel)world);
              entity.portalBlock = pos.immutable();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b6669a8fd4e20c178e9b5d5f0343588e432a718b..996bf44999c6a71943a5d14e4d1849fa329cb737 100644
+index 41eb254be9de5464d5835037b659b47d5c452904..66cf37e6fcf4f0b5977ed780bc4335d1de39c987 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -648,6 +648,11 @@ public class PurpurWorldConfig {
+@@ -650,6 +650,11 @@ public class PurpurWorldConfig {
          furnaceUseLavaFromUnderneath = getBoolean("blocks.furnace.use-lava-from-underneath", furnaceUseLavaFromUnderneath);
      }
  

--- a/patches/server/0181-Add-toggle-for-end-portal-safe-teleporting.patch
+++ b/patches/server/0181-Add-toggle-for-end-portal-safe-teleporting.patch
@@ -45,10 +45,10 @@ index f80f6da484f4144e743079e5104bf503419074b2..2deddc746e43896584bd65ba8e7971a8
              entity.portalWorld = ((ServerLevel)world);
              entity.portalBlock = pos.immutable();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 41eb254be9de5464d5835037b659b47d5c452904..66cf37e6fcf4f0b5977ed780bc4335d1de39c987 100644
+index 532e7e8fabf89c45707cc5c256f81fd0d4081b1f..cfefd0aab5032133c8512f94280457a4673d7f4f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -650,6 +650,11 @@ public class PurpurWorldConfig {
+@@ -652,6 +652,11 @@ public class PurpurWorldConfig {
          furnaceUseLavaFromUnderneath = getBoolean("blocks.furnace.use-lava-from-underneath", furnaceUseLavaFromUnderneath);
      }
  

--- a/patches/server/0183-Burp-delay-burp-after-eating-food-fills-hunger-bar-c.patch
+++ b/patches/server/0183-Burp-delay-burp-after-eating-food-fills-hunger-bar-c.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Burp delay, burp after eating food fills hunger bar
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 97b6ab27109b1bd7614ff3cc1322452608587ad9..ba0684615a20218cf1727ac02b6326589f80cb96 100644
+index 4ec3fd47de4d22aa76a742a1fc1edff6fe95c82c..53769c1781a3ea5e3c0330684d6b998adbe15a4e 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -199,6 +199,8 @@ public abstract class Player extends LivingEntity {
@@ -56,10 +56,10 @@ index 4a2dcf9bd83dd3fdff43483f887f4f58dc4715cd..87f9e03fb5e095396e054a84be60ec45
  
      public void eat(Item item, ItemStack stack) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 996bf44999c6a71943a5d14e4d1849fa329cb737..54e6d43554f8cc5c9d5bb10ed869d9a333e4c214 100644
+index 66cf37e6fcf4f0b5977ed780bc4335d1de39c987..e13a7a92865ab7447685285c90c04c7f2da65ad1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -388,6 +388,8 @@ public class PurpurWorldConfig {
+@@ -390,6 +390,8 @@ public class PurpurWorldConfig {
      public boolean playerSleepNearMonsters = false;
      public boolean playersSkipNight = true;
      public double playerCriticalDamageMultiplier = 1.5D;
@@ -68,7 +68,7 @@ index 996bf44999c6a71943a5d14e4d1849fa329cb737..54e6d43554f8cc5c9d5bb10ed869d9a3
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -410,6 +412,8 @@ public class PurpurWorldConfig {
+@@ -412,6 +414,8 @@ public class PurpurWorldConfig {
          playerSleepNearMonsters = getBoolean("gameplay-mechanics.player.sleep-ignore-nearby-mobs", playerSleepNearMonsters);
          playersSkipNight = getBoolean("gameplay-mechanics.player.can-skip-night", playersSkipNight);
          playerCriticalDamageMultiplier = getDouble("gameplay-mechanics.player.critical-damage-multiplier", playerCriticalDamageMultiplier);

--- a/patches/server/0183-Burp-delay-burp-after-eating-food-fills-hunger-bar-c.patch
+++ b/patches/server/0183-Burp-delay-burp-after-eating-food-fills-hunger-bar-c.patch
@@ -56,10 +56,10 @@ index 4a2dcf9bd83dd3fdff43483f887f4f58dc4715cd..87f9e03fb5e095396e054a84be60ec45
  
      public void eat(Item item, ItemStack stack) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 66cf37e6fcf4f0b5977ed780bc4335d1de39c987..e13a7a92865ab7447685285c90c04c7f2da65ad1 100644
+index cfefd0aab5032133c8512f94280457a4673d7f4f..c24cadbdb14e7b16f342b4d22fa0730d42e9c7d1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -390,6 +390,8 @@ public class PurpurWorldConfig {
+@@ -392,6 +392,8 @@ public class PurpurWorldConfig {
      public boolean playerSleepNearMonsters = false;
      public boolean playersSkipNight = true;
      public double playerCriticalDamageMultiplier = 1.5D;
@@ -68,7 +68,7 @@ index 66cf37e6fcf4f0b5977ed780bc4335d1de39c987..e13a7a92865ab7447685285c90c04c7f
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -412,6 +414,8 @@ public class PurpurWorldConfig {
+@@ -414,6 +416,8 @@ public class PurpurWorldConfig {
          playerSleepNearMonsters = getBoolean("gameplay-mechanics.player.sleep-ignore-nearby-mobs", playerSleepNearMonsters);
          playersSkipNight = getBoolean("gameplay-mechanics.player.can-skip-night", playersSkipNight);
          playerCriticalDamageMultiplier = getDouble("gameplay-mechanics.player.critical-damage-multiplier", playerCriticalDamageMultiplier);

--- a/patches/server/0186-Shulker-spawn-from-bullet-options.patch
+++ b/patches/server/0186-Shulker-spawn-from-bullet-options.patch
@@ -67,10 +67,10 @@ index 2170715ed0e81a3055e4ab546c8b294c5ef7f142..beae4e2b9f61df83215de860d64c4ce2
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e13a7a92865ab7447685285c90c04c7f2da65ad1..bf93daf11397e22a950995f8dbf07830e62cb227 100644
+index c24cadbdb14e7b16f342b4d22fa0730d42e9c7d1..9060abce4148ea3b9a4878463d94135f3aa000a6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1935,6 +1935,11 @@ public class PurpurWorldConfig {
+@@ -1937,6 +1937,11 @@ public class PurpurWorldConfig {
      public boolean shulkerControllable = true;
      public double shulkerMaxHealth = 30.0D;
      public boolean shulkerTakeDamageFromWater = false;
@@ -82,7 +82,7 @@ index e13a7a92865ab7447685285c90c04c7f2da65ad1..bf93daf11397e22a950995f8dbf07830
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -1946,6 +1951,11 @@ public class PurpurWorldConfig {
+@@ -1948,6 +1953,11 @@ public class PurpurWorldConfig {
          }
          shulkerMaxHealth = getDouble("mobs.shulker.attributes.max_health", shulkerMaxHealth);
          shulkerTakeDamageFromWater = getBoolean("mobs.shulker.takes-damage-from-water", shulkerTakeDamageFromWater);

--- a/patches/server/0186-Shulker-spawn-from-bullet-options.patch
+++ b/patches/server/0186-Shulker-spawn-from-bullet-options.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] Shulker spawn from bullet options
 (7 - 1) / 5.0 = 1.2    1.0 - 1.2 = -0.2     0% (6 other shulkers)
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-index 41a6cd3a81c531b6349ca364b85712954a97aa11..b64c492a245494ab60c325d66dc6ec65418a1e4e 100644
+index cd0e0d15868bcefef28d801dbd2aa41ac982baac..6ce1b5223bec2ee093de2374f20b8629a5d68069 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
 @@ -510,11 +510,20 @@ public class Shulker extends AbstractGolem implements VariantHolder<Optional<Dye
@@ -67,10 +67,10 @@ index 2170715ed0e81a3055e4ab546c8b294c5ef7f142..beae4e2b9f61df83215de860d64c4ce2
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 54e6d43554f8cc5c9d5bb10ed869d9a333e4c214..4323702cb21a37ff9d9e8496906879a516a3c6ed 100644
+index e13a7a92865ab7447685285c90c04c7f2da65ad1..bf93daf11397e22a950995f8dbf07830e62cb227 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1933,6 +1933,11 @@ public class PurpurWorldConfig {
+@@ -1935,6 +1935,11 @@ public class PurpurWorldConfig {
      public boolean shulkerControllable = true;
      public double shulkerMaxHealth = 30.0D;
      public boolean shulkerTakeDamageFromWater = false;
@@ -82,7 +82,7 @@ index 54e6d43554f8cc5c9d5bb10ed869d9a333e4c214..4323702cb21a37ff9d9e8496906879a5
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -1944,6 +1949,11 @@ public class PurpurWorldConfig {
+@@ -1946,6 +1951,11 @@ public class PurpurWorldConfig {
          }
          shulkerMaxHealth = getDouble("mobs.shulker.attributes.max_health", shulkerMaxHealth);
          shulkerTakeDamageFromWater = getBoolean("mobs.shulker.takes-damage-from-water", shulkerTakeDamageFromWater);

--- a/patches/server/0187-Eating-glow-berries-adds-glow-effect.patch
+++ b/patches/server/0187-Eating-glow-berries-adds-glow-effect.patch
@@ -18,10 +18,10 @@ index 42e6aeea8d2e076aea7fa2c1ccf5edcc5efba46f..1f2e467272dddf3e91b7ab7037a0367b
      public static final Item SOUL_CAMPFIRE = registerBlock(Blocks.SOUL_CAMPFIRE);
      public static final Item SHROOMLIGHT = registerBlock(Blocks.SHROOMLIGHT);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4323702cb21a37ff9d9e8496906879a516a3c6ed..5f29c9df27495ea34ee22ba2ba8e1fb0cdd85ab9 100644
+index bf93daf11397e22a950995f8dbf07830e62cb227..5c7216a49bedf3cb56ee006b15e56e70f64c4bb0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -220,6 +220,7 @@ public class PurpurWorldConfig {
+@@ -221,6 +221,7 @@ public class PurpurWorldConfig {
      public int enderPearlCooldown = 20;
      public int enderPearlCooldownCreative = 20;
      public float enderPearlEndermiteChance = 0.05F;
@@ -29,7 +29,7 @@ index 4323702cb21a37ff9d9e8496906879a516a3c6ed..5f29c9df27495ea34ee22ba2ba8e1fb0
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -263,6 +264,7 @@ public class PurpurWorldConfig {
+@@ -265,6 +266,7 @@ public class PurpurWorldConfig {
          enderPearlCooldown = getInt("gameplay-mechanics.item.ender-pearl.cooldown", enderPearlCooldown);
          enderPearlCooldownCreative = getInt("gameplay-mechanics.item.ender-pearl.creative-cooldown", enderPearlCooldownCreative);
          enderPearlEndermiteChance = (float) getDouble("gameplay-mechanics.item.ender-pearl.endermite-spawn-chance", enderPearlEndermiteChance);

--- a/patches/server/0187-Eating-glow-berries-adds-glow-effect.patch
+++ b/patches/server/0187-Eating-glow-berries-adds-glow-effect.patch
@@ -18,10 +18,10 @@ index 42e6aeea8d2e076aea7fa2c1ccf5edcc5efba46f..1f2e467272dddf3e91b7ab7037a0367b
      public static final Item SOUL_CAMPFIRE = registerBlock(Blocks.SOUL_CAMPFIRE);
      public static final Item SHROOMLIGHT = registerBlock(Blocks.SHROOMLIGHT);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index bf93daf11397e22a950995f8dbf07830e62cb227..5c7216a49bedf3cb56ee006b15e56e70f64c4bb0 100644
+index 9060abce4148ea3b9a4878463d94135f3aa000a6..5aa344d013bc4d5b7c83a3c6c32cbcbe140985bd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -221,6 +221,7 @@ public class PurpurWorldConfig {
+@@ -222,6 +222,7 @@ public class PurpurWorldConfig {
      public int enderPearlCooldown = 20;
      public int enderPearlCooldownCreative = 20;
      public float enderPearlEndermiteChance = 0.05F;
@@ -29,7 +29,7 @@ index bf93daf11397e22a950995f8dbf07830e62cb227..5c7216a49bedf3cb56ee006b15e56e70
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -265,6 +266,7 @@ public class PurpurWorldConfig {
+@@ -267,6 +268,7 @@ public class PurpurWorldConfig {
          enderPearlCooldown = getInt("gameplay-mechanics.item.ender-pearl.cooldown", enderPearlCooldown);
          enderPearlCooldownCreative = getInt("gameplay-mechanics.item.ender-pearl.creative-cooldown", enderPearlCooldownCreative);
          enderPearlEndermiteChance = (float) getDouble("gameplay-mechanics.item.ender-pearl.endermite-spawn-chance", enderPearlEndermiteChance);

--- a/patches/server/0188-Option-to-make-drowned-break-doors.patch
+++ b/patches/server/0188-Option-to-make-drowned-break-doors.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Option to make drowned break doors
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Drowned.java b/src/main/java/net/minecraft/world/entity/monster/Drowned.java
-index 31fb0cd50b4263abcdde323e79300c1a88b572c1..d1f5b3900dbb17d262fea85c45a82ba3a2f46cad 100644
+index 5ed737a9656546775540c15f81f308d94e7a3444..feef31edb1833da45c42b73894f610ac3add7c8e 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Drowned.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Drowned.java
 @@ -29,6 +29,7 @@ import net.minecraft.world.entity.ai.goal.MoveToBlockGoal;
@@ -34,10 +34,10 @@ index 31fb0cd50b4263abcdde323e79300c1a88b572c1..d1f5b3900dbb17d262fea85c45a82ba3
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5f29c9df27495ea34ee22ba2ba8e1fb0cdd85ab9..56b27b640d1cf772c1fe466d51b3aea84065f1ee 100644
+index 5c7216a49bedf3cb56ee006b15e56e70f64c4bb0..63c8162fac8ee0e082da76c45059986efc39c063 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1079,6 +1079,7 @@ public class PurpurWorldConfig {
+@@ -1081,6 +1081,7 @@ public class PurpurWorldConfig {
      public double drownedJockeyChance = 0.05D;
      public boolean drownedJockeyTryExistingChickens = true;
      public boolean drownedTakeDamageFromWater = false;
@@ -45,7 +45,7 @@ index 5f29c9df27495ea34ee22ba2ba8e1fb0cdd85ab9..56b27b640d1cf772c1fe466d51b3aea8
      private void drownedSettings() {
          drownedRidable = getBoolean("mobs.drowned.ridable", drownedRidable);
          drownedRidableInWater = getBoolean("mobs.drowned.ridable-in-water", drownedRidableInWater);
-@@ -1094,6 +1095,7 @@ public class PurpurWorldConfig {
+@@ -1096,6 +1097,7 @@ public class PurpurWorldConfig {
          drownedJockeyChance = getDouble("mobs.drowned.jockey.chance", drownedJockeyChance);
          drownedJockeyTryExistingChickens = getBoolean("mobs.drowned.jockey.try-existing-chickens", drownedJockeyTryExistingChickens);
          drownedTakeDamageFromWater = getBoolean("mobs.drowned.takes-damage-from-water", drownedTakeDamageFromWater);

--- a/patches/server/0188-Option-to-make-drowned-break-doors.patch
+++ b/patches/server/0188-Option-to-make-drowned-break-doors.patch
@@ -34,10 +34,10 @@ index 5ed737a9656546775540c15f81f308d94e7a3444..feef31edb1833da45c42b73894f610ac
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5c7216a49bedf3cb56ee006b15e56e70f64c4bb0..63c8162fac8ee0e082da76c45059986efc39c063 100644
+index 5aa344d013bc4d5b7c83a3c6c32cbcbe140985bd..79ee0e450e2f740c5818c4b1b092b2cb93307dee 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1081,6 +1081,7 @@ public class PurpurWorldConfig {
+@@ -1083,6 +1083,7 @@ public class PurpurWorldConfig {
      public double drownedJockeyChance = 0.05D;
      public boolean drownedJockeyTryExistingChickens = true;
      public boolean drownedTakeDamageFromWater = false;
@@ -45,7 +45,7 @@ index 5c7216a49bedf3cb56ee006b15e56e70f64c4bb0..63c8162fac8ee0e082da76c45059986e
      private void drownedSettings() {
          drownedRidable = getBoolean("mobs.drowned.ridable", drownedRidable);
          drownedRidableInWater = getBoolean("mobs.drowned.ridable-in-water", drownedRidableInWater);
-@@ -1096,6 +1097,7 @@ public class PurpurWorldConfig {
+@@ -1098,6 +1099,7 @@ public class PurpurWorldConfig {
          drownedJockeyChance = getDouble("mobs.drowned.jockey.chance", drownedJockeyChance);
          drownedJockeyTryExistingChickens = getBoolean("mobs.drowned.jockey.try-existing-chickens", drownedJockeyTryExistingChickens);
          drownedTakeDamageFromWater = getBoolean("mobs.drowned.takes-damage-from-water", drownedTakeDamageFromWater);

--- a/patches/server/0189-Configurable-hunger-starvation-damage.patch
+++ b/patches/server/0189-Configurable-hunger-starvation-damage.patch
@@ -18,10 +18,10 @@ index 87f9e03fb5e095396e054a84be60ec455d3fbd35..3d2e3c7dd3bf5c8f483a933e9f686858
  
                  this.tickTimer = 0;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d5161e92f05a0e8b6722cd5b56e10a2861e75d15..cf1ff8dc7e1279c11293740f1b1bdb6a413ce870 100644
+index 63c8162fac8ee0e082da76c45059986efc39c063..974b849fb30767e16859fb9fc154cf67bc30b0cb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2588,4 +2588,9 @@ public class PurpurWorldConfig {
+@@ -2590,4 +2590,9 @@ public class PurpurWorldConfig {
          zombifiedPiglinCountAsPlayerKillWhenAngry = getBoolean("mobs.zombified_piglin.count-as-player-kill-when-angry", zombifiedPiglinCountAsPlayerKillWhenAngry);
          zombifiedPiglinTakeDamageFromWater = getBoolean("mobs.zombified_piglin.takes-damage-from-water", zombifiedPiglinTakeDamageFromWater);
      }

--- a/patches/server/0189-Configurable-hunger-starvation-damage.patch
+++ b/patches/server/0189-Configurable-hunger-starvation-damage.patch
@@ -18,10 +18,10 @@ index 87f9e03fb5e095396e054a84be60ec455d3fbd35..3d2e3c7dd3bf5c8f483a933e9f686858
  
                  this.tickTimer = 0;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 63c8162fac8ee0e082da76c45059986efc39c063..974b849fb30767e16859fb9fc154cf67bc30b0cb 100644
+index 79ee0e450e2f740c5818c4b1b092b2cb93307dee..bd6745d1d4ef878f6add91259ef888dafdb0f1cd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2590,4 +2590,9 @@ public class PurpurWorldConfig {
+@@ -2592,4 +2592,9 @@ public class PurpurWorldConfig {
          zombifiedPiglinCountAsPlayerKillWhenAngry = getBoolean("mobs.zombified_piglin.count-as-player-kill-when-angry", zombifiedPiglinCountAsPlayerKillWhenAngry);
          zombifiedPiglinTakeDamageFromWater = getBoolean("mobs.zombified_piglin.takes-damage-from-water", zombifiedPiglinTakeDamageFromWater);
      }

--- a/patches/server/0192-Tool-actionable-options.patch
+++ b/patches/server/0192-Tool-actionable-options.patch
@@ -122,10 +122,10 @@ index 180aec596110309aade13d2080f8824d152b07cb..c4aec1e5135a79837918b692e75a7b55
                  return InteractionResult.PASS;
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index eb1d45c456f28bd49131f835b8e8a65253b0ce74..ce8aac7a189c0e4f8240950673066fb3d82dc86d 100644
+index 974b849fb30767e16859fb9fc154cf67bc30b0cb..e0ebcd3e5af7421bffafe1e61e00e0052955cbbd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -520,6 +520,159 @@ public class PurpurWorldConfig {
+@@ -522,6 +522,159 @@ public class PurpurWorldConfig {
          });
      }
  

--- a/patches/server/0192-Tool-actionable-options.patch
+++ b/patches/server/0192-Tool-actionable-options.patch
@@ -122,10 +122,10 @@ index 180aec596110309aade13d2080f8824d152b07cb..c4aec1e5135a79837918b692e75a7b55
                  return InteractionResult.PASS;
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 974b849fb30767e16859fb9fc154cf67bc30b0cb..e0ebcd3e5af7421bffafe1e61e00e0052955cbbd 100644
+index bd6745d1d4ef878f6add91259ef888dafdb0f1cd..217d7314456c977434ef6959fcc682e7fa6679d5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -522,6 +522,159 @@ public class PurpurWorldConfig {
+@@ -524,6 +524,159 @@ public class PurpurWorldConfig {
          });
      }
  

--- a/patches/server/0196-option-to-disable-shulker-box-items-from-dropping-co.patch
+++ b/patches/server/0196-option-to-disable-shulker-box-items-from-dropping-co.patch
@@ -19,10 +19,10 @@ index b0204af850ee182773ad458208cccd946ad148d5..81eb7092e6172bf9685d4feb52dabb01
              CompoundTag nbttagcompound = BlockItem.getBlockEntityData(itemstack);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ce8aac7a189c0e4f8240950673066fb3d82dc86d..078d5d8248e8d0bb7f055579628f7d032fef4767 100644
+index e0ebcd3e5af7421bffafe1e61e00e0052955cbbd..6d19e8039c9ef58cf1cf8edf450ab1b2a77b7c83 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -221,6 +221,7 @@ public class PurpurWorldConfig {
+@@ -222,6 +222,7 @@ public class PurpurWorldConfig {
      public int enderPearlCooldownCreative = 20;
      public float enderPearlEndermiteChance = 0.05F;
      public int glowBerriesEatGlowDuration = 0;
@@ -30,7 +30,7 @@ index ce8aac7a189c0e4f8240950673066fb3d82dc86d..078d5d8248e8d0bb7f055579628f7d03
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -265,6 +266,7 @@ public class PurpurWorldConfig {
+@@ -267,6 +268,7 @@ public class PurpurWorldConfig {
          enderPearlCooldownCreative = getInt("gameplay-mechanics.item.ender-pearl.creative-cooldown", enderPearlCooldownCreative);
          enderPearlEndermiteChance = (float) getDouble("gameplay-mechanics.item.ender-pearl.endermite-spawn-chance", enderPearlEndermiteChance);
          glowBerriesEatGlowDuration = getInt("gameplay-mechanics.item.glow_berries.eat-glow-duration", glowBerriesEatGlowDuration);

--- a/patches/server/0196-option-to-disable-shulker-box-items-from-dropping-co.patch
+++ b/patches/server/0196-option-to-disable-shulker-box-items-from-dropping-co.patch
@@ -19,10 +19,10 @@ index b0204af850ee182773ad458208cccd946ad148d5..81eb7092e6172bf9685d4feb52dabb01
              CompoundTag nbttagcompound = BlockItem.getBlockEntityData(itemstack);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e0ebcd3e5af7421bffafe1e61e00e0052955cbbd..6d19e8039c9ef58cf1cf8edf450ab1b2a77b7c83 100644
+index 217d7314456c977434ef6959fcc682e7fa6679d5..00706a28fb5a0967ccaa0e402de1281d85df0fc5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -222,6 +222,7 @@ public class PurpurWorldConfig {
+@@ -223,6 +223,7 @@ public class PurpurWorldConfig {
      public int enderPearlCooldownCreative = 20;
      public float enderPearlEndermiteChance = 0.05F;
      public int glowBerriesEatGlowDuration = 0;
@@ -30,7 +30,7 @@ index e0ebcd3e5af7421bffafe1e61e00e0052955cbbd..6d19e8039c9ef58cf1cf8edf450ab1b2
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -267,6 +268,7 @@ public class PurpurWorldConfig {
+@@ -269,6 +270,7 @@ public class PurpurWorldConfig {
          enderPearlCooldownCreative = getInt("gameplay-mechanics.item.ender-pearl.creative-cooldown", enderPearlCooldownCreative);
          enderPearlEndermiteChance = (float) getDouble("gameplay-mechanics.item.ender-pearl.endermite-spawn-chance", enderPearlEndermiteChance);
          glowBerriesEatGlowDuration = getInt("gameplay-mechanics.item.glow_berries.eat-glow-duration", glowBerriesEatGlowDuration);

--- a/patches/server/0197-Silk-touchable-budding-amethyst.patch
+++ b/patches/server/0197-Silk-touchable-budding-amethyst.patch
@@ -24,10 +24,10 @@ index bedccb8717d08d5a60058445b04ddff149e7d36c..5293ffca3da94c9c485a87d1232b6a90
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6d19e8039c9ef58cf1cf8edf450ab1b2a77b7c83..c4e8b1c69dab4623582a12a2bd8283f24eb2148c 100644
+index 00706a28fb5a0967ccaa0e402de1281d85df0fc5..046266cce1c07950645a7dad832e1944af880550 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -716,6 +716,11 @@ public class PurpurWorldConfig {
+@@ -718,6 +718,11 @@ public class PurpurWorldConfig {
          }
      }
  
@@ -39,7 +39,7 @@ index 6d19e8039c9ef58cf1cf8edf450ab1b2a77b7c83..c4e8b1c69dab4623582a12a2bd8283f2
      public boolean chestOpenWithBlockOnTop = false;
      private void chestSettings() {
          chestOpenWithBlockOnTop = getBoolean("blocks.chest.open-with-solid-block-on-top", chestOpenWithBlockOnTop);
-@@ -2751,3 +2756,4 @@ public class PurpurWorldConfig {
+@@ -2753,3 +2758,4 @@ public class PurpurWorldConfig {
          hungerStarvationDamage = (float) getDouble("hunger.starvation-damage", hungerStarvationDamage);
      }
  }

--- a/patches/server/0197-Silk-touchable-budding-amethyst.patch
+++ b/patches/server/0197-Silk-touchable-budding-amethyst.patch
@@ -24,10 +24,10 @@ index bedccb8717d08d5a60058445b04ddff149e7d36c..5293ffca3da94c9c485a87d1232b6a90
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e84aa0fc0fabc6b3fc4602e0803d21e07f6d5b2e..3b51d99cefd879b5a723017c77f2f8a7cc5f6b70 100644
+index 6d19e8039c9ef58cf1cf8edf450ab1b2a77b7c83..c4e8b1c69dab4623582a12a2bd8283f24eb2148c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -714,6 +714,11 @@ public class PurpurWorldConfig {
+@@ -716,6 +716,11 @@ public class PurpurWorldConfig {
          }
      }
  
@@ -39,7 +39,7 @@ index e84aa0fc0fabc6b3fc4602e0803d21e07f6d5b2e..3b51d99cefd879b5a723017c77f2f8a7
      public boolean chestOpenWithBlockOnTop = false;
      private void chestSettings() {
          chestOpenWithBlockOnTop = getBoolean("blocks.chest.open-with-solid-block-on-top", chestOpenWithBlockOnTop);
-@@ -2749,3 +2754,4 @@ public class PurpurWorldConfig {
+@@ -2751,3 +2756,4 @@ public class PurpurWorldConfig {
          hungerStarvationDamage = (float) getDouble("hunger.starvation-damage", hungerStarvationDamage);
      }
  }

--- a/patches/server/0198-Big-dripleaf-tilt-delay.patch
+++ b/patches/server/0198-Big-dripleaf-tilt-delay.patch
@@ -24,10 +24,10 @@ index 8537581e7ca1f4efb492a2e734f46f947f36cffa..5f89229ff68d923c5cdee40e72e379ba
          if (i != -1) {
              world.scheduleTick(blockposition, (Block) this, i);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index c4e8b1c69dab4623582a12a2bd8283f24eb2148c..7c7f96cf3ab5566fd1fac5867bc31842d12fb27a 100644
+index 046266cce1c07950645a7dad832e1944af880550..9642374fd97fc0dc55f668fb6d85d2258b7dd77d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -716,6 +716,22 @@ public class PurpurWorldConfig {
+@@ -718,6 +718,22 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0198-Big-dripleaf-tilt-delay.patch
+++ b/patches/server/0198-Big-dripleaf-tilt-delay.patch
@@ -24,10 +24,10 @@ index 8537581e7ca1f4efb492a2e734f46f947f36cffa..5f89229ff68d923c5cdee40e72e379ba
          if (i != -1) {
              world.scheduleTick(blockposition, (Block) this, i);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 132f66e24a84de83327b3cd14069fe3cd4fc21f8..0e3360540a33aae9197200e171dae9a745bbb2d5 100644
+index c4e8b1c69dab4623582a12a2bd8283f24eb2148c..7c7f96cf3ab5566fd1fac5867bc31842d12fb27a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -714,6 +714,22 @@ public class PurpurWorldConfig {
+@@ -716,6 +716,22 @@ public class PurpurWorldConfig {
          }
      }
  

--- a/patches/server/0199-Player-ridable-in-water-option.patch
+++ b/patches/server/0199-Player-ridable-in-water-option.patch
@@ -21,10 +21,10 @@ index af882016364257f01a154b99783e96f5e932364f..8e088b2a9b10ca0f1188469a7dd360b2
          if (!this.isPassenger() && this.onGround && !this.isInWater() && !this.isInPowderSnow) {
              if (this.getShoulderEntityLeft().isEmpty()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ab1248327190ccf3f36cf0b7443902ed5816ca52..967f131637618e03f119c05aadaefa0dc3a6b6fa 100644
+index 7c7f96cf3ab5566fd1fac5867bc31842d12fb27a..282a72a89f006012d32c494c13d475f7fd93fe56 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -394,6 +394,7 @@ public class PurpurWorldConfig {
+@@ -396,6 +396,7 @@ public class PurpurWorldConfig {
      public double playerCriticalDamageMultiplier = 1.5D;
      public int playerBurpDelay = 10;
      public boolean playerBurpWhenFull = false;
@@ -32,7 +32,7 @@ index ab1248327190ccf3f36cf0b7443902ed5816ca52..967f131637618e03f119c05aadaefa0d
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -418,6 +419,7 @@ public class PurpurWorldConfig {
+@@ -420,6 +421,7 @@ public class PurpurWorldConfig {
          playerCriticalDamageMultiplier = getDouble("gameplay-mechanics.player.critical-damage-multiplier", playerCriticalDamageMultiplier);
          playerBurpDelay = getInt("gameplay-mechanics.player.burp-delay", playerBurpDelay);
          playerBurpWhenFull = getBoolean("gameplay-mechanics.player.burp-when-full", playerBurpWhenFull);

--- a/patches/server/0199-Player-ridable-in-water-option.patch
+++ b/patches/server/0199-Player-ridable-in-water-option.patch
@@ -21,10 +21,10 @@ index af882016364257f01a154b99783e96f5e932364f..8e088b2a9b10ca0f1188469a7dd360b2
          if (!this.isPassenger() && this.onGround && !this.isInWater() && !this.isInPowderSnow) {
              if (this.getShoulderEntityLeft().isEmpty()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7c7f96cf3ab5566fd1fac5867bc31842d12fb27a..282a72a89f006012d32c494c13d475f7fd93fe56 100644
+index 9642374fd97fc0dc55f668fb6d85d2258b7dd77d..e1f96fc7deec93fb7eea12a600630d603924469b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -396,6 +396,7 @@ public class PurpurWorldConfig {
+@@ -398,6 +398,7 @@ public class PurpurWorldConfig {
      public double playerCriticalDamageMultiplier = 1.5D;
      public int playerBurpDelay = 10;
      public boolean playerBurpWhenFull = false;
@@ -32,7 +32,7 @@ index 7c7f96cf3ab5566fd1fac5867bc31842d12fb27a..282a72a89f006012d32c494c13d475f7
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -420,6 +421,7 @@ public class PurpurWorldConfig {
+@@ -422,6 +423,7 @@ public class PurpurWorldConfig {
          playerCriticalDamageMultiplier = getDouble("gameplay-mechanics.player.critical-damage-multiplier", playerCriticalDamageMultiplier);
          playerBurpDelay = getInt("gameplay-mechanics.player.burp-delay", playerBurpDelay);
          playerBurpWhenFull = getBoolean("gameplay-mechanics.player.burp-when-full", playerBurpWhenFull);

--- a/patches/server/0200-Config-to-disable-Enderman-teleport-on-projectile-hi.patch
+++ b/patches/server/0200-Config-to-disable-Enderman-teleport-on-projectile-hi.patch
@@ -17,10 +17,10 @@ index 60720f0bad840d35c9d0f1fc327f6069b348a41a..9e5f6666cbc4303d095a4f95db9acd0b
                  for (int i = 0; i < 64; ++i) {
                      if (this.teleport()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 282a72a89f006012d32c494c13d475f7fd93fe56..70c52c8324354308899b963a71c593c6b65dfa2b 100644
+index e1f96fc7deec93fb7eea12a600630d603924469b..a816046f8da838365a71ed63904ed04ca9b46906 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1336,6 +1336,7 @@ public class PurpurWorldConfig {
+@@ -1338,6 +1338,7 @@ public class PurpurWorldConfig {
      public boolean endermanAggroEndermitesOnlyIfPlayerSpawned = false;
      public boolean endermanIgnorePlayerDragonHead = false;
      public boolean endermanDisableStareAggro = false;
@@ -28,7 +28,7 @@ index 282a72a89f006012d32c494c13d475f7fd93fe56..70c52c8324354308899b963a71c593c6
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1358,6 +1359,7 @@ public class PurpurWorldConfig {
+@@ -1360,6 +1361,7 @@ public class PurpurWorldConfig {
          endermanAggroEndermitesOnlyIfPlayerSpawned = getBoolean("mobs.enderman.aggressive-towards-endermites-only-spawned-by-player-thrown-ender-pearls", endermanAggroEndermitesOnlyIfPlayerSpawned);
          endermanIgnorePlayerDragonHead = getBoolean("mobs.enderman.ignore-players-wearing-dragon-head", endermanIgnorePlayerDragonHead);
          endermanDisableStareAggro = getBoolean("mobs.enderman.disable-player-stare-aggression", endermanDisableStareAggro);

--- a/patches/server/0200-Config-to-disable-Enderman-teleport-on-projectile-hi.patch
+++ b/patches/server/0200-Config-to-disable-Enderman-teleport-on-projectile-hi.patch
@@ -17,10 +17,10 @@ index 60720f0bad840d35c9d0f1fc327f6069b348a41a..9e5f6666cbc4303d095a4f95db9acd0b
                  for (int i = 0; i < 64; ++i) {
                      if (this.teleport()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 967f131637618e03f119c05aadaefa0dc3a6b6fa..4a7b01606a2fe7aad5ecaf515e2ba8d4fa328539 100644
+index 282a72a89f006012d32c494c13d475f7fd93fe56..70c52c8324354308899b963a71c593c6b65dfa2b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1334,6 +1334,7 @@ public class PurpurWorldConfig {
+@@ -1336,6 +1336,7 @@ public class PurpurWorldConfig {
      public boolean endermanAggroEndermitesOnlyIfPlayerSpawned = false;
      public boolean endermanIgnorePlayerDragonHead = false;
      public boolean endermanDisableStareAggro = false;
@@ -28,7 +28,7 @@ index 967f131637618e03f119c05aadaefa0dc3a6b6fa..4a7b01606a2fe7aad5ecaf515e2ba8d4
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1356,6 +1357,7 @@ public class PurpurWorldConfig {
+@@ -1358,6 +1359,7 @@ public class PurpurWorldConfig {
          endermanAggroEndermitesOnlyIfPlayerSpawned = getBoolean("mobs.enderman.aggressive-towards-endermites-only-spawned-by-player-thrown-ender-pearls", endermanAggroEndermitesOnlyIfPlayerSpawned);
          endermanIgnorePlayerDragonHead = getBoolean("mobs.enderman.ignore-players-wearing-dragon-head", endermanIgnorePlayerDragonHead);
          endermanDisableStareAggro = getBoolean("mobs.enderman.disable-player-stare-aggression", endermanDisableStareAggro);

--- a/patches/server/0201-Add-compass-command.patch
+++ b/patches/server/0201-Add-compass-command.patch
@@ -89,10 +89,10 @@ index 31f5d9bcc11dc78b0d04c55560d5a2fa18bf3896..42532975d8c5558a7598e759838e75f2
          hideHiddenPlayersFromEntitySelector = getBoolean("settings.command.hide-hidden-players-from-entity-selector", hideHiddenPlayersFromEntitySelector);
          uptimeFormat = getString("settings.command.uptime.format", uptimeFormat);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 8f43f33e86e012c9e6c199ec159ce34b4e45cdef..4450897735088ca7b126556ebb7ee785241e850b 100644
+index 70c52c8324354308899b963a71c593c6b65dfa2b..3730029760823053ae3ec3377b173157cd0163c8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -222,6 +222,7 @@ public class PurpurWorldConfig {
+@@ -223,6 +223,7 @@ public class PurpurWorldConfig {
      public float enderPearlEndermiteChance = 0.05F;
      public int glowBerriesEatGlowDuration = 0;
      public boolean shulkerBoxItemDropContentsWhenDestroyed = true;
@@ -100,7 +100,7 @@ index 8f43f33e86e012c9e6c199ec159ce34b4e45cdef..4450897735088ca7b126556ebb7ee785
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -267,6 +268,7 @@ public class PurpurWorldConfig {
+@@ -269,6 +270,7 @@ public class PurpurWorldConfig {
          enderPearlEndermiteChance = (float) getDouble("gameplay-mechanics.item.ender-pearl.endermite-spawn-chance", enderPearlEndermiteChance);
          glowBerriesEatGlowDuration = getInt("gameplay-mechanics.item.glow_berries.eat-glow-duration", glowBerriesEatGlowDuration);
          shulkerBoxItemDropContentsWhenDestroyed = getBoolean("gameplay-mechanics.item.shulker_box.drop-contents-when-destroyed", shulkerBoxItemDropContentsWhenDestroyed);

--- a/patches/server/0201-Add-compass-command.patch
+++ b/patches/server/0201-Add-compass-command.patch
@@ -89,10 +89,10 @@ index 31f5d9bcc11dc78b0d04c55560d5a2fa18bf3896..42532975d8c5558a7598e759838e75f2
          hideHiddenPlayersFromEntitySelector = getBoolean("settings.command.hide-hidden-players-from-entity-selector", hideHiddenPlayersFromEntitySelector);
          uptimeFormat = getString("settings.command.uptime.format", uptimeFormat);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 70c52c8324354308899b963a71c593c6b65dfa2b..3730029760823053ae3ec3377b173157cd0163c8 100644
+index a816046f8da838365a71ed63904ed04ca9b46906..179907b8a9babefb1b551b5c6055da18a54d5567 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -223,6 +223,7 @@ public class PurpurWorldConfig {
+@@ -224,6 +224,7 @@ public class PurpurWorldConfig {
      public float enderPearlEndermiteChance = 0.05F;
      public int glowBerriesEatGlowDuration = 0;
      public boolean shulkerBoxItemDropContentsWhenDestroyed = true;
@@ -100,7 +100,7 @@ index 70c52c8324354308899b963a71c593c6b65dfa2b..3730029760823053ae3ec3377b173157
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -269,6 +270,7 @@ public class PurpurWorldConfig {
+@@ -271,6 +272,7 @@ public class PurpurWorldConfig {
          enderPearlEndermiteChance = (float) getDouble("gameplay-mechanics.item.ender-pearl.endermite-spawn-chance", enderPearlEndermiteChance);
          glowBerriesEatGlowDuration = getInt("gameplay-mechanics.item.glow_berries.eat-glow-duration", glowBerriesEatGlowDuration);
          shulkerBoxItemDropContentsWhenDestroyed = getBoolean("gameplay-mechanics.item.shulker_box.drop-contents-when-destroyed", shulkerBoxItemDropContentsWhenDestroyed);

--- a/patches/server/0203-Add-Option-for-disable-observer-clocks.patch
+++ b/patches/server/0203-Add-Option-for-disable-observer-clocks.patch
@@ -18,10 +18,10 @@ index 7b45d6b9a005036ca5051d089a7be792eb87012f..8806c97ecc6bdd8a64c2d82bb2f58f46
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 8725552721e2171a4f00339eb05bd347bab1818f..d7a06f73ee7c1861a0228cb37dbd6e14e938fd17 100644
+index dc32919de1be7b2e34e75cc93824a262246e181a..60ffefcdf868670e3a8140ed5cba26c8f74319f5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -367,6 +367,11 @@ public class PurpurWorldConfig {
+@@ -369,6 +369,11 @@ public class PurpurWorldConfig {
          villageSiegeSpawning = getBoolean("gameplay-mechanics.mob-spawning.village-sieges", predicate);
      }
  

--- a/patches/server/0203-Add-Option-for-disable-observer-clocks.patch
+++ b/patches/server/0203-Add-Option-for-disable-observer-clocks.patch
@@ -18,10 +18,10 @@ index 7b45d6b9a005036ca5051d089a7be792eb87012f..8806c97ecc6bdd8a64c2d82bb2f58f46
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index dc32919de1be7b2e34e75cc93824a262246e181a..60ffefcdf868670e3a8140ed5cba26c8f74319f5 100644
+index 9f8257758ea9766f1cae5c8f8753efc79f18e1e9..e16210dc87535705091b9aa9edb4a59fef06cbfd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -369,6 +369,11 @@ public class PurpurWorldConfig {
+@@ -371,6 +371,11 @@ public class PurpurWorldConfig {
          villageSiegeSpawning = getBoolean("gameplay-mechanics.mob-spawning.village-sieges", predicate);
      }
  

--- a/patches/server/0204-Customizeable-Zombie-Villager-curing-times.patch
+++ b/patches/server/0204-Customizeable-Zombie-Villager-curing-times.patch
@@ -18,10 +18,10 @@ index 1084adce8dc55b19ed9d90c0c5ad6675fff0afc5..9d981e392143baa43b6006ca9ef319fd
  
                  return InteractionResult.SUCCESS;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 60ffefcdf868670e3a8140ed5cba26c8f74319f5..a0beb76cb448346332c10dde1ccfc62a06369af6 100644
+index e16210dc87535705091b9aa9edb4a59fef06cbfd..e503b9018183fa6491529d1c5fe630906fb61a50 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2735,6 +2735,8 @@ public class PurpurWorldConfig {
+@@ -2737,6 +2737,8 @@ public class PurpurWorldConfig {
      public double zombieVillagerJockeyChance = 0.05D;
      public boolean zombieVillagerJockeyTryExistingChickens = true;
      public boolean zombieVillagerTakeDamageFromWater = false;
@@ -30,7 +30,7 @@ index 60ffefcdf868670e3a8140ed5cba26c8f74319f5..a0beb76cb448346332c10dde1ccfc62a
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2750,6 +2752,8 @@ public class PurpurWorldConfig {
+@@ -2752,6 +2754,8 @@ public class PurpurWorldConfig {
          zombieVillagerJockeyChance = getDouble("mobs.zombie_villager.jockey.chance", zombieVillagerJockeyChance);
          zombieVillagerJockeyTryExistingChickens = getBoolean("mobs.zombie_villager.jockey.try-existing-chickens", zombieVillagerJockeyTryExistingChickens);
          zombieVillagerTakeDamageFromWater = getBoolean("mobs.zombie_villager.takes-damage-from-water", zombieVillagerTakeDamageFromWater);

--- a/patches/server/0204-Customizeable-Zombie-Villager-curing-times.patch
+++ b/patches/server/0204-Customizeable-Zombie-Villager-curing-times.patch
@@ -18,10 +18,10 @@ index 1084adce8dc55b19ed9d90c0c5ad6675fff0afc5..9d981e392143baa43b6006ca9ef319fd
  
                  return InteractionResult.SUCCESS;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 478b00fd65409724fa152fde36b6c7929d07622d..ef4d18edfc90e978e365e5ea0134d72b1c5c386e 100644
+index 60ffefcdf868670e3a8140ed5cba26c8f74319f5..a0beb76cb448346332c10dde1ccfc62a06369af6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2733,6 +2733,8 @@ public class PurpurWorldConfig {
+@@ -2735,6 +2735,8 @@ public class PurpurWorldConfig {
      public double zombieVillagerJockeyChance = 0.05D;
      public boolean zombieVillagerJockeyTryExistingChickens = true;
      public boolean zombieVillagerTakeDamageFromWater = false;
@@ -30,7 +30,7 @@ index 478b00fd65409724fa152fde36b6c7929d07622d..ef4d18edfc90e978e365e5ea0134d72b
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2748,6 +2750,8 @@ public class PurpurWorldConfig {
+@@ -2750,6 +2752,8 @@ public class PurpurWorldConfig {
          zombieVillagerJockeyChance = getDouble("mobs.zombie_villager.jockey.chance", zombieVillagerJockeyChance);
          zombieVillagerJockeyTryExistingChickens = getBoolean("mobs.zombie_villager.jockey.try-existing-chickens", zombieVillagerJockeyTryExistingChickens);
          zombieVillagerTakeDamageFromWater = getBoolean("mobs.zombie_villager.takes-damage-from-water", zombieVillagerTakeDamageFromWater);

--- a/patches/server/0205-Option-for-sponges-to-work-on-lava.patch
+++ b/patches/server/0205-Option-for-sponges-to-work-on-lava.patch
@@ -18,10 +18,10 @@ index d96e3fbc0fd4275c29e7e6154ef66e9ed1a5d829..df04a571ebd3c04bc7b58c1ee5661a1f
                          ++i;
                          if (j < world.purpurConfig.spongeAbsorptionRadius) { // Purpur
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index c0ff231020261a78202b0dfb35a14b86415353a0..ace4b438823a3580517360e0fa587d5d5562c804 100644
+index a0beb76cb448346332c10dde1ccfc62a06369af6..471d665eac3118351edfae1e492e5a679a9ccfbc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -925,9 +925,11 @@ public class PurpurWorldConfig {
+@@ -927,9 +927,11 @@ public class PurpurWorldConfig {
  
      public int spongeAbsorptionArea = 64;
      public int spongeAbsorptionRadius = 6;

--- a/patches/server/0205-Option-for-sponges-to-work-on-lava.patch
+++ b/patches/server/0205-Option-for-sponges-to-work-on-lava.patch
@@ -18,10 +18,10 @@ index d96e3fbc0fd4275c29e7e6154ef66e9ed1a5d829..df04a571ebd3c04bc7b58c1ee5661a1f
                          ++i;
                          if (j < world.purpurConfig.spongeAbsorptionRadius) { // Purpur
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a0beb76cb448346332c10dde1ccfc62a06369af6..471d665eac3118351edfae1e492e5a679a9ccfbc 100644
+index e503b9018183fa6491529d1c5fe630906fb61a50..24232ea98d8ba1983b363689397ce4cef2826557 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -927,9 +927,11 @@ public class PurpurWorldConfig {
+@@ -929,9 +929,11 @@ public class PurpurWorldConfig {
  
      public int spongeAbsorptionArea = 64;
      public int spongeAbsorptionRadius = 6;

--- a/patches/server/0206-Toggle-for-Wither-s-spawn-sound.patch
+++ b/patches/server/0206-Toggle-for-Wither-s-spawn-sound.patch
@@ -18,10 +18,10 @@ index cb869ddaeed10f8edd0a327553bfe5dcbb405e3d..588ff25c19f7c0acc627f2d8425dbae5
                      // this.world.globalLevelEvent(1023, new BlockPosition(this), 0);
                      int viewDistance = ((ServerLevel) this.level).getCraftServer().getViewDistance() * 16;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 471d665eac3118351edfae1e492e5a679a9ccfbc..a1442f2c7b9c21b540b8523cfa80c1fd93837062 100644
+index 24232ea98d8ba1983b363689397ce4cef2826557..9d16759f8e736e3981a448ab3a7d784636bc05f3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2580,6 +2580,7 @@ public class PurpurWorldConfig {
+@@ -2582,6 +2582,7 @@ public class PurpurWorldConfig {
      public boolean witherTakeDamageFromWater = false;
      public boolean witherCanRideVehicles = false;
      public float witherExplosionRadius = 1.0F;
@@ -29,7 +29,7 @@ index 471d665eac3118351edfae1e492e5a679a9ccfbc..a1442f2c7b9c21b540b8523cfa80c1fd
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2601,6 +2602,7 @@ public class PurpurWorldConfig {
+@@ -2603,6 +2604,7 @@ public class PurpurWorldConfig {
          witherTakeDamageFromWater = getBoolean("mobs.wither.takes-damage-from-water", witherTakeDamageFromWater);
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);
          witherExplosionRadius = (float) getDouble("mobs.wither.explosion-radius", witherExplosionRadius);

--- a/patches/server/0206-Toggle-for-Wither-s-spawn-sound.patch
+++ b/patches/server/0206-Toggle-for-Wither-s-spawn-sound.patch
@@ -18,10 +18,10 @@ index cb869ddaeed10f8edd0a327553bfe5dcbb405e3d..588ff25c19f7c0acc627f2d8425dbae5
                      // this.world.globalLevelEvent(1023, new BlockPosition(this), 0);
                      int viewDistance = ((ServerLevel) this.level).getCraftServer().getViewDistance() * 16;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e306f28641f14897a14eab7f618b4ae954df3afc..e4d20da9aedf0b0232781936d791b6c4a1463f88 100644
+index 471d665eac3118351edfae1e492e5a679a9ccfbc..a1442f2c7b9c21b540b8523cfa80c1fd93837062 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2578,6 +2578,7 @@ public class PurpurWorldConfig {
+@@ -2580,6 +2580,7 @@ public class PurpurWorldConfig {
      public boolean witherTakeDamageFromWater = false;
      public boolean witherCanRideVehicles = false;
      public float witherExplosionRadius = 1.0F;
@@ -29,7 +29,7 @@ index e306f28641f14897a14eab7f618b4ae954df3afc..e4d20da9aedf0b0232781936d791b6c4
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2599,6 +2600,7 @@ public class PurpurWorldConfig {
+@@ -2601,6 +2602,7 @@ public class PurpurWorldConfig {
          witherTakeDamageFromWater = getBoolean("mobs.wither.takes-damage-from-water", witherTakeDamageFromWater);
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);
          witherExplosionRadius = (float) getDouble("mobs.wither.explosion-radius", witherExplosionRadius);

--- a/patches/server/0207-Cactus-breaks-from-solid-neighbors-config.patch
+++ b/patches/server/0207-Cactus-breaks-from-solid-neighbors-config.patch
@@ -18,10 +18,10 @@ index 7579946ce222b6ab3685a7fd9821bcd5a4babe33..2fffe4452d8f3fa5b9365dff1cfe5b5d
          return false;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1316968cc4422f8bf60fae492fb4b1056f56111e..28f83de054bc1bc8477db7671a71dcf11f010370 100644
+index a1442f2c7b9c21b540b8523cfa80c1fd93837062..29e5d41eec9ad2165a55a3bd780c01500fd7905e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -746,6 +746,11 @@ public class PurpurWorldConfig {
+@@ -748,6 +748,11 @@ public class PurpurWorldConfig {
          buddingAmethystSilkTouch = getBoolean("blocks.budding_amethyst.silk-touch", buddingAmethystSilkTouch);
      }
  

--- a/patches/server/0207-Cactus-breaks-from-solid-neighbors-config.patch
+++ b/patches/server/0207-Cactus-breaks-from-solid-neighbors-config.patch
@@ -18,10 +18,10 @@ index 7579946ce222b6ab3685a7fd9821bcd5a4babe33..2fffe4452d8f3fa5b9365dff1cfe5b5d
          return false;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a1442f2c7b9c21b540b8523cfa80c1fd93837062..29e5d41eec9ad2165a55a3bd780c01500fd7905e 100644
+index 9d16759f8e736e3981a448ab3a7d784636bc05f3..558ce467d5b39d763abc7377053f1432b5d4d3e3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -748,6 +748,11 @@ public class PurpurWorldConfig {
+@@ -750,6 +750,11 @@ public class PurpurWorldConfig {
          buddingAmethystSilkTouch = getBoolean("blocks.budding_amethyst.silk-touch", buddingAmethystSilkTouch);
      }
  

--- a/patches/server/0208-Config-to-remove-curse-of-binding-with-weakness.patch
+++ b/patches/server/0208-Config-to-remove-curse-of-binding-with-weakness.patch
@@ -26,10 +26,10 @@ index da0f5c5e6ca7ce7b38792e6da52c5cdcdbae3b78..4136bcd49fe05d916ab65de0e8661451
  
                  @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 28f83de054bc1bc8477db7671a71dcf11f010370..749e884f3b1149a5d875867ac9fa31b85b72ac40 100644
+index 29e5d41eec9ad2165a55a3bd780c01500fd7905e..a4ba9c797f254ab7e3f3062db6701d03acc4796c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -404,6 +404,7 @@ public class PurpurWorldConfig {
+@@ -406,6 +406,7 @@ public class PurpurWorldConfig {
      public int playerBurpDelay = 10;
      public boolean playerBurpWhenFull = false;
      public boolean playerRidableInWater = false;
@@ -37,7 +37,7 @@ index 28f83de054bc1bc8477db7671a71dcf11f010370..749e884f3b1149a5d875867ac9fa31b8
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -429,6 +430,7 @@ public class PurpurWorldConfig {
+@@ -431,6 +432,7 @@ public class PurpurWorldConfig {
          playerBurpDelay = getInt("gameplay-mechanics.player.burp-delay", playerBurpDelay);
          playerBurpWhenFull = getBoolean("gameplay-mechanics.player.burp-when-full", playerBurpWhenFull);
          playerRidableInWater = getBoolean("gameplay-mechanics.player.ridable-in-water", playerRidableInWater);

--- a/patches/server/0208-Config-to-remove-curse-of-binding-with-weakness.patch
+++ b/patches/server/0208-Config-to-remove-curse-of-binding-with-weakness.patch
@@ -26,10 +26,10 @@ index da0f5c5e6ca7ce7b38792e6da52c5cdcdbae3b78..4136bcd49fe05d916ab65de0e8661451
  
                  @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 29e5d41eec9ad2165a55a3bd780c01500fd7905e..a4ba9c797f254ab7e3f3062db6701d03acc4796c 100644
+index 558ce467d5b39d763abc7377053f1432b5d4d3e3..6146547d1d980ccf78e7265e51b1c34718834773 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -406,6 +406,7 @@ public class PurpurWorldConfig {
+@@ -408,6 +408,7 @@ public class PurpurWorldConfig {
      public int playerBurpDelay = 10;
      public boolean playerBurpWhenFull = false;
      public boolean playerRidableInWater = false;
@@ -37,7 +37,7 @@ index 29e5d41eec9ad2165a55a3bd780c01500fd7905e..a4ba9c797f254ab7e3f3062db6701d03
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -431,6 +432,7 @@ public class PurpurWorldConfig {
+@@ -433,6 +434,7 @@ public class PurpurWorldConfig {
          playerBurpDelay = getInt("gameplay-mechanics.player.burp-delay", playerBurpDelay);
          playerBurpWhenFull = getBoolean("gameplay-mechanics.player.burp-when-full", playerBurpWhenFull);
          playerRidableInWater = getBoolean("gameplay-mechanics.player.ridable-in-water", playerRidableInWater);

--- a/patches/server/0209-Conduit-behavior-configuration.patch
+++ b/patches/server/0209-Conduit-behavior-configuration.patch
@@ -77,10 +77,10 @@ index 963a596154091b79ca139af6274aa323518ad1ad..4dcac3899a500d8586580bcfd5b4516e
          });
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a4ba9c797f254ab7e3f3062db6701d03acc4796c..c16d82193762958271a89a04a2ee7ed98c269097 100644
+index 6146547d1d980ccf78e7265e51b1c34718834773..2ad07c394672ccda23853ee8e384219fb49bcdb4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2799,5 +2799,28 @@ public class PurpurWorldConfig {
+@@ -2801,5 +2801,28 @@ public class PurpurWorldConfig {
      private void hungerSettings() {
          hungerStarvationDamage = (float) getDouble("hunger.starvation-damage", hungerStarvationDamage);
      }

--- a/patches/server/0209-Conduit-behavior-configuration.patch
+++ b/patches/server/0209-Conduit-behavior-configuration.patch
@@ -77,10 +77,10 @@ index 963a596154091b79ca139af6274aa323518ad1ad..4dcac3899a500d8586580bcfd5b4516e
          });
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5cb2cfea76523cd0dabc1918a5b426ef0052edc1..5d17356098c6d38249e3c813f78836da6d50dc07 100644
+index a4ba9c797f254ab7e3f3062db6701d03acc4796c..c16d82193762958271a89a04a2ee7ed98c269097 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2797,5 +2797,28 @@ public class PurpurWorldConfig {
+@@ -2799,5 +2799,28 @@ public class PurpurWorldConfig {
      private void hungerSettings() {
          hungerStarvationDamage = (float) getDouble("hunger.starvation-damage", hungerStarvationDamage);
      }

--- a/patches/server/0210-Cauldron-fill-chances.patch
+++ b/patches/server/0210-Cauldron-fill-chances.patch
@@ -47,10 +47,10 @@ index 6b909d41ccdf6c1ac3ac0c4e673ff52f0d14a238..b8f69063cec4d31c9d9525a04c46ed89
  
                      if (dripChance < f1) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5d17356098c6d38249e3c813f78836da6d50dc07..54a086a14ffad32496b5602a4fe1aa4535055579 100644
+index c16d82193762958271a89a04a2ee7ed98c269097..7a9093f36c1d81bfdd2f2a2208195354cab492fa 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2820,5 +2820,16 @@ public class PurpurWorldConfig {
+@@ -2822,5 +2822,16 @@ public class PurpurWorldConfig {
          });
          conduitBlocks = conduitBlockList.toArray(Block[]::new);
      }

--- a/patches/server/0210-Cauldron-fill-chances.patch
+++ b/patches/server/0210-Cauldron-fill-chances.patch
@@ -47,10 +47,10 @@ index 6b909d41ccdf6c1ac3ac0c4e673ff52f0d14a238..b8f69063cec4d31c9d9525a04c46ed89
  
                      if (dripChance < f1) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index c16d82193762958271a89a04a2ee7ed98c269097..7a9093f36c1d81bfdd2f2a2208195354cab492fa 100644
+index 2ad07c394672ccda23853ee8e384219fb49bcdb4..ad4cc60a0187965f7d7ba5c5bd28dfc56b0ee69d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2822,5 +2822,16 @@ public class PurpurWorldConfig {
+@@ -2824,5 +2824,16 @@ public class PurpurWorldConfig {
          });
          conduitBlocks = conduitBlockList.toArray(Block[]::new);
      }

--- a/patches/server/0212-Shulker-change-color-with-dye.patch
+++ b/patches/server/0212-Shulker-change-color-with-dye.patch
@@ -47,10 +47,10 @@ index 6ce1b5223bec2ee093de2374f20b8629a5d68069..9ac0caba4dcddc59850ac0ef52603478
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 15895c5a3750ce9cf3c38e9696f558e81baa04ef..150ce2feeb3e8a1db6ec5bed5a286affbce44d29 100644
+index 703f96434c10b0558503a709042f7a6f4ce8fe22..6e62217ae4f548350aa289c36d41285ef808bdef 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2144,6 +2144,7 @@ public class PurpurWorldConfig {
+@@ -2146,6 +2146,7 @@ public class PurpurWorldConfig {
      public double shulkerSpawnFromBulletNearbyRange = 8.0D;
      public String shulkerSpawnFromBulletNearbyEquation = "(nearby - 1) / 5.0";
      public boolean shulkerSpawnFromBulletRandomColor = false;
@@ -58,7 +58,7 @@ index 15895c5a3750ce9cf3c38e9696f558e81baa04ef..150ce2feeb3e8a1db6ec5bed5a286aff
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -2160,6 +2161,7 @@ public class PurpurWorldConfig {
+@@ -2162,6 +2163,7 @@ public class PurpurWorldConfig {
          shulkerSpawnFromBulletNearbyRange = getDouble("mobs.shulker.spawn-from-bullet.nearby-range", shulkerSpawnFromBulletNearbyRange);
          shulkerSpawnFromBulletNearbyEquation = getString("mobs.shulker.spawn-from-bullet.nearby-equation", shulkerSpawnFromBulletNearbyEquation);
          shulkerSpawnFromBulletRandomColor = getBoolean("mobs.shulker.spawn-from-bullet.random-color", shulkerSpawnFromBulletRandomColor);

--- a/patches/server/0212-Shulker-change-color-with-dye.patch
+++ b/patches/server/0212-Shulker-change-color-with-dye.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Shulker change color with dye
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-index b64c492a245494ab60c325d66dc6ec65418a1e4e..893141e599c6e1917831110470b6b1c0bb0ba1d5 100644
+index 6ce1b5223bec2ee093de2374f20b8629a5d68069..9ac0caba4dcddc59850ac0ef5260347858f0cd4b 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
 @@ -22,6 +22,8 @@ import net.minecraft.tags.DamageTypeTags;
@@ -47,10 +47,10 @@ index b64c492a245494ab60c325d66dc6ec65418a1e4e..893141e599c6e1917831110470b6b1c0
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 79d12e8b16f72badca9cca05bc70423de2fd1e58..8418214dce4920bb42e0042dc4d11cb4764c2f78 100644
+index 15895c5a3750ce9cf3c38e9696f558e81baa04ef..150ce2feeb3e8a1db6ec5bed5a286affbce44d29 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2142,6 +2142,7 @@ public class PurpurWorldConfig {
+@@ -2144,6 +2144,7 @@ public class PurpurWorldConfig {
      public double shulkerSpawnFromBulletNearbyRange = 8.0D;
      public String shulkerSpawnFromBulletNearbyEquation = "(nearby - 1) / 5.0";
      public boolean shulkerSpawnFromBulletRandomColor = false;
@@ -58,7 +58,7 @@ index 79d12e8b16f72badca9cca05bc70423de2fd1e58..8418214dce4920bb42e0042dc4d11cb4
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -2158,6 +2159,7 @@ public class PurpurWorldConfig {
+@@ -2160,6 +2161,7 @@ public class PurpurWorldConfig {
          shulkerSpawnFromBulletNearbyRange = getDouble("mobs.shulker.spawn-from-bullet.nearby-range", shulkerSpawnFromBulletNearbyRange);
          shulkerSpawnFromBulletNearbyEquation = getString("mobs.shulker.spawn-from-bullet.nearby-equation", shulkerSpawnFromBulletNearbyEquation);
          shulkerSpawnFromBulletRandomColor = getBoolean("mobs.shulker.spawn-from-bullet.random-color", shulkerSpawnFromBulletRandomColor);

--- a/patches/server/0216-Chance-for-azalea-blocks-to-grow-into-trees-naturall.patch
+++ b/patches/server/0216-Chance-for-azalea-blocks-to-grow-into-trees-naturall.patch
@@ -45,10 +45,10 @@ index 8584a65433555133cdcfc24a078fb0b53b9f83bc..4afc4670f9b00a4087410ec366fe45fe
      public static final Block PINK_PETALS = register("pink_petals", new PinkPetalsBlock(BlockBehaviour.Properties.of(Material.PLANT).noCollission().sound(SoundType.PINK_PETALS).requiredFeatures(FeatureFlags.UPDATE_1_20)));
      public static final Block MOSS_BLOCK = register("moss_block", new MossBlock(BlockBehaviour.Properties.of(Material.MOSS, MaterialColor.COLOR_GREEN).strength(0.1F).sound(SoundType.MOSS)));
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1c7786ed41551346c6127574b0afaf0e5d408af7..d501f384313ac6b11f8d36754f4acd307ddb9ec8 100644
+index a9fedadbfad4fc18a553ae4c31508b7295471840..5a3101216f34ec82d2b49596f1c01a5a1508954d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -703,6 +703,11 @@ public class PurpurWorldConfig {
+@@ -705,6 +705,11 @@ public class PurpurWorldConfig {
          anvilColorsUseMiniMessage = getBoolean("blocks.anvil.use-mini-message", anvilColorsUseMiniMessage);
      }
  
@@ -60,7 +60,7 @@ index 1c7786ed41551346c6127574b0afaf0e5d408af7..d501f384313ac6b11f8d36754f4acd30
      public int beaconLevelOne = 20;
      public int beaconLevelTwo = 30;
      public int beaconLevelThree = 40;
-@@ -845,6 +850,11 @@ public class PurpurWorldConfig {
+@@ -847,6 +852,11 @@ public class PurpurWorldConfig {
          farmlandTramplingFeatherFalling = getBoolean("blocks.farmland.feather-fall-distance-affects-trampling", farmlandTramplingFeatherFalling);
      }
  

--- a/patches/server/0216-Chance-for-azalea-blocks-to-grow-into-trees-naturall.patch
+++ b/patches/server/0216-Chance-for-azalea-blocks-to-grow-into-trees-naturall.patch
@@ -45,10 +45,10 @@ index 8584a65433555133cdcfc24a078fb0b53b9f83bc..4afc4670f9b00a4087410ec366fe45fe
      public static final Block PINK_PETALS = register("pink_petals", new PinkPetalsBlock(BlockBehaviour.Properties.of(Material.PLANT).noCollission().sound(SoundType.PINK_PETALS).requiredFeatures(FeatureFlags.UPDATE_1_20)));
      public static final Block MOSS_BLOCK = register("moss_block", new MossBlock(BlockBehaviour.Properties.of(Material.MOSS, MaterialColor.COLOR_GREEN).strength(0.1F).sound(SoundType.MOSS)));
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a0adc2d1bec20b8feb170dab5cc40c306ef453e9..13cb469e9bdde5db59bd93711fe2d2e02cff0722 100644
+index 1c7786ed41551346c6127574b0afaf0e5d408af7..d501f384313ac6b11f8d36754f4acd307ddb9ec8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -701,6 +701,11 @@ public class PurpurWorldConfig {
+@@ -703,6 +703,11 @@ public class PurpurWorldConfig {
          anvilColorsUseMiniMessage = getBoolean("blocks.anvil.use-mini-message", anvilColorsUseMiniMessage);
      }
  
@@ -60,7 +60,7 @@ index a0adc2d1bec20b8feb170dab5cc40c306ef453e9..13cb469e9bdde5db59bd93711fe2d2e0
      public int beaconLevelOne = 20;
      public int beaconLevelTwo = 30;
      public int beaconLevelThree = 40;
-@@ -843,6 +848,11 @@ public class PurpurWorldConfig {
+@@ -845,6 +850,11 @@ public class PurpurWorldConfig {
          farmlandTramplingFeatherFalling = getBoolean("blocks.farmland.feather-fall-distance-affects-trampling", farmlandTramplingFeatherFalling);
      }
  

--- a/patches/server/0217-Shift-right-click-to-use-exp-for-mending.patch
+++ b/patches/server/0217-Shift-right-click-to-use-exp-for-mending.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Shift right click to use exp for mending
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index 88c8f2c53c024021e7bad1e4666e3438b53ab588..41d9bba8466ad9500ff02b9926e5e3cb15561e56 100644
+index 49335b4fc2a9caab1418531a814210bf52b3cc43..ebf1ac089202c06fd2cc593dc12c21fe2d0a8de8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -509,6 +509,7 @@ public class ServerPlayerGameMode {
@@ -36,7 +36,7 @@ index 88c8f2c53c024021e7bad1e4666e3438b53ab588..41d9bba8466ad9500ff02b9926e5e3cb
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2b8d8dafc0df272ad095130021795cfa7716ef46..f6350fbe18a87a27db70e70bbcb628231a57977c 100644
+index e3b9bea53438316ad23ebd072e476c7e14c11f92..f4d72c5c365bd9f31fce33ff069db94489f426ef 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2076,6 +2076,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -48,10 +48,10 @@ index 2b8d8dafc0df272ad095130021795cfa7716ef46..f6350fbe18a87a27db70e70bbcb62823
                  cancelled = event.useItemInHand() == Event.Result.DENY;
              } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 13cb469e9bdde5db59bd93711fe2d2e02cff0722..e71f3d9fe397392c68fc8a3de600f4551c7ccd5f 100644
+index d501f384313ac6b11f8d36754f4acd307ddb9ec8..409d9e124279e59e5e44cd0433272dc108d8405b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -411,6 +411,7 @@ public class PurpurWorldConfig {
+@@ -413,6 +413,7 @@ public class PurpurWorldConfig {
      public boolean playerBurpWhenFull = false;
      public boolean playerRidableInWater = false;
      public boolean playerRemoveBindingWithWeakness = false;
@@ -59,7 +59,7 @@ index 13cb469e9bdde5db59bd93711fe2d2e02cff0722..e71f3d9fe397392c68fc8a3de600f455
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -437,6 +438,7 @@ public class PurpurWorldConfig {
+@@ -439,6 +440,7 @@ public class PurpurWorldConfig {
          playerBurpWhenFull = getBoolean("gameplay-mechanics.player.burp-when-full", playerBurpWhenFull);
          playerRidableInWater = getBoolean("gameplay-mechanics.player.ridable-in-water", playerRidableInWater);
          playerRemoveBindingWithWeakness = getBoolean("gameplay-mechanics.player.curse-of-binding.remove-with-weakness", playerRemoveBindingWithWeakness);

--- a/patches/server/0217-Shift-right-click-to-use-exp-for-mending.patch
+++ b/patches/server/0217-Shift-right-click-to-use-exp-for-mending.patch
@@ -36,7 +36,7 @@ index 49335b4fc2a9caab1418531a814210bf52b3cc43..ebf1ac089202c06fd2cc593dc12c21fe
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e3b9bea53438316ad23ebd072e476c7e14c11f92..f4d72c5c365bd9f31fce33ff069db94489f426ef 100644
+index 2bfa3ee8fba634c33545b68dbd5d49fa1984ed55..47ff0f978bac2552a04c946ac0bf59ddf6338f7d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2076,6 +2076,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -48,10 +48,10 @@ index e3b9bea53438316ad23ebd072e476c7e14c11f92..f4d72c5c365bd9f31fce33ff069db944
                  cancelled = event.useItemInHand() == Event.Result.DENY;
              } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d501f384313ac6b11f8d36754f4acd307ddb9ec8..409d9e124279e59e5e44cd0433272dc108d8405b 100644
+index 5a3101216f34ec82d2b49596f1c01a5a1508954d..a61b258279e5c44eac353c4e991a7eb5fe238e53 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -413,6 +413,7 @@ public class PurpurWorldConfig {
+@@ -415,6 +415,7 @@ public class PurpurWorldConfig {
      public boolean playerBurpWhenFull = false;
      public boolean playerRidableInWater = false;
      public boolean playerRemoveBindingWithWeakness = false;
@@ -59,7 +59,7 @@ index d501f384313ac6b11f8d36754f4acd307ddb9ec8..409d9e124279e59e5e44cd0433272dc1
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -439,6 +440,7 @@ public class PurpurWorldConfig {
+@@ -441,6 +442,7 @@ public class PurpurWorldConfig {
          playerBurpWhenFull = getBoolean("gameplay-mechanics.player.burp-when-full", playerBurpWhenFull);
          playerRidableInWater = getBoolean("gameplay-mechanics.player.ridable-in-water", playerRidableInWater);
          playerRemoveBindingWithWeakness = getBoolean("gameplay-mechanics.player.curse-of-binding.remove-with-weakness", playerRemoveBindingWithWeakness);

--- a/patches/server/0218-Dolphins-naturally-aggressive-to-players-chance.patch
+++ b/patches/server/0218-Dolphins-naturally-aggressive-to-players-chance.patch
@@ -47,10 +47,10 @@ index f8d3a5d2dc254501c7e4405444ed4439f9af915e..c038a23c4e19c5bf160792cf599acc8f
  
      public static AttributeSupplier.Builder createAttributes() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e71f3d9fe397392c68fc8a3de600f4551c7ccd5f..6ff66f88aa0c9e16b67bbc057acd4f65b7a604df 100644
+index 409d9e124279e59e5e44cd0433272dc108d8405b..a30b290fa63a0c5ff9bfa0eb0ea29b2e20eeb3aa 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1240,6 +1240,7 @@ public class PurpurWorldConfig {
+@@ -1242,6 +1242,7 @@ public class PurpurWorldConfig {
      public double dolphinMaxHealth = 10.0D;
      public boolean dolphinDisableTreasureSearching = false;
      public boolean dolphinTakeDamageFromWater = false;
@@ -58,7 +58,7 @@ index e71f3d9fe397392c68fc8a3de600f4551c7ccd5f..6ff66f88aa0c9e16b67bbc057acd4f65
      private void dolphinSettings() {
          dolphinRidable = getBoolean("mobs.dolphin.ridable", dolphinRidable);
          dolphinControllable = getBoolean("mobs.dolphin.controllable", dolphinControllable);
-@@ -1254,6 +1255,7 @@ public class PurpurWorldConfig {
+@@ -1256,6 +1257,7 @@ public class PurpurWorldConfig {
          dolphinMaxHealth = getDouble("mobs.dolphin.attributes.max_health", dolphinMaxHealth);
          dolphinDisableTreasureSearching = getBoolean("mobs.dolphin.disable-treasure-searching", dolphinDisableTreasureSearching);
          dolphinTakeDamageFromWater = getBoolean("mobs.dolphin.takes-damage-from-water", dolphinTakeDamageFromWater);

--- a/patches/server/0218-Dolphins-naturally-aggressive-to-players-chance.patch
+++ b/patches/server/0218-Dolphins-naturally-aggressive-to-players-chance.patch
@@ -47,10 +47,10 @@ index f8d3a5d2dc254501c7e4405444ed4439f9af915e..c038a23c4e19c5bf160792cf599acc8f
  
      public static AttributeSupplier.Builder createAttributes() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 409d9e124279e59e5e44cd0433272dc108d8405b..a30b290fa63a0c5ff9bfa0eb0ea29b2e20eeb3aa 100644
+index a61b258279e5c44eac353c4e991a7eb5fe238e53..d4511d3c5dde9ae8b4608259d045bedb2323d98f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1242,6 +1242,7 @@ public class PurpurWorldConfig {
+@@ -1244,6 +1244,7 @@ public class PurpurWorldConfig {
      public double dolphinMaxHealth = 10.0D;
      public boolean dolphinDisableTreasureSearching = false;
      public boolean dolphinTakeDamageFromWater = false;
@@ -58,7 +58,7 @@ index 409d9e124279e59e5e44cd0433272dc108d8405b..a30b290fa63a0c5ff9bfa0eb0ea29b2e
      private void dolphinSettings() {
          dolphinRidable = getBoolean("mobs.dolphin.ridable", dolphinRidable);
          dolphinControllable = getBoolean("mobs.dolphin.controllable", dolphinControllable);
-@@ -1256,6 +1257,7 @@ public class PurpurWorldConfig {
+@@ -1258,6 +1259,7 @@ public class PurpurWorldConfig {
          dolphinMaxHealth = getDouble("mobs.dolphin.attributes.max_health", dolphinMaxHealth);
          dolphinDisableTreasureSearching = getBoolean("mobs.dolphin.disable-treasure-searching", dolphinDisableTreasureSearching);
          dolphinTakeDamageFromWater = getBoolean("mobs.dolphin.takes-damage-from-water", dolphinTakeDamageFromWater);

--- a/patches/server/0219-Cows-naturally-aggressive-to-players-chance.patch
+++ b/patches/server/0219-Cows-naturally-aggressive-to-players-chance.patch
@@ -59,10 +59,10 @@ index ece8f5c4277d6b42fd19df64bfa624f96f1390ca..17c94ffb73b6bc2fbf7b700934a0eb01
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a30b290fa63a0c5ff9bfa0eb0ea29b2e20eeb3aa..127fc96a6b47098161e89cdb92bab1ca4604cc17 100644
+index d4511d3c5dde9ae8b4608259d045bedb2323d98f..068d204154cf18397fad3a3240a88e76e9a703cc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1191,7 +1191,14 @@ public class PurpurWorldConfig {
+@@ -1193,7 +1193,14 @@ public class PurpurWorldConfig {
      public int cowFeedMushrooms = 0;
      public int cowBreedingTicks = 6000;
      public boolean cowTakeDamageFromWater = false;
@@ -77,7 +77,7 @@ index a30b290fa63a0c5ff9bfa0eb0ea29b2e20eeb3aa..127fc96a6b47098161e89cdb92bab1ca
          cowRidable = getBoolean("mobs.cow.ridable", cowRidable);
          cowRidableInWater = getBoolean("mobs.cow.ridable-in-water", cowRidableInWater);
          cowControllable = getBoolean("mobs.cow.controllable", cowControllable);
-@@ -1204,6 +1211,8 @@ public class PurpurWorldConfig {
+@@ -1206,6 +1213,8 @@ public class PurpurWorldConfig {
          cowFeedMushrooms = getInt("mobs.cow.feed-mushrooms-for-mooshroom", cowFeedMushrooms);
          cowBreedingTicks = getInt("mobs.cow.breeding-delay-ticks", cowBreedingTicks);
          cowTakeDamageFromWater = getBoolean("mobs.cow.takes-damage-from-water", cowTakeDamageFromWater);

--- a/patches/server/0219-Cows-naturally-aggressive-to-players-chance.patch
+++ b/patches/server/0219-Cows-naturally-aggressive-to-players-chance.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Cows naturally aggressive to players chance
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Cow.java b/src/main/java/net/minecraft/world/entity/animal/Cow.java
-index 48d20fcd481e76e180410c11040b2164315fce23..7bf4b399d68b04a43465e85061113249d7ecf0d3 100644
+index ece8f5c4277d6b42fd19df64bfa624f96f1390ca..17c94ffb73b6bc2fbf7b700934a0eb01e117756a 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Cow.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Cow.java
 @@ -38,6 +38,7 @@ import org.bukkit.craftbukkit.inventory.CraftItemStack;
@@ -59,10 +59,10 @@ index 48d20fcd481e76e180410c11040b2164315fce23..7bf4b399d68b04a43465e85061113249
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6ff66f88aa0c9e16b67bbc057acd4f65b7a604df..d99280d34614bc01303ad0de23dc39400131b915 100644
+index a30b290fa63a0c5ff9bfa0eb0ea29b2e20eeb3aa..127fc96a6b47098161e89cdb92bab1ca4604cc17 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1189,7 +1189,14 @@ public class PurpurWorldConfig {
+@@ -1191,7 +1191,14 @@ public class PurpurWorldConfig {
      public int cowFeedMushrooms = 0;
      public int cowBreedingTicks = 6000;
      public boolean cowTakeDamageFromWater = false;
@@ -77,7 +77,7 @@ index 6ff66f88aa0c9e16b67bbc057acd4f65b7a604df..d99280d34614bc01303ad0de23dc3940
          cowRidable = getBoolean("mobs.cow.ridable", cowRidable);
          cowRidableInWater = getBoolean("mobs.cow.ridable-in-water", cowRidableInWater);
          cowControllable = getBoolean("mobs.cow.controllable", cowControllable);
-@@ -1202,6 +1209,8 @@ public class PurpurWorldConfig {
+@@ -1204,6 +1211,8 @@ public class PurpurWorldConfig {
          cowFeedMushrooms = getInt("mobs.cow.feed-mushrooms-for-mooshroom", cowFeedMushrooms);
          cowBreedingTicks = getInt("mobs.cow.breeding-delay-ticks", cowBreedingTicks);
          cowTakeDamageFromWater = getBoolean("mobs.cow.takes-damage-from-water", cowTakeDamageFromWater);

--- a/patches/server/0220-Option-for-beds-to-explode-on-villager-sleep.patch
+++ b/patches/server/0220-Option-for-beds-to-explode-on-villager-sleep.patch
@@ -22,10 +22,10 @@ index 1649070edaf0812dd480429cd6d07af84def8311..4f114d7cf5e6429e74bcf3653568beb1
          this.brain.setMemory(MemoryModuleType.LAST_SLEPT, this.level.getGameTime()); // CraftBukkit - decompile error
          this.brain.eraseMemory(MemoryModuleType.WALK_TARGET);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 127fc96a6b47098161e89cdb92bab1ca4604cc17..4c1bb8397f6732e8d2d3a97c37f4d73337fc7407 100644
+index 068d204154cf18397fad3a3240a88e76e9a703cc..c36db31a08bf32bf299a98556ef1b603904c0e5d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -722,6 +722,7 @@ public class PurpurWorldConfig {
+@@ -724,6 +724,7 @@ public class PurpurWorldConfig {
      }
  
      public boolean bedExplode = true;
@@ -33,7 +33,7 @@ index 127fc96a6b47098161e89cdb92bab1ca4604cc17..4c1bb8397f6732e8d2d3a97c37f4d733
      public double bedExplosionPower = 5.0D;
      public boolean bedExplosionFire = true;
      public net.minecraft.world.level.Level.ExplosionInteraction bedExplosionEffect = net.minecraft.world.level.Level.ExplosionInteraction.BLOCK;
-@@ -732,6 +733,7 @@ public class PurpurWorldConfig {
+@@ -734,6 +735,7 @@ public class PurpurWorldConfig {
              }
          }
          bedExplode = getBoolean("blocks.bed.explode", bedExplode);

--- a/patches/server/0220-Option-for-beds-to-explode-on-villager-sleep.patch
+++ b/patches/server/0220-Option-for-beds-to-explode-on-villager-sleep.patch
@@ -22,10 +22,10 @@ index 1649070edaf0812dd480429cd6d07af84def8311..4f114d7cf5e6429e74bcf3653568beb1
          this.brain.setMemory(MemoryModuleType.LAST_SLEPT, this.level.getGameTime()); // CraftBukkit - decompile error
          this.brain.eraseMemory(MemoryModuleType.WALK_TARGET);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e38e3ab793a26e47b0a7882757e0dd99985070c8..d8ae27755319b4655286099ca38d054c07874b8a 100644
+index 127fc96a6b47098161e89cdb92bab1ca4604cc17..4c1bb8397f6732e8d2d3a97c37f4d73337fc7407 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -720,6 +720,7 @@ public class PurpurWorldConfig {
+@@ -722,6 +722,7 @@ public class PurpurWorldConfig {
      }
  
      public boolean bedExplode = true;
@@ -33,7 +33,7 @@ index e38e3ab793a26e47b0a7882757e0dd99985070c8..d8ae27755319b4655286099ca38d054c
      public double bedExplosionPower = 5.0D;
      public boolean bedExplosionFire = true;
      public net.minecraft.world.level.Level.ExplosionInteraction bedExplosionEffect = net.minecraft.world.level.Level.ExplosionInteraction.BLOCK;
-@@ -730,6 +731,7 @@ public class PurpurWorldConfig {
+@@ -732,6 +733,7 @@ public class PurpurWorldConfig {
              }
          }
          bedExplode = getBoolean("blocks.bed.explode", bedExplode);

--- a/patches/server/0221-Halloween-options-and-optimizations.patch
+++ b/patches/server/0221-Halloween-options-and-optimizations.patch
@@ -60,10 +60,10 @@ index f4b9d73f5ce95c7725dbffbafc29c837fe1f87e6..074cbcf451f0f524510b4ab0273fceed
                  this.armorDropChances[EquipmentSlot.HEAD.getIndex()] = 0.0F;
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4c1bb8397f6732e8d2d3a97c37f4d73337fc7407..a39bd6f699d288d965a38152958738a4f46dc5c1 100644
+index c36db31a08bf32bf299a98556ef1b603904c0e5d..a67a2d78529be584c6c64a23d03a2f40b39066b4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1584,6 +1584,13 @@ public class PurpurWorldConfig {
+@@ -1586,6 +1586,13 @@ public class PurpurWorldConfig {
          guardianTakeDamageFromWater = getBoolean("mobs.guardian.takes-damage-from-water", guardianTakeDamageFromWater);
      }
  

--- a/patches/server/0221-Halloween-options-and-optimizations.patch
+++ b/patches/server/0221-Halloween-options-and-optimizations.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Halloween options and optimizations
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ambient/Bat.java b/src/main/java/net/minecraft/world/entity/ambient/Bat.java
-index a108716b9945fafc8c51835151bc7e0ff903be35..68878b236a21a6fec7cbea0eec8e602188bc774e 100644
+index fa9ed6d5ae13ddd14ef8677ca9ad30398a2333f4..3541479dac8404b9c2ec3788cd521aec3fae7c24 100644
 --- a/src/main/java/net/minecraft/world/entity/ambient/Bat.java
 +++ b/src/main/java/net/minecraft/world/entity/ambient/Bat.java
 @@ -314,7 +314,7 @@ public class Bat extends AmbientCreature {
@@ -43,7 +43,7 @@ index ea897da752c96c58d137af56544e9bf50135c6ec..32a303f9ac9768daf621e3aa561cd6b3
                  this.armorDropChances[EquipmentSlot.HEAD.getIndex()] = 0.0F;
              }
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index d6093557894789eb20f79b83547620b47bb65ffb..dfa2806faedf70ca5ffe77087a67822a21e6aac2 100644
+index f4b9d73f5ce95c7725dbffbafc29c837fe1f87e6..074cbcf451f0f524510b4ab0273fceedfba143e3 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -593,11 +593,7 @@ public class Zombie extends Monster {
@@ -60,10 +60,10 @@ index d6093557894789eb20f79b83547620b47bb65ffb..dfa2806faedf70ca5ffe77087a67822a
                  this.armorDropChances[EquipmentSlot.HEAD.getIndex()] = 0.0F;
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 06d6dacdf928c67fd336da111c1c50142aab523f..1a569f7c27e4880baeaa5b6a1aa2f9542573cb29 100644
+index 4c1bb8397f6732e8d2d3a97c37f4d73337fc7407..a39bd6f699d288d965a38152958738a4f46dc5c1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1582,6 +1582,13 @@ public class PurpurWorldConfig {
+@@ -1584,6 +1584,13 @@ public class PurpurWorldConfig {
          guardianTakeDamageFromWater = getBoolean("mobs.guardian.takes-damage-from-water", guardianTakeDamageFromWater);
      }
  

--- a/patches/server/0224-Campfire-option-for-lit-when-placed.patch
+++ b/patches/server/0224-Campfire-option-for-lit-when-placed.patch
@@ -18,10 +18,10 @@ index 219c87dcf065e86512f330fbeec59e55f4675083..f8fd3b320494d1c1e8ee3d170f2feebd
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a39bd6f699d288d965a38152958738a4f46dc5c1..7513bf52c8c3dd8af605aa1b0b18e7c56150926c 100644
+index a67a2d78529be584c6c64a23d03a2f40b39066b4..caa705caf37b14efbc3dba79358f9f68cb503a94 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -770,6 +770,11 @@ public class PurpurWorldConfig {
+@@ -772,6 +772,11 @@ public class PurpurWorldConfig {
          cactusBreaksFromSolidNeighbors = getBoolean("blocks.cactus.breaks-from-solid-neighbors", cactusBreaksFromSolidNeighbors);
      }
  

--- a/patches/server/0224-Campfire-option-for-lit-when-placed.patch
+++ b/patches/server/0224-Campfire-option-for-lit-when-placed.patch
@@ -18,10 +18,10 @@ index 219c87dcf065e86512f330fbeec59e55f4675083..f8fd3b320494d1c1e8ee3d170f2feebd
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1a569f7c27e4880baeaa5b6a1aa2f9542573cb29..26277dd2df640b83e823e386b4ab61d66473faf5 100644
+index a39bd6f699d288d965a38152958738a4f46dc5c1..7513bf52c8c3dd8af605aa1b0b18e7c56150926c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -768,6 +768,11 @@ public class PurpurWorldConfig {
+@@ -770,6 +770,11 @@ public class PurpurWorldConfig {
          cactusBreaksFromSolidNeighbors = getBoolean("blocks.cactus.breaks-from-solid-neighbors", cactusBreaksFromSolidNeighbors);
      }
  

--- a/patches/server/0225-options-to-extinguish-fire-blocks-with-snowballs.patch
+++ b/patches/server/0225-options-to-extinguish-fire-blocks-with-snowballs.patch
@@ -46,10 +46,10 @@ index 5827236f351cd0679af764644bb22bb286ac361d..9a84e8cc1d1b2803a061fe9ef6297c9c
      protected void onHit(HitResult hitResult) {
          super.onHit(hitResult);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7513bf52c8c3dd8af605aa1b0b18e7c56150926c..2f9be14b40c536f907e78b4cd82d4664e5b8a84b 100644
+index caa705caf37b14efbc3dba79358f9f68cb503a94..1e7fed6def1273d84fa9d30aeaaf2850d4c3955d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -232,6 +232,9 @@ public class PurpurWorldConfig {
+@@ -233,6 +233,9 @@ public class PurpurWorldConfig {
      public int glowBerriesEatGlowDuration = 0;
      public boolean shulkerBoxItemDropContentsWhenDestroyed = true;
      public boolean compassItemShowsBossBar = false;
@@ -59,7 +59,7 @@ index 7513bf52c8c3dd8af605aa1b0b18e7c56150926c..2f9be14b40c536f907e78b4cd82d4664
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -279,6 +282,9 @@ public class PurpurWorldConfig {
+@@ -281,6 +284,9 @@ public class PurpurWorldConfig {
          glowBerriesEatGlowDuration = getInt("gameplay-mechanics.item.glow_berries.eat-glow-duration", glowBerriesEatGlowDuration);
          shulkerBoxItemDropContentsWhenDestroyed = getBoolean("gameplay-mechanics.item.shulker_box.drop-contents-when-destroyed", shulkerBoxItemDropContentsWhenDestroyed);
          compassItemShowsBossBar = getBoolean("gameplay-mechanics.item.compass.holding-shows-bossbar", compassItemShowsBossBar);

--- a/patches/server/0225-options-to-extinguish-fire-blocks-with-snowballs.patch
+++ b/patches/server/0225-options-to-extinguish-fire-blocks-with-snowballs.patch
@@ -46,10 +46,10 @@ index 5827236f351cd0679af764644bb22bb286ac361d..9a84e8cc1d1b2803a061fe9ef6297c9c
      protected void onHit(HitResult hitResult) {
          super.onHit(hitResult);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 26277dd2df640b83e823e386b4ab61d66473faf5..26cd4abf4e14122ad9e02542c4a901c00eb9c471 100644
+index 7513bf52c8c3dd8af605aa1b0b18e7c56150926c..2f9be14b40c536f907e78b4cd82d4664e5b8a84b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -231,6 +231,9 @@ public class PurpurWorldConfig {
+@@ -232,6 +232,9 @@ public class PurpurWorldConfig {
      public int glowBerriesEatGlowDuration = 0;
      public boolean shulkerBoxItemDropContentsWhenDestroyed = true;
      public boolean compassItemShowsBossBar = false;
@@ -59,7 +59,7 @@ index 26277dd2df640b83e823e386b4ab61d66473faf5..26cd4abf4e14122ad9e02542c4a901c0
      private void itemSettings() {
          itemImmuneToCactus.clear();
          getList("gameplay-mechanics.item.immune.cactus", new ArrayList<>()).forEach(key -> {
-@@ -277,6 +280,9 @@ public class PurpurWorldConfig {
+@@ -279,6 +282,9 @@ public class PurpurWorldConfig {
          glowBerriesEatGlowDuration = getInt("gameplay-mechanics.item.glow_berries.eat-glow-duration", glowBerriesEatGlowDuration);
          shulkerBoxItemDropContentsWhenDestroyed = getBoolean("gameplay-mechanics.item.shulker_box.drop-contents-when-destroyed", shulkerBoxItemDropContentsWhenDestroyed);
          compassItemShowsBossBar = getBoolean("gameplay-mechanics.item.compass.holding-shows-bossbar", compassItemShowsBossBar);

--- a/patches/server/0226-Add-option-to-disable-zombie-villagers-cure.patch
+++ b/patches/server/0226-Add-option-to-disable-zombie-villagers-cure.patch
@@ -18,10 +18,10 @@ index 9d981e392143baa43b6006ca9ef319fd538c304a..ce644b92598f70872e365584844eaefa
                      itemstack.shrink(1);
                  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 2f9be14b40c536f907e78b4cd82d4664e5b8a84b..28d4e1940844b97ce19adae1d73949c51abcf54d 100644
+index 1e7fed6def1273d84fa9d30aeaaf2850d4c3955d..59829bbc091874f2ae8d640c9e2c400bb9fcd93b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2799,6 +2799,7 @@ public class PurpurWorldConfig {
+@@ -2801,6 +2801,7 @@ public class PurpurWorldConfig {
      public boolean zombieVillagerTakeDamageFromWater = false;
      public int zombieVillagerCuringTimeMin = 3600;
      public int zombieVillagerCuringTimeMax = 6000;
@@ -29,7 +29,7 @@ index 2f9be14b40c536f907e78b4cd82d4664e5b8a84b..28d4e1940844b97ce19adae1d73949c5
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2816,6 +2817,7 @@ public class PurpurWorldConfig {
+@@ -2818,6 +2819,7 @@ public class PurpurWorldConfig {
          zombieVillagerTakeDamageFromWater = getBoolean("mobs.zombie_villager.takes-damage-from-water", zombieVillagerTakeDamageFromWater);
          zombieVillagerCuringTimeMin = getInt("mobs.zombie_villager.curing_time.min", zombieVillagerCuringTimeMin);
          zombieVillagerCuringTimeMax = getInt("mobs.zombie_villager.curing_time.max", zombieVillagerCuringTimeMax);

--- a/patches/server/0226-Add-option-to-disable-zombie-villagers-cure.patch
+++ b/patches/server/0226-Add-option-to-disable-zombie-villagers-cure.patch
@@ -18,10 +18,10 @@ index 9d981e392143baa43b6006ca9ef319fd538c304a..ce644b92598f70872e365584844eaefa
                      itemstack.shrink(1);
                  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3c12d3ef4815f191078211582b25092b9c4f984c..c8b77f1838d0edfea3e5750e3e04aaeaa87e1f17 100644
+index 2f9be14b40c536f907e78b4cd82d4664e5b8a84b..28d4e1940844b97ce19adae1d73949c51abcf54d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2797,6 +2797,7 @@ public class PurpurWorldConfig {
+@@ -2799,6 +2799,7 @@ public class PurpurWorldConfig {
      public boolean zombieVillagerTakeDamageFromWater = false;
      public int zombieVillagerCuringTimeMin = 3600;
      public int zombieVillagerCuringTimeMax = 6000;
@@ -29,7 +29,7 @@ index 3c12d3ef4815f191078211582b25092b9c4f984c..c8b77f1838d0edfea3e5750e3e04aaea
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2814,6 +2815,7 @@ public class PurpurWorldConfig {
+@@ -2816,6 +2817,7 @@ public class PurpurWorldConfig {
          zombieVillagerTakeDamageFromWater = getBoolean("mobs.zombie_villager.takes-damage-from-water", zombieVillagerTakeDamageFromWater);
          zombieVillagerCuringTimeMin = getInt("mobs.zombie_villager.curing_time.min", zombieVillagerCuringTimeMin);
          zombieVillagerCuringTimeMax = getInt("mobs.zombie_villager.curing_time.max", zombieVillagerCuringTimeMax);

--- a/patches/server/0228-Signs-allow-color-codes.patch
+++ b/patches/server/0228-Signs-allow-color-codes.patch
@@ -17,7 +17,7 @@ index b4544ea2a307c2b89796753e33f64ffaf893f83f..087fd880ec62fed20383ef665b4f4d2e
          this.connection.send(new ClientboundBlockUpdatePacket(this.level, sign.getBlockPos()));
          this.connection.send(new ClientboundOpenSignEditorPacket(sign.getBlockPos()));
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f4d72c5c365bd9f31fce33ff069db94489f426ef..7ac53c74ed4ee76a49d383afa6063917d6f4d252 100644
+index 47ff0f978bac2552a04c946ac0bf59ddf6338f7d..a56a1e9f32f818948c5e2cce39ee02395e460bfd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -3532,11 +3532,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -70,10 +70,10 @@ index 4da4edae517a0efec6e03a719ec47b700509dab1..9e760a8e8244b15daaf0abdfc5f8a51d
      public CompoundTag getUpdateTag() {
          return this.saveWithoutMetadata();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6aec7b46f7e59eec481da6c40067c5016d172e4b..80462267cc43e5f66acc2fb1e0b48fd5848127a4 100644
+index 1d63320d555e92ae0b3fe2ead918b99a55252299..6496bd5297acf36a38994a39c97c4615179993e4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -951,8 +951,10 @@ public class PurpurWorldConfig {
+@@ -953,8 +953,10 @@ public class PurpurWorldConfig {
      }
  
      public boolean signRightClickEdit = false;

--- a/patches/server/0228-Signs-allow-color-codes.patch
+++ b/patches/server/0228-Signs-allow-color-codes.patch
@@ -17,7 +17,7 @@ index b4544ea2a307c2b89796753e33f64ffaf893f83f..087fd880ec62fed20383ef665b4f4d2e
          this.connection.send(new ClientboundBlockUpdatePacket(this.level, sign.getBlockPos()));
          this.connection.send(new ClientboundOpenSignEditorPacket(sign.getBlockPos()));
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f6350fbe18a87a27db70e70bbcb628231a57977c..00981d521fd8e73e586efb46926d5e42520ac4f9 100644
+index f4d72c5c365bd9f31fce33ff069db94489f426ef..7ac53c74ed4ee76a49d383afa6063917d6f4d252 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -3532,11 +3532,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -70,10 +70,10 @@ index 4da4edae517a0efec6e03a719ec47b700509dab1..9e760a8e8244b15daaf0abdfc5f8a51d
      public CompoundTag getUpdateTag() {
          return this.saveWithoutMetadata();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 35e9d41a22a48f05a9bf0e934ecc1f08dc18412d..06dbb9b24a27552133a57573ffa44e22671dc7ff 100644
+index 6aec7b46f7e59eec481da6c40067c5016d172e4b..80462267cc43e5f66acc2fb1e0b48fd5848127a4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -949,8 +949,10 @@ public class PurpurWorldConfig {
+@@ -951,8 +951,10 @@ public class PurpurWorldConfig {
      }
  
      public boolean signRightClickEdit = false;

--- a/patches/server/0230-Mobs-always-drop-experience.patch
+++ b/patches/server/0230-Mobs-always-drop-experience.patch
@@ -1157,10 +1157,10 @@ index e06f3ee85dde587f1146d4a3d70e8a2e5b9a128b..2e9dd920e5c3943cba4c53ec2a2b48ee
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efbc355b776 100644
+index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614dbd4f33547 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1013,12 +1013,14 @@ public class PurpurWorldConfig {
+@@ -1015,12 +1015,14 @@ public class PurpurWorldConfig {
      public double axolotlMaxHealth = 14.0D;
      public int axolotlBreedingTicks = 6000;
      public boolean axolotlTakeDamageFromWater = false;
@@ -1175,7 +1175,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean batRidable = false;
-@@ -1034,6 +1036,7 @@ public class PurpurWorldConfig {
+@@ -1036,6 +1038,7 @@ public class PurpurWorldConfig {
      public double batArmorToughness = 0.0D;
      public double batAttackKnockback = 0.0D;
      public boolean batTakeDamageFromWater = false;
@@ -1183,7 +1183,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void batSettings() {
          batRidable = getBoolean("mobs.bat.ridable", batRidable);
          batRidableInWater = getBoolean("mobs.bat.ridable-in-water", batRidableInWater);
-@@ -1046,6 +1049,7 @@ public class PurpurWorldConfig {
+@@ -1048,6 +1051,7 @@ public class PurpurWorldConfig {
          }
          batMaxHealth = getDouble("mobs.bat.attributes.max_health", batMaxHealth);
          batTakeDamageFromWater = getBoolean("mobs.bat.takes-damage-from-water", batTakeDamageFromWater);
@@ -1191,7 +1191,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean beeRidable = false;
-@@ -1057,6 +1061,7 @@ public class PurpurWorldConfig {
+@@ -1059,6 +1063,7 @@ public class PurpurWorldConfig {
      public boolean beeTakeDamageFromWater = false;
      public boolean beeCanWorkAtNight = false;
      public boolean beeCanWorkInRain = false;
@@ -1199,7 +1199,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -1072,6 +1077,7 @@ public class PurpurWorldConfig {
+@@ -1074,6 +1079,7 @@ public class PurpurWorldConfig {
          beeTakeDamageFromWater = getBoolean("mobs.bee.takes-damage-from-water", beeTakeDamageFromWater);
          beeCanWorkAtNight = getBoolean("mobs.bee.can-work-at-night", beeCanWorkAtNight);
          beeCanWorkInRain = getBoolean("mobs.bee.can-work-in-rain", beeCanWorkInRain);
@@ -1207,7 +1207,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean blazeRidable = false;
-@@ -1080,6 +1086,7 @@ public class PurpurWorldConfig {
+@@ -1082,6 +1088,7 @@ public class PurpurWorldConfig {
      public double blazeMaxY = 320D;
      public double blazeMaxHealth = 20.0D;
      public boolean blazeTakeDamageFromWater = true;
@@ -1215,7 +1215,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void blazeSettings() {
          blazeRidable = getBoolean("mobs.blaze.ridable", blazeRidable);
          blazeRidableInWater = getBoolean("mobs.blaze.ridable-in-water", blazeRidableInWater);
-@@ -1092,6 +1099,7 @@ public class PurpurWorldConfig {
+@@ -1094,6 +1101,7 @@ public class PurpurWorldConfig {
          }
          blazeMaxHealth = getDouble("mobs.blaze.attributes.max_health", blazeMaxHealth);
          blazeTakeDamageFromWater = getBoolean("mobs.blaze.takes-damage-from-water", blazeTakeDamageFromWater);
@@ -1223,7 +1223,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public int camelBreedingTicks = 6000;
-@@ -1121,6 +1129,7 @@ public class PurpurWorldConfig {
+@@ -1123,6 +1131,7 @@ public class PurpurWorldConfig {
      public int catBreedingTicks = 6000;
      public DyeColor catDefaultCollarColor = DyeColor.RED;
      public boolean catTakeDamageFromWater = false;
@@ -1231,7 +1231,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void catSettings() {
          catRidable = getBoolean("mobs.cat.ridable", catRidable);
          catRidableInWater = getBoolean("mobs.cat.ridable-in-water", catRidableInWater);
-@@ -1141,6 +1150,7 @@ public class PurpurWorldConfig {
+@@ -1143,6 +1152,7 @@ public class PurpurWorldConfig {
              catDefaultCollarColor = DyeColor.RED;
          }
          catTakeDamageFromWater = getBoolean("mobs.cat.takes-damage-from-water", catTakeDamageFromWater);
@@ -1239,7 +1239,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean caveSpiderRidable = false;
-@@ -1148,6 +1158,7 @@ public class PurpurWorldConfig {
+@@ -1150,6 +1160,7 @@ public class PurpurWorldConfig {
      public boolean caveSpiderControllable = true;
      public double caveSpiderMaxHealth = 12.0D;
      public boolean caveSpiderTakeDamageFromWater = false;
@@ -1247,7 +1247,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void caveSpiderSettings() {
          caveSpiderRidable = getBoolean("mobs.cave_spider.ridable", caveSpiderRidable);
          caveSpiderRidableInWater = getBoolean("mobs.cave_spider.ridable-in-water", caveSpiderRidableInWater);
-@@ -1159,6 +1170,7 @@ public class PurpurWorldConfig {
+@@ -1161,6 +1172,7 @@ public class PurpurWorldConfig {
          }
          caveSpiderMaxHealth = getDouble("mobs.cave_spider.attributes.max_health", caveSpiderMaxHealth);
          caveSpiderTakeDamageFromWater = getBoolean("mobs.cave_spider.takes-damage-from-water", caveSpiderTakeDamageFromWater);
@@ -1255,7 +1255,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean chickenRidable = false;
-@@ -1168,6 +1180,7 @@ public class PurpurWorldConfig {
+@@ -1170,6 +1182,7 @@ public class PurpurWorldConfig {
      public boolean chickenRetaliate = false;
      public int chickenBreedingTicks = 6000;
      public boolean chickenTakeDamageFromWater = false;
@@ -1263,7 +1263,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void chickenSettings() {
          chickenRidable = getBoolean("mobs.chicken.ridable", chickenRidable);
          chickenRidableInWater = getBoolean("mobs.chicken.ridable-in-water", chickenRidableInWater);
-@@ -1181,12 +1194,14 @@ public class PurpurWorldConfig {
+@@ -1183,12 +1196,14 @@ public class PurpurWorldConfig {
          chickenRetaliate = getBoolean("mobs.chicken.retaliate", chickenRetaliate);
          chickenBreedingTicks = getInt("mobs.chicken.breeding-delay-ticks", chickenBreedingTicks);
          chickenTakeDamageFromWater = getBoolean("mobs.chicken.takes-damage-from-water", chickenTakeDamageFromWater);
@@ -1278,7 +1278,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void codSettings() {
          codRidable = getBoolean("mobs.cod.ridable", codRidable);
          codControllable = getBoolean("mobs.cod.controllable", codControllable);
-@@ -1197,6 +1212,7 @@ public class PurpurWorldConfig {
+@@ -1199,6 +1214,7 @@ public class PurpurWorldConfig {
          }
          codMaxHealth = getDouble("mobs.cod.attributes.max_health", codMaxHealth);
          codTakeDamageFromWater = getBoolean("mobs.cod.takes-damage-from-water", codTakeDamageFromWater);
@@ -1286,7 +1286,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean cowRidable = false;
-@@ -1208,6 +1224,7 @@ public class PurpurWorldConfig {
+@@ -1210,6 +1226,7 @@ public class PurpurWorldConfig {
      public boolean cowTakeDamageFromWater = false;
      public double cowNaturallyAggressiveToPlayersChance = 0.0D;
      public double cowNaturallyAggressiveToPlayersDamage = 2.0D;
@@ -1294,7 +1294,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void cowSettings() {
          if (PurpurConfig.version < 22) {
              double oldValue = getDouble("mobs.cow.naturally-aggressive-to-players-chance", cowNaturallyAggressiveToPlayersChance);
-@@ -1228,6 +1245,7 @@ public class PurpurWorldConfig {
+@@ -1230,6 +1247,7 @@ public class PurpurWorldConfig {
          cowTakeDamageFromWater = getBoolean("mobs.cow.takes-damage-from-water", cowTakeDamageFromWater);
          cowNaturallyAggressiveToPlayersChance = getDouble("mobs.cow.naturally-aggressive-to-players.chance", cowNaturallyAggressiveToPlayersChance);
          cowNaturallyAggressiveToPlayersDamage = getDouble("mobs.cow.naturally-aggressive-to-players.damage", cowNaturallyAggressiveToPlayersDamage);
@@ -1302,7 +1302,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean creeperRidable = false;
-@@ -1240,6 +1258,7 @@ public class PurpurWorldConfig {
+@@ -1242,6 +1260,7 @@ public class PurpurWorldConfig {
      public boolean creeperTakeDamageFromWater = false;
      public boolean creeperExplodeWhenKilled = false;
      public boolean creeperHealthRadius = false;
@@ -1310,7 +1310,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1256,6 +1275,7 @@ public class PurpurWorldConfig {
+@@ -1258,6 +1277,7 @@ public class PurpurWorldConfig {
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
@@ -1318,7 +1318,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean dolphinRidable = false;
-@@ -1267,6 +1287,7 @@ public class PurpurWorldConfig {
+@@ -1269,6 +1289,7 @@ public class PurpurWorldConfig {
      public boolean dolphinDisableTreasureSearching = false;
      public boolean dolphinTakeDamageFromWater = false;
      public double dolphinNaturallyAggressiveToPlayersChance = 0.0D;
@@ -1326,7 +1326,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void dolphinSettings() {
          dolphinRidable = getBoolean("mobs.dolphin.ridable", dolphinRidable);
          dolphinControllable = getBoolean("mobs.dolphin.controllable", dolphinControllable);
-@@ -1282,6 +1303,7 @@ public class PurpurWorldConfig {
+@@ -1284,6 +1305,7 @@ public class PurpurWorldConfig {
          dolphinDisableTreasureSearching = getBoolean("mobs.dolphin.disable-treasure-searching", dolphinDisableTreasureSearching);
          dolphinTakeDamageFromWater = getBoolean("mobs.dolphin.takes-damage-from-water", dolphinTakeDamageFromWater);
          dolphinNaturallyAggressiveToPlayersChance = getDouble("mobs.dolphin.naturally-aggressive-to-players-chance", dolphinNaturallyAggressiveToPlayersChance);
@@ -1334,7 +1334,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean donkeyRidableInWater = false;
-@@ -1293,6 +1315,7 @@ public class PurpurWorldConfig {
+@@ -1295,6 +1317,7 @@ public class PurpurWorldConfig {
      public double donkeyMovementSpeedMax = 0.175D;
      public int donkeyBreedingTicks = 6000;
      public boolean donkeyTakeDamageFromWater = false;
@@ -1342,7 +1342,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void donkeySettings() {
          donkeyRidableInWater = getBoolean("mobs.donkey.ridable-in-water", donkeyRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1310,6 +1333,7 @@ public class PurpurWorldConfig {
+@@ -1312,6 +1335,7 @@ public class PurpurWorldConfig {
          donkeyMovementSpeedMax = getDouble("mobs.donkey.attributes.movement_speed.max", donkeyMovementSpeedMax);
          donkeyBreedingTicks = getInt("mobs.donkey.breeding-delay-ticks", donkeyBreedingTicks);
          donkeyTakeDamageFromWater = getBoolean("mobs.donkey.takes-damage-from-water", donkeyTakeDamageFromWater);
@@ -1350,7 +1350,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean drownedRidable = false;
-@@ -1322,6 +1346,7 @@ public class PurpurWorldConfig {
+@@ -1324,6 +1348,7 @@ public class PurpurWorldConfig {
      public boolean drownedJockeyTryExistingChickens = true;
      public boolean drownedTakeDamageFromWater = false;
      public boolean drownedBreakDoors = false;
@@ -1358,7 +1358,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void drownedSettings() {
          drownedRidable = getBoolean("mobs.drowned.ridable", drownedRidable);
          drownedRidableInWater = getBoolean("mobs.drowned.ridable-in-water", drownedRidableInWater);
-@@ -1338,12 +1363,14 @@ public class PurpurWorldConfig {
+@@ -1340,12 +1365,14 @@ public class PurpurWorldConfig {
          drownedJockeyTryExistingChickens = getBoolean("mobs.drowned.jockey.try-existing-chickens", drownedJockeyTryExistingChickens);
          drownedTakeDamageFromWater = getBoolean("mobs.drowned.takes-damage-from-water", drownedTakeDamageFromWater);
          drownedBreakDoors = getBoolean("mobs.drowned.can-break-doors", drownedBreakDoors);
@@ -1373,7 +1373,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void elderGuardianSettings() {
          elderGuardianRidable = getBoolean("mobs.elder_guardian.ridable", elderGuardianRidable);
          elderGuardianControllable = getBoolean("mobs.elder_guardian.controllable", elderGuardianControllable);
-@@ -1354,6 +1381,7 @@ public class PurpurWorldConfig {
+@@ -1356,6 +1383,7 @@ public class PurpurWorldConfig {
          }
          elderGuardianMaxHealth = getDouble("mobs.elder_guardian.attributes.max_health", elderGuardianMaxHealth);
          elderGuardianTakeDamageFromWater = getBoolean("mobs.elder_guardian.takes-damage-from-water", elderGuardianTakeDamageFromWater);
@@ -1381,7 +1381,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean enderDragonRidable = false;
-@@ -1399,6 +1427,7 @@ public class PurpurWorldConfig {
+@@ -1401,6 +1429,7 @@ public class PurpurWorldConfig {
      public boolean endermanIgnorePlayerDragonHead = false;
      public boolean endermanDisableStareAggro = false;
      public boolean endermanIgnoreProjectiles = false;
@@ -1389,7 +1389,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1422,6 +1451,7 @@ public class PurpurWorldConfig {
+@@ -1424,6 +1453,7 @@ public class PurpurWorldConfig {
          endermanIgnorePlayerDragonHead = getBoolean("mobs.enderman.ignore-players-wearing-dragon-head", endermanIgnorePlayerDragonHead);
          endermanDisableStareAggro = getBoolean("mobs.enderman.disable-player-stare-aggression", endermanDisableStareAggro);
          endermanIgnoreProjectiles = getBoolean("mobs.enderman.ignore-projectiles", endermanIgnoreProjectiles);
@@ -1397,7 +1397,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean endermiteRidable = false;
-@@ -1429,6 +1459,7 @@ public class PurpurWorldConfig {
+@@ -1431,6 +1461,7 @@ public class PurpurWorldConfig {
      public boolean endermiteControllable = true;
      public double endermiteMaxHealth = 8.0D;
      public boolean endermiteTakeDamageFromWater = false;
@@ -1405,7 +1405,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void endermiteSettings() {
          endermiteRidable = getBoolean("mobs.endermite.ridable", endermiteRidable);
          endermiteRidableInWater = getBoolean("mobs.endermite.ridable-in-water", endermiteRidableInWater);
-@@ -1440,6 +1471,7 @@ public class PurpurWorldConfig {
+@@ -1442,6 +1473,7 @@ public class PurpurWorldConfig {
          }
          endermiteMaxHealth = getDouble("mobs.endermite.attributes.max_health", endermiteMaxHealth);
          endermiteTakeDamageFromWater = getBoolean("mobs.endermite.takes-damage-from-water", endermiteTakeDamageFromWater);
@@ -1413,7 +1413,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean evokerRidable = false;
-@@ -1448,6 +1480,7 @@ public class PurpurWorldConfig {
+@@ -1450,6 +1482,7 @@ public class PurpurWorldConfig {
      public double evokerMaxHealth = 24.0D;
      public boolean evokerBypassMobGriefing = false;
      public boolean evokerTakeDamageFromWater = false;
@@ -1421,7 +1421,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void evokerSettings() {
          evokerRidable = getBoolean("mobs.evoker.ridable", evokerRidable);
          evokerRidableInWater = getBoolean("mobs.evoker.ridable-in-water", evokerRidableInWater);
-@@ -1460,6 +1493,7 @@ public class PurpurWorldConfig {
+@@ -1462,6 +1495,7 @@ public class PurpurWorldConfig {
          evokerMaxHealth = getDouble("mobs.evoker.attributes.max_health", evokerMaxHealth);
          evokerBypassMobGriefing = getBoolean("mobs.evoker.bypass-mob-griefing", evokerBypassMobGriefing);
          evokerTakeDamageFromWater = getBoolean("mobs.evoker.takes-damage-from-water", evokerTakeDamageFromWater);
@@ -1429,7 +1429,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean foxRidable = false;
-@@ -1470,6 +1504,7 @@ public class PurpurWorldConfig {
+@@ -1472,6 +1506,7 @@ public class PurpurWorldConfig {
      public int foxBreedingTicks = 6000;
      public boolean foxBypassMobGriefing = false;
      public boolean foxTakeDamageFromWater = false;
@@ -1437,7 +1437,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void foxSettings() {
          foxRidable = getBoolean("mobs.fox.ridable", foxRidable);
          foxRidableInWater = getBoolean("mobs.fox.ridable-in-water", foxRidableInWater);
-@@ -1484,6 +1519,7 @@ public class PurpurWorldConfig {
+@@ -1486,6 +1521,7 @@ public class PurpurWorldConfig {
          foxBreedingTicks = getInt("mobs.fox.breeding-delay-ticks", foxBreedingTicks);
          foxBypassMobGriefing = getBoolean("mobs.fox.bypass-mob-griefing", foxBypassMobGriefing);
          foxTakeDamageFromWater = getBoolean("mobs.fox.takes-damage-from-water", foxTakeDamageFromWater);
@@ -1445,7 +1445,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean frogRidable = false;
-@@ -1505,6 +1541,7 @@ public class PurpurWorldConfig {
+@@ -1507,6 +1543,7 @@ public class PurpurWorldConfig {
      public double ghastMaxY = 320D;
      public double ghastMaxHealth = 10.0D;
      public boolean ghastTakeDamageFromWater = false;
@@ -1453,7 +1453,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void ghastSettings() {
          ghastRidable = getBoolean("mobs.ghast.ridable", ghastRidable);
          ghastRidableInWater = getBoolean("mobs.ghast.ridable-in-water", ghastRidableInWater);
-@@ -1517,6 +1554,7 @@ public class PurpurWorldConfig {
+@@ -1519,6 +1556,7 @@ public class PurpurWorldConfig {
          }
          ghastMaxHealth = getDouble("mobs.ghast.attributes.max_health", ghastMaxHealth);
          ghastTakeDamageFromWater = getBoolean("mobs.ghast.takes-damage-from-water", ghastTakeDamageFromWater);
@@ -1461,7 +1461,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean giantRidable = false;
-@@ -1530,6 +1568,7 @@ public class PurpurWorldConfig {
+@@ -1532,6 +1570,7 @@ public class PurpurWorldConfig {
      public boolean giantHaveAI = false;
      public boolean giantHaveHostileAI = false;
      public boolean giantTakeDamageFromWater = false;
@@ -1469,7 +1469,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void giantSettings() {
          giantRidable = getBoolean("mobs.giant.ridable", giantRidable);
          giantRidableInWater = getBoolean("mobs.giant.ridable-in-water", giantRidableInWater);
-@@ -1551,6 +1590,7 @@ public class PurpurWorldConfig {
+@@ -1553,6 +1592,7 @@ public class PurpurWorldConfig {
          giantHaveAI = getBoolean("mobs.giant.have-ai", giantHaveAI);
          giantHaveHostileAI = getBoolean("mobs.giant.have-hostile-ai", giantHaveHostileAI);
          giantTakeDamageFromWater = getBoolean("mobs.giant.takes-damage-from-water", giantTakeDamageFromWater);
@@ -1477,7 +1477,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean glowSquidRidable = false;
-@@ -1558,12 +1598,14 @@ public class PurpurWorldConfig {
+@@ -1560,12 +1600,14 @@ public class PurpurWorldConfig {
      public double glowSquidMaxHealth = 10.0D;
      public boolean glowSquidsCanFly = false;
      public boolean glowSquidTakeDamageFromWater = false;
@@ -1492,7 +1492,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean goatRidable = false;
-@@ -1572,6 +1614,7 @@ public class PurpurWorldConfig {
+@@ -1574,6 +1616,7 @@ public class PurpurWorldConfig {
      public double goatMaxHealth = 10.0D;
      public int goatBreedingTicks = 6000;
      public boolean goatTakeDamageFromWater = false;
@@ -1500,7 +1500,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void goatSettings() {
          goatRidable = getBoolean("mobs.goat.ridable", goatRidable);
          goatRidableInWater = getBoolean("mobs.goat.ridable-in-water", goatRidableInWater);
-@@ -1579,12 +1622,14 @@ public class PurpurWorldConfig {
+@@ -1581,12 +1624,14 @@ public class PurpurWorldConfig {
          goatMaxHealth = getDouble("mobs.goat.attributes.max_health", goatMaxHealth);
          goatBreedingTicks = getInt("mobs.goat.breeding-delay-ticks", goatBreedingTicks);
          goatTakeDamageFromWater = getBoolean("mobs.goat.takes-damage-from-water", goatTakeDamageFromWater);
@@ -1515,7 +1515,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void guardianSettings() {
          guardianRidable = getBoolean("mobs.guardian.ridable", guardianRidable);
          guardianControllable = getBoolean("mobs.guardian.controllable", guardianControllable);
-@@ -1595,6 +1640,7 @@ public class PurpurWorldConfig {
+@@ -1597,6 +1642,7 @@ public class PurpurWorldConfig {
          }
          guardianMaxHealth = getDouble("mobs.guardian.attributes.max_health", guardianMaxHealth);
          guardianTakeDamageFromWater = getBoolean("mobs.guardian.takes-damage-from-water", guardianTakeDamageFromWater);
@@ -1523,7 +1523,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean forceHalloweenSeason = false;
-@@ -1610,6 +1656,7 @@ public class PurpurWorldConfig {
+@@ -1612,6 +1658,7 @@ public class PurpurWorldConfig {
      public double hoglinMaxHealth = 40.0D;
      public int hoglinBreedingTicks = 6000;
      public boolean hoglinTakeDamageFromWater = false;
@@ -1531,7 +1531,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void hoglinSettings() {
          hoglinRidable = getBoolean("mobs.hoglin.ridable", hoglinRidable);
          hoglinRidableInWater = getBoolean("mobs.hoglin.ridable-in-water", hoglinRidableInWater);
-@@ -1622,6 +1669,7 @@ public class PurpurWorldConfig {
+@@ -1624,6 +1671,7 @@ public class PurpurWorldConfig {
          hoglinMaxHealth = getDouble("mobs.hoglin.attributes.max_health", hoglinMaxHealth);
          hoglinBreedingTicks = getInt("mobs.hoglin.breeding-delay-ticks", hoglinBreedingTicks);
          hoglinTakeDamageFromWater = getBoolean("mobs.hoglin.takes-damage-from-water", hoglinTakeDamageFromWater);
@@ -1539,7 +1539,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean horseRidableInWater = false;
-@@ -1633,6 +1681,7 @@ public class PurpurWorldConfig {
+@@ -1635,6 +1683,7 @@ public class PurpurWorldConfig {
      public double horseMovementSpeedMax = 0.3375D;
      public int horseBreedingTicks = 6000;
      public boolean horseTakeDamageFromWater = false;
@@ -1547,7 +1547,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void horseSettings() {
          horseRidableInWater = getBoolean("mobs.horse.ridable-in-water", horseRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1650,6 +1699,7 @@ public class PurpurWorldConfig {
+@@ -1652,6 +1701,7 @@ public class PurpurWorldConfig {
          horseMovementSpeedMax = getDouble("mobs.horse.attributes.movement_speed.max", horseMovementSpeedMax);
          horseBreedingTicks = getInt("mobs.horse.breeding-delay-ticks", horseBreedingTicks);
          horseTakeDamageFromWater = getBoolean("mobs.horse.takes-damage-from-water", horseTakeDamageFromWater);
@@ -1555,7 +1555,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean huskRidable = false;
-@@ -1661,6 +1711,7 @@ public class PurpurWorldConfig {
+@@ -1663,6 +1713,7 @@ public class PurpurWorldConfig {
      public double huskJockeyChance = 0.05D;
      public boolean huskJockeyTryExistingChickens = true;
      public boolean huskTakeDamageFromWater = false;
@@ -1563,7 +1563,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void huskSettings() {
          huskRidable = getBoolean("mobs.husk.ridable", huskRidable);
          huskRidableInWater = getBoolean("mobs.husk.ridable-in-water", huskRidableInWater);
-@@ -1676,6 +1727,7 @@ public class PurpurWorldConfig {
+@@ -1678,6 +1729,7 @@ public class PurpurWorldConfig {
          huskJockeyChance = getDouble("mobs.husk.jockey.chance", huskJockeyChance);
          huskJockeyTryExistingChickens = getBoolean("mobs.husk.jockey.try-existing-chickens", huskJockeyTryExistingChickens);
          huskTakeDamageFromWater = getBoolean("mobs.husk.takes-damage-from-water", huskTakeDamageFromWater);
@@ -1571,7 +1571,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean illusionerRidable = false;
-@@ -1685,6 +1737,7 @@ public class PurpurWorldConfig {
+@@ -1687,6 +1739,7 @@ public class PurpurWorldConfig {
      public double illusionerFollowRange = 18.0D;
      public double illusionerMaxHealth = 32.0D;
      public boolean illusionerTakeDamageFromWater = false;
@@ -1579,7 +1579,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void illusionerSettings() {
          illusionerRidable = getBoolean("mobs.illusioner.ridable", illusionerRidable);
          illusionerRidableInWater = getBoolean("mobs.illusioner.ridable-in-water", illusionerRidableInWater);
-@@ -1702,6 +1755,7 @@ public class PurpurWorldConfig {
+@@ -1704,6 +1757,7 @@ public class PurpurWorldConfig {
          }
          illusionerMaxHealth = getDouble("mobs.illusioner.attributes.max_health", illusionerMaxHealth);
          illusionerTakeDamageFromWater = getBoolean("mobs.illusioner.takes-damage-from-water", illusionerTakeDamageFromWater);
@@ -1587,7 +1587,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean ironGolemRidable = false;
-@@ -1712,6 +1766,7 @@ public class PurpurWorldConfig {
+@@ -1714,6 +1768,7 @@ public class PurpurWorldConfig {
      public boolean ironGolemTakeDamageFromWater = false;
      public boolean ironGolemPoppyCalm = false;
      public boolean ironGolemHealCalm = false;
@@ -1595,7 +1595,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void ironGolemSettings() {
          ironGolemRidable = getBoolean("mobs.iron_golem.ridable", ironGolemRidable);
          ironGolemRidableInWater = getBoolean("mobs.iron_golem.ridable-in-water", ironGolemRidableInWater);
-@@ -1726,6 +1781,7 @@ public class PurpurWorldConfig {
+@@ -1728,6 +1783,7 @@ public class PurpurWorldConfig {
          ironGolemTakeDamageFromWater = getBoolean("mobs.iron_golem.takes-damage-from-water", ironGolemTakeDamageFromWater);
          ironGolemPoppyCalm = getBoolean("mobs.iron_golem.poppy-calms-anger", ironGolemPoppyCalm);
          ironGolemHealCalm = getBoolean("mobs.iron_golem.healing-calms-anger", ironGolemHealCalm);
@@ -1603,7 +1603,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean llamaRidable = false;
-@@ -1740,6 +1796,7 @@ public class PurpurWorldConfig {
+@@ -1742,6 +1798,7 @@ public class PurpurWorldConfig {
      public int llamaBreedingTicks = 6000;
      public boolean llamaTakeDamageFromWater = false;
      public boolean llamaJoinCaravans = true;
@@ -1611,7 +1611,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void llamaSettings() {
          llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
          llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
-@@ -1760,6 +1817,7 @@ public class PurpurWorldConfig {
+@@ -1762,6 +1819,7 @@ public class PurpurWorldConfig {
          llamaBreedingTicks = getInt("mobs.llama.breeding-delay-ticks", llamaBreedingTicks);
          llamaTakeDamageFromWater = getBoolean("mobs.llama.takes-damage-from-water", llamaTakeDamageFromWater);
          llamaJoinCaravans = getBoolean("mobs.llama.join-caravans", llamaJoinCaravans);
@@ -1619,7 +1619,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean magmaCubeRidable = false;
-@@ -1770,6 +1828,7 @@ public class PurpurWorldConfig {
+@@ -1772,6 +1830,7 @@ public class PurpurWorldConfig {
      public Map<Integer, Double> magmaCubeMaxHealthCache = new HashMap<>();
      public Map<Integer, Double> magmaCubeAttackDamageCache = new HashMap<>();
      public boolean magmaCubeTakeDamageFromWater = false;
@@ -1627,7 +1627,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void magmaCubeSettings() {
          magmaCubeRidable = getBoolean("mobs.magma_cube.ridable", magmaCubeRidable);
          magmaCubeRidableInWater = getBoolean("mobs.magma_cube.ridable-in-water", magmaCubeRidableInWater);
-@@ -1784,6 +1843,7 @@ public class PurpurWorldConfig {
+@@ -1786,6 +1845,7 @@ public class PurpurWorldConfig {
          magmaCubeMaxHealthCache.clear();
          magmaCubeAttackDamageCache.clear();
          magmaCubeTakeDamageFromWater = getBoolean("mobs.magma_cube.takes-damage-from-water", magmaCubeTakeDamageFromWater);
@@ -1635,7 +1635,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean mooshroomRidable = false;
-@@ -1792,6 +1852,7 @@ public class PurpurWorldConfig {
+@@ -1794,6 +1854,7 @@ public class PurpurWorldConfig {
      public double mooshroomMaxHealth = 10.0D;
      public int mooshroomBreedingTicks = 6000;
      public boolean mooshroomTakeDamageFromWater = false;
@@ -1643,7 +1643,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void mooshroomSettings() {
          mooshroomRidable = getBoolean("mobs.mooshroom.ridable", mooshroomRidable);
          mooshroomRidableInWater = getBoolean("mobs.mooshroom.ridable-in-water", mooshroomRidableInWater);
-@@ -1804,6 +1865,7 @@ public class PurpurWorldConfig {
+@@ -1806,6 +1867,7 @@ public class PurpurWorldConfig {
          mooshroomMaxHealth = getDouble("mobs.mooshroom.attributes.max_health", mooshroomMaxHealth);
          mooshroomBreedingTicks = getInt("mobs.mooshroom.breeding-delay-ticks", mooshroomBreedingTicks);
          mooshroomTakeDamageFromWater = getBoolean("mobs.mooshroom.takes-damage-from-water", mooshroomTakeDamageFromWater);
@@ -1651,7 +1651,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean muleRidableInWater = false;
-@@ -1815,6 +1877,7 @@ public class PurpurWorldConfig {
+@@ -1817,6 +1879,7 @@ public class PurpurWorldConfig {
      public double muleMovementSpeedMax = 0.175D;
      public int muleBreedingTicks = 6000;
      public boolean muleTakeDamageFromWater = false;
@@ -1659,7 +1659,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void muleSettings() {
          muleRidableInWater = getBoolean("mobs.mule.ridable-in-water", muleRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1832,6 +1895,7 @@ public class PurpurWorldConfig {
+@@ -1834,6 +1897,7 @@ public class PurpurWorldConfig {
          muleMovementSpeedMax = getDouble("mobs.mule.attributes.movement_speed.max", muleMovementSpeedMax);
          muleBreedingTicks = getInt("mobs.mule.breeding-delay-ticks", muleBreedingTicks);
          muleTakeDamageFromWater = getBoolean("mobs.mule.takes-damage-from-water", muleTakeDamageFromWater);
@@ -1667,7 +1667,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean ocelotRidable = false;
-@@ -1840,6 +1904,7 @@ public class PurpurWorldConfig {
+@@ -1842,6 +1906,7 @@ public class PurpurWorldConfig {
      public double ocelotMaxHealth = 10.0D;
      public int ocelotBreedingTicks = 6000;
      public boolean ocelotTakeDamageFromWater = false;
@@ -1675,7 +1675,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void ocelotSettings() {
          ocelotRidable = getBoolean("mobs.ocelot.ridable", ocelotRidable);
          ocelotRidableInWater = getBoolean("mobs.ocelot.ridable-in-water", ocelotRidableInWater);
-@@ -1852,6 +1917,7 @@ public class PurpurWorldConfig {
+@@ -1854,6 +1919,7 @@ public class PurpurWorldConfig {
          ocelotMaxHealth = getDouble("mobs.ocelot.attributes.max_health", ocelotMaxHealth);
          ocelotBreedingTicks = getInt("mobs.ocelot.breeding-delay-ticks", ocelotBreedingTicks);
          ocelotTakeDamageFromWater = getBoolean("mobs.ocelot.takes-damage-from-water", ocelotTakeDamageFromWater);
@@ -1683,7 +1683,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean pandaRidable = false;
-@@ -1860,6 +1926,7 @@ public class PurpurWorldConfig {
+@@ -1862,6 +1928,7 @@ public class PurpurWorldConfig {
      public double pandaMaxHealth = 20.0D;
      public int pandaBreedingTicks = 6000;
      public boolean pandaTakeDamageFromWater = false;
@@ -1691,7 +1691,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void pandaSettings() {
          pandaRidable = getBoolean("mobs.panda.ridable", pandaRidable);
          pandaRidableInWater = getBoolean("mobs.panda.ridable-in-water", pandaRidableInWater);
-@@ -1872,6 +1939,7 @@ public class PurpurWorldConfig {
+@@ -1874,6 +1941,7 @@ public class PurpurWorldConfig {
          pandaMaxHealth = getDouble("mobs.panda.attributes.max_health", pandaMaxHealth);
          pandaBreedingTicks = getInt("mobs.panda.breeding-delay-ticks", pandaBreedingTicks);
          pandaTakeDamageFromWater = getBoolean("mobs.panda.takes-damage-from-water", pandaTakeDamageFromWater);
@@ -1699,7 +1699,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean parrotRidable = false;
-@@ -1881,6 +1949,7 @@ public class PurpurWorldConfig {
+@@ -1883,6 +1951,7 @@ public class PurpurWorldConfig {
      public double parrotMaxHealth = 6.0D;
      public boolean parrotTakeDamageFromWater = false;
      public boolean parrotBreedable = false;
@@ -1707,7 +1707,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void parrotSettings() {
          parrotRidable = getBoolean("mobs.parrot.ridable", parrotRidable);
          parrotRidableInWater = getBoolean("mobs.parrot.ridable-in-water", parrotRidableInWater);
-@@ -1894,6 +1963,7 @@ public class PurpurWorldConfig {
+@@ -1896,6 +1965,7 @@ public class PurpurWorldConfig {
          parrotMaxHealth = getDouble("mobs.parrot.attributes.max_health", parrotMaxHealth);
          parrotTakeDamageFromWater = getBoolean("mobs.parrot.takes-damage-from-water", parrotTakeDamageFromWater);
          parrotBreedable = getBoolean("mobs.parrot.can-breed", parrotBreedable);
@@ -1715,7 +1715,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean phantomRidable = false;
-@@ -1921,6 +1991,7 @@ public class PurpurWorldConfig {
+@@ -1923,6 +1993,7 @@ public class PurpurWorldConfig {
      public boolean phantomBurnInDaylight = true;
      public boolean phantomFlamesOnSwoop = false;
      public boolean phantomTakeDamageFromWater = false;
@@ -1723,7 +1723,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void phantomSettings() {
          phantomRidable = getBoolean("mobs.phantom.ridable", phantomRidable);
          phantomRidableInWater = getBoolean("mobs.phantom.ridable-in-water", phantomRidableInWater);
-@@ -1956,6 +2027,7 @@ public class PurpurWorldConfig {
+@@ -1958,6 +2029,7 @@ public class PurpurWorldConfig {
          phantomIgnorePlayersWithTorch = getBoolean("mobs.phantom.ignore-players-with-torch", phantomIgnorePlayersWithTorch);
          phantomFlamesOnSwoop = getBoolean("mobs.phantom.flames-on-swoop", phantomFlamesOnSwoop);
          phantomTakeDamageFromWater = getBoolean("mobs.phantom.takes-damage-from-water", phantomTakeDamageFromWater);
@@ -1731,7 +1731,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean pigRidable = false;
-@@ -1965,6 +2037,7 @@ public class PurpurWorldConfig {
+@@ -1967,6 +2039,7 @@ public class PurpurWorldConfig {
      public boolean pigGiveSaddleBack = false;
      public int pigBreedingTicks = 6000;
      public boolean pigTakeDamageFromWater = false;
@@ -1739,7 +1739,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void pigSettings() {
          pigRidable = getBoolean("mobs.pig.ridable", pigRidable);
          pigRidableInWater = getBoolean("mobs.pig.ridable-in-water", pigRidableInWater);
-@@ -1978,6 +2051,7 @@ public class PurpurWorldConfig {
+@@ -1980,6 +2053,7 @@ public class PurpurWorldConfig {
          pigGiveSaddleBack = getBoolean("mobs.pig.give-saddle-back", pigGiveSaddleBack);
          pigBreedingTicks = getInt("mobs.pig.breeding-delay-ticks", pigBreedingTicks);
          pigTakeDamageFromWater = getBoolean("mobs.pig.takes-damage-from-water", pigTakeDamageFromWater);
@@ -1747,7 +1747,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean piglinRidable = false;
-@@ -1987,6 +2061,7 @@ public class PurpurWorldConfig {
+@@ -1989,6 +2063,7 @@ public class PurpurWorldConfig {
      public boolean piglinBypassMobGriefing = false;
      public boolean piglinTakeDamageFromWater = false;
      public int piglinPortalSpawnModifier = 2000;
@@ -1755,7 +1755,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -2000,6 +2075,7 @@ public class PurpurWorldConfig {
+@@ -2002,6 +2077,7 @@ public class PurpurWorldConfig {
          piglinBypassMobGriefing = getBoolean("mobs.piglin.bypass-mob-griefing", piglinBypassMobGriefing);
          piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);
          piglinPortalSpawnModifier = getInt("mobs.piglin.portal-spawn-modifier", piglinPortalSpawnModifier);
@@ -1763,7 +1763,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean piglinBruteRidable = false;
-@@ -2007,6 +2083,7 @@ public class PurpurWorldConfig {
+@@ -2009,6 +2085,7 @@ public class PurpurWorldConfig {
      public boolean piglinBruteControllable = true;
      public double piglinBruteMaxHealth = 50.0D;
      public boolean piglinBruteTakeDamageFromWater = false;
@@ -1771,7 +1771,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void piglinBruteSettings() {
          piglinBruteRidable = getBoolean("mobs.piglin_brute.ridable", piglinBruteRidable);
          piglinBruteRidableInWater = getBoolean("mobs.piglin_brute.ridable-in-water", piglinBruteRidableInWater);
-@@ -2018,6 +2095,7 @@ public class PurpurWorldConfig {
+@@ -2020,6 +2097,7 @@ public class PurpurWorldConfig {
          }
          piglinBruteMaxHealth = getDouble("mobs.piglin_brute.attributes.max_health", piglinBruteMaxHealth);
          piglinBruteTakeDamageFromWater = getBoolean("mobs.piglin_brute.takes-damage-from-water", piglinBruteTakeDamageFromWater);
@@ -1779,7 +1779,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean pillagerRidable = false;
-@@ -2026,6 +2104,7 @@ public class PurpurWorldConfig {
+@@ -2028,6 +2106,7 @@ public class PurpurWorldConfig {
      public double pillagerMaxHealth = 24.0D;
      public boolean pillagerBypassMobGriefing = false;
      public boolean pillagerTakeDamageFromWater = false;
@@ -1787,7 +1787,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void pillagerSettings() {
          pillagerRidable = getBoolean("mobs.pillager.ridable", pillagerRidable);
          pillagerRidableInWater = getBoolean("mobs.pillager.ridable-in-water", pillagerRidableInWater);
-@@ -2038,6 +2117,7 @@ public class PurpurWorldConfig {
+@@ -2040,6 +2119,7 @@ public class PurpurWorldConfig {
          pillagerMaxHealth = getDouble("mobs.pillager.attributes.max_health", pillagerMaxHealth);
          pillagerBypassMobGriefing = getBoolean("mobs.pillager.bypass-mob-griefing", pillagerBypassMobGriefing);
          pillagerTakeDamageFromWater = getBoolean("mobs.pillager.takes-damage-from-water", pillagerTakeDamageFromWater);
@@ -1795,7 +1795,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean polarBearRidable = false;
-@@ -2048,6 +2128,7 @@ public class PurpurWorldConfig {
+@@ -2050,6 +2130,7 @@ public class PurpurWorldConfig {
      public Item polarBearBreedableItem = null;
      public int polarBearBreedingTicks = 6000;
      public boolean polarBearTakeDamageFromWater = false;
@@ -1803,7 +1803,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void polarBearSettings() {
          polarBearRidable = getBoolean("mobs.polar_bear.ridable", polarBearRidable);
          polarBearRidableInWater = getBoolean("mobs.polar_bear.ridable-in-water", polarBearRidableInWater);
-@@ -2063,12 +2144,14 @@ public class PurpurWorldConfig {
+@@ -2065,12 +2146,14 @@ public class PurpurWorldConfig {
          if (item != Items.AIR) polarBearBreedableItem = item;
          polarBearBreedingTicks = getInt("mobs.polar_bear.breeding-delay-ticks", polarBearBreedingTicks);
          polarBearTakeDamageFromWater = getBoolean("mobs.polar_bear.takes-damage-from-water", polarBearTakeDamageFromWater);
@@ -1818,7 +1818,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void pufferfishSettings() {
          pufferfishRidable = getBoolean("mobs.pufferfish.ridable", pufferfishRidable);
          pufferfishControllable = getBoolean("mobs.pufferfish.controllable", pufferfishControllable);
-@@ -2079,6 +2162,7 @@ public class PurpurWorldConfig {
+@@ -2081,6 +2164,7 @@ public class PurpurWorldConfig {
          }
          pufferfishMaxHealth = getDouble("mobs.pufferfish.attributes.max_health", pufferfishMaxHealth);
          pufferfishTakeDamageFromWater = getBoolean("mobs.pufferfish.takes-damage-from-water", pufferfishTakeDamageFromWater);
@@ -1826,7 +1826,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean rabbitRidable = false;
-@@ -2090,6 +2174,7 @@ public class PurpurWorldConfig {
+@@ -2092,6 +2176,7 @@ public class PurpurWorldConfig {
      public int rabbitBreedingTicks = 6000;
      public boolean rabbitBypassMobGriefing = false;
      public boolean rabbitTakeDamageFromWater = false;
@@ -1834,7 +1834,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void rabbitSettings() {
          rabbitRidable = getBoolean("mobs.rabbit.ridable", rabbitRidable);
          rabbitRidableInWater = getBoolean("mobs.rabbit.ridable-in-water", rabbitRidableInWater);
-@@ -2105,6 +2190,7 @@ public class PurpurWorldConfig {
+@@ -2107,6 +2192,7 @@ public class PurpurWorldConfig {
          rabbitBreedingTicks = getInt("mobs.rabbit.breeding-delay-ticks", rabbitBreedingTicks);
          rabbitBypassMobGriefing = getBoolean("mobs.rabbit.bypass-mob-griefing", rabbitBypassMobGriefing);
          rabbitTakeDamageFromWater = getBoolean("mobs.rabbit.takes-damage-from-water", rabbitTakeDamageFromWater);
@@ -1842,7 +1842,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean ravagerRidable = false;
-@@ -2114,6 +2200,7 @@ public class PurpurWorldConfig {
+@@ -2116,6 +2202,7 @@ public class PurpurWorldConfig {
      public boolean ravagerBypassMobGriefing = false;
      public boolean ravagerTakeDamageFromWater = false;
      public List<Block> ravagerGriefableBlocks = new ArrayList<>();
@@ -1850,7 +1850,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void ravagerSettings() {
          ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
          ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
-@@ -2143,12 +2230,14 @@ public class PurpurWorldConfig {
+@@ -2145,12 +2232,14 @@ public class PurpurWorldConfig {
                  ravagerGriefableBlocks.add(block);
              }
          });
@@ -1865,7 +1865,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void salmonSettings() {
          salmonRidable = getBoolean("mobs.salmon.ridable", salmonRidable);
          salmonControllable = getBoolean("mobs.salmon.controllable", salmonControllable);
-@@ -2159,6 +2248,7 @@ public class PurpurWorldConfig {
+@@ -2161,6 +2250,7 @@ public class PurpurWorldConfig {
          }
          salmonMaxHealth = getDouble("mobs.salmon.attributes.max_health", salmonMaxHealth);
          salmonTakeDamageFromWater = getBoolean("mobs.salmon.takes-damage-from-water", salmonTakeDamageFromWater);
@@ -1873,7 +1873,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean sheepRidable = false;
-@@ -2168,6 +2258,7 @@ public class PurpurWorldConfig {
+@@ -2170,6 +2260,7 @@ public class PurpurWorldConfig {
      public int sheepBreedingTicks = 6000;
      public boolean sheepBypassMobGriefing = false;
      public boolean sheepTakeDamageFromWater = false;
@@ -1881,7 +1881,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -2181,6 +2272,7 @@ public class PurpurWorldConfig {
+@@ -2183,6 +2274,7 @@ public class PurpurWorldConfig {
          sheepBreedingTicks = getInt("mobs.sheep.breeding-delay-ticks", sheepBreedingTicks);
          sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
          sheepTakeDamageFromWater = getBoolean("mobs.sheep.takes-damage-from-water", sheepTakeDamageFromWater);
@@ -1889,7 +1889,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean shulkerRidable = false;
-@@ -2194,6 +2286,7 @@ public class PurpurWorldConfig {
+@@ -2196,6 +2288,7 @@ public class PurpurWorldConfig {
      public String shulkerSpawnFromBulletNearbyEquation = "(nearby - 1) / 5.0";
      public boolean shulkerSpawnFromBulletRandomColor = false;
      public boolean shulkerChangeColorWithDye = false;
@@ -1897,7 +1897,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -2211,6 +2304,7 @@ public class PurpurWorldConfig {
+@@ -2213,6 +2306,7 @@ public class PurpurWorldConfig {
          shulkerSpawnFromBulletNearbyEquation = getString("mobs.shulker.spawn-from-bullet.nearby-equation", shulkerSpawnFromBulletNearbyEquation);
          shulkerSpawnFromBulletRandomColor = getBoolean("mobs.shulker.spawn-from-bullet.random-color", shulkerSpawnFromBulletRandomColor);
          shulkerChangeColorWithDye = getBoolean("mobs.shulker.change-color-with-dye", shulkerChangeColorWithDye);
@@ -1905,7 +1905,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean silverfishRidable = false;
-@@ -2219,6 +2313,7 @@ public class PurpurWorldConfig {
+@@ -2221,6 +2315,7 @@ public class PurpurWorldConfig {
      public double silverfishMaxHealth = 8.0D;
      public boolean silverfishBypassMobGriefing = false;
      public boolean silverfishTakeDamageFromWater = false;
@@ -1913,7 +1913,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void silverfishSettings() {
          silverfishRidable = getBoolean("mobs.silverfish.ridable", silverfishRidable);
          silverfishRidableInWater = getBoolean("mobs.silverfish.ridable-in-water", silverfishRidableInWater);
-@@ -2231,6 +2326,7 @@ public class PurpurWorldConfig {
+@@ -2233,6 +2328,7 @@ public class PurpurWorldConfig {
          silverfishMaxHealth = getDouble("mobs.silverfish.attributes.max_health", silverfishMaxHealth);
          silverfishBypassMobGriefing = getBoolean("mobs.silverfish.bypass-mob-griefing", silverfishBypassMobGriefing);
          silverfishTakeDamageFromWater = getBoolean("mobs.silverfish.takes-damage-from-water", silverfishTakeDamageFromWater);
@@ -1921,7 +1921,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean skeletonRidable = false;
-@@ -2238,6 +2334,7 @@ public class PurpurWorldConfig {
+@@ -2240,6 +2336,7 @@ public class PurpurWorldConfig {
      public boolean skeletonControllable = true;
      public double skeletonMaxHealth = 20.0D;
      public boolean skeletonTakeDamageFromWater = false;
@@ -1929,7 +1929,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2249,6 +2346,7 @@ public class PurpurWorldConfig {
+@@ -2251,6 +2348,7 @@ public class PurpurWorldConfig {
          }
          skeletonMaxHealth = getDouble("mobs.skeleton.attributes.max_health", skeletonMaxHealth);
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
@@ -1937,7 +1937,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean skeletonHorseRidableInWater = true;
-@@ -2260,6 +2358,7 @@ public class PurpurWorldConfig {
+@@ -2262,6 +2360,7 @@ public class PurpurWorldConfig {
      public double skeletonHorseMovementSpeedMin = 0.2D;
      public double skeletonHorseMovementSpeedMax = 0.2D;
      public boolean skeletonHorseTakeDamageFromWater = false;
@@ -1945,7 +1945,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void skeletonHorseSettings() {
          skeletonHorseRidableInWater = getBoolean("mobs.skeleton_horse.ridable-in-water", skeletonHorseRidableInWater);
          skeletonHorseCanSwim = getBoolean("mobs.skeleton_horse.can-swim", skeletonHorseCanSwim);
-@@ -2276,6 +2375,7 @@ public class PurpurWorldConfig {
+@@ -2278,6 +2377,7 @@ public class PurpurWorldConfig {
          skeletonHorseMovementSpeedMin = getDouble("mobs.skeleton_horse.attributes.movement_speed.min", skeletonHorseMovementSpeedMin);
          skeletonHorseMovementSpeedMax = getDouble("mobs.skeleton_horse.attributes.movement_speed.max", skeletonHorseMovementSpeedMax);
          skeletonHorseTakeDamageFromWater = getBoolean("mobs.skeleton_horse.takes-damage-from-water", skeletonHorseTakeDamageFromWater);
@@ -1953,7 +1953,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean slimeRidable = false;
-@@ -2286,6 +2386,7 @@ public class PurpurWorldConfig {
+@@ -2288,6 +2388,7 @@ public class PurpurWorldConfig {
      public Map<Integer, Double> slimeMaxHealthCache = new HashMap<>();
      public Map<Integer, Double> slimeAttackDamageCache = new HashMap<>();
      public boolean slimeTakeDamageFromWater = false;
@@ -1961,7 +1961,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void slimeSettings() {
          slimeRidable = getBoolean("mobs.slime.ridable", slimeRidable);
          slimeRidableInWater = getBoolean("mobs.slime.ridable-in-water", slimeRidableInWater);
-@@ -2300,6 +2401,7 @@ public class PurpurWorldConfig {
+@@ -2302,6 +2403,7 @@ public class PurpurWorldConfig {
          slimeMaxHealthCache.clear();
          slimeAttackDamageCache.clear();
          slimeTakeDamageFromWater = getBoolean("mobs.slime.takes-damage-from-water", slimeTakeDamageFromWater);
@@ -1969,7 +1969,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean snowGolemRidable = false;
-@@ -2315,6 +2417,7 @@ public class PurpurWorldConfig {
+@@ -2317,6 +2419,7 @@ public class PurpurWorldConfig {
      public double snowGolemAttackDistance = 1.25D;
      public boolean snowGolemBypassMobGriefing = false;
      public boolean snowGolemTakeDamageFromWater = true;
@@ -1977,7 +1977,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void snowGolemSettings() {
          snowGolemRidable = getBoolean("mobs.snow_golem.ridable", snowGolemRidable);
          snowGolemRidableInWater = getBoolean("mobs.snow_golem.ridable-in-water", snowGolemRidableInWater);
-@@ -2334,6 +2437,7 @@ public class PurpurWorldConfig {
+@@ -2336,6 +2439,7 @@ public class PurpurWorldConfig {
          snowGolemAttackDistance = getDouble("mobs.snow_golem.attack-distance", snowGolemAttackDistance);
          snowGolemBypassMobGriefing = getBoolean("mobs.snow_golem.bypass-mob-griefing", snowGolemBypassMobGriefing);
          snowGolemTakeDamageFromWater = getBoolean("mobs.snow_golem.takes-damage-from-water", snowGolemTakeDamageFromWater);
@@ -1985,7 +1985,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean snifferRidable = false;
-@@ -2354,6 +2458,7 @@ public class PurpurWorldConfig {
+@@ -2356,6 +2460,7 @@ public class PurpurWorldConfig {
      public double squidOffsetWaterCheck = 0.0D;
      public boolean squidsCanFly = false;
      public boolean squidTakeDamageFromWater = false;
@@ -1993,7 +1993,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void squidSettings() {
          squidRidable = getBoolean("mobs.squid.ridable", squidRidable);
          squidControllable = getBoolean("mobs.squid.controllable", squidControllable);
-@@ -2367,6 +2472,7 @@ public class PurpurWorldConfig {
+@@ -2369,6 +2474,7 @@ public class PurpurWorldConfig {
          squidOffsetWaterCheck = getDouble("mobs.squid.water-offset-check", squidOffsetWaterCheck);
          squidsCanFly = getBoolean("mobs.squid.can-fly", squidsCanFly);
          squidTakeDamageFromWater = getBoolean("mobs.squid.takes-damage-from-water", squidTakeDamageFromWater);
@@ -2001,7 +2001,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean spiderRidable = false;
-@@ -2374,6 +2480,7 @@ public class PurpurWorldConfig {
+@@ -2376,6 +2482,7 @@ public class PurpurWorldConfig {
      public boolean spiderControllable = true;
      public double spiderMaxHealth = 16.0D;
      public boolean spiderTakeDamageFromWater = false;
@@ -2009,7 +2009,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void spiderSettings() {
          spiderRidable = getBoolean("mobs.spider.ridable", spiderRidable);
          spiderRidableInWater = getBoolean("mobs.spider.ridable-in-water", spiderRidableInWater);
-@@ -2385,6 +2492,7 @@ public class PurpurWorldConfig {
+@@ -2387,6 +2494,7 @@ public class PurpurWorldConfig {
          }
          spiderMaxHealth = getDouble("mobs.spider.attributes.max_health", spiderMaxHealth);
          spiderTakeDamageFromWater = getBoolean("mobs.spider.takes-damage-from-water", spiderTakeDamageFromWater);
@@ -2017,7 +2017,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean strayRidable = false;
-@@ -2392,6 +2500,7 @@ public class PurpurWorldConfig {
+@@ -2394,6 +2502,7 @@ public class PurpurWorldConfig {
      public boolean strayControllable = true;
      public double strayMaxHealth = 20.0D;
      public boolean strayTakeDamageFromWater = false;
@@ -2025,7 +2025,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void straySettings() {
          strayRidable = getBoolean("mobs.stray.ridable", strayRidable);
          strayRidableInWater = getBoolean("mobs.stray.ridable-in-water", strayRidableInWater);
-@@ -2403,6 +2512,7 @@ public class PurpurWorldConfig {
+@@ -2405,6 +2514,7 @@ public class PurpurWorldConfig {
          }
          strayMaxHealth = getDouble("mobs.stray.attributes.max_health", strayMaxHealth);
          strayTakeDamageFromWater = getBoolean("mobs.stray.takes-damage-from-water", strayTakeDamageFromWater);
@@ -2033,7 +2033,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean striderRidable = false;
-@@ -2412,6 +2522,7 @@ public class PurpurWorldConfig {
+@@ -2414,6 +2524,7 @@ public class PurpurWorldConfig {
      public int striderBreedingTicks = 6000;
      public boolean striderGiveSaddleBack = false;
      public boolean striderTakeDamageFromWater = true;
@@ -2041,7 +2041,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void striderSettings() {
          striderRidable = getBoolean("mobs.strider.ridable", striderRidable);
          striderRidableInWater = getBoolean("mobs.strider.ridable-in-water", striderRidableInWater);
-@@ -2425,6 +2536,7 @@ public class PurpurWorldConfig {
+@@ -2427,6 +2538,7 @@ public class PurpurWorldConfig {
          striderBreedingTicks = getInt("mobs.strider.breeding-delay-ticks", striderBreedingTicks);
          striderGiveSaddleBack = getBoolean("mobs.strider.give-saddle-back", striderGiveSaddleBack);
          striderTakeDamageFromWater = getBoolean("mobs.strider.takes-damage-from-water", striderTakeDamageFromWater);
@@ -2049,7 +2049,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean tadpoleRidable = false;
-@@ -2447,6 +2559,7 @@ public class PurpurWorldConfig {
+@@ -2449,6 +2561,7 @@ public class PurpurWorldConfig {
      public double traderLlamaMovementSpeedMax = 0.175D;
      public int traderLlamaBreedingTicks = 6000;
      public boolean traderLlamaTakeDamageFromWater = false;
@@ -2057,7 +2057,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void traderLlamaSettings() {
          traderLlamaRidable = getBoolean("mobs.trader_llama.ridable", traderLlamaRidable);
          traderLlamaRidableInWater = getBoolean("mobs.trader_llama.ridable-in-water", traderLlamaRidableInWater);
-@@ -2466,12 +2579,14 @@ public class PurpurWorldConfig {
+@@ -2468,12 +2581,14 @@ public class PurpurWorldConfig {
          traderLlamaMovementSpeedMax = getDouble("mobs.trader_llama.attributes.movement_speed.max", traderLlamaMovementSpeedMax);
          traderLlamaBreedingTicks = getInt("mobs.trader_llama.breeding-delay-ticks", traderLlamaBreedingTicks);
          traderLlamaTakeDamageFromWater = getBoolean("mobs.trader_llama.takes-damage-from-water", traderLlamaTakeDamageFromWater);
@@ -2072,7 +2072,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void tropicalFishSettings() {
          tropicalFishRidable = getBoolean("mobs.tropical_fish.ridable", tropicalFishRidable);
          tropicalFishControllable = getBoolean("mobs.tropical_fish.controllable", tropicalFishControllable);
-@@ -2482,6 +2597,7 @@ public class PurpurWorldConfig {
+@@ -2484,6 +2599,7 @@ public class PurpurWorldConfig {
          }
          tropicalFishMaxHealth = getDouble("mobs.tropical_fish.attributes.max_health", tropicalFishMaxHealth);
          tropicalFishTakeDamageFromWater = getBoolean("mobs.tropical_fish.takes-damage-from-water", tropicalFishTakeDamageFromWater);
@@ -2080,7 +2080,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean turtleRidable = false;
-@@ -2490,6 +2606,7 @@ public class PurpurWorldConfig {
+@@ -2492,6 +2608,7 @@ public class PurpurWorldConfig {
      public double turtleMaxHealth = 30.0D;
      public int turtleBreedingTicks = 6000;
      public boolean turtleTakeDamageFromWater = false;
@@ -2088,7 +2088,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void turtleSettings() {
          turtleRidable = getBoolean("mobs.turtle.ridable", turtleRidable);
          turtleRidableInWater = getBoolean("mobs.turtle.ridable-in-water", turtleRidableInWater);
-@@ -2502,6 +2619,7 @@ public class PurpurWorldConfig {
+@@ -2504,6 +2621,7 @@ public class PurpurWorldConfig {
          turtleMaxHealth = getDouble("mobs.turtle.attributes.max_health", turtleMaxHealth);
          turtleBreedingTicks = getInt("mobs.turtle.breeding-delay-ticks", turtleBreedingTicks);
          turtleTakeDamageFromWater = getBoolean("mobs.turtle.takes-damage-from-water", turtleTakeDamageFromWater);
@@ -2096,7 +2096,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean vexRidable = false;
-@@ -2510,6 +2628,7 @@ public class PurpurWorldConfig {
+@@ -2512,6 +2630,7 @@ public class PurpurWorldConfig {
      public double vexMaxY = 320D;
      public double vexMaxHealth = 14.0D;
      public boolean vexTakeDamageFromWater = false;
@@ -2104,7 +2104,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void vexSettings() {
          vexRidable = getBoolean("mobs.vex.ridable", vexRidable);
          vexRidableInWater = getBoolean("mobs.vex.ridable-in-water", vexRidableInWater);
-@@ -2522,6 +2641,7 @@ public class PurpurWorldConfig {
+@@ -2524,6 +2643,7 @@ public class PurpurWorldConfig {
          }
          vexMaxHealth = getDouble("mobs.vex.attributes.max_health", vexMaxHealth);
          vexTakeDamageFromWater = getBoolean("mobs.vex.takes-damage-from-water", vexTakeDamageFromWater);
@@ -2112,7 +2112,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean villagerRidable = false;
-@@ -2537,6 +2657,7 @@ public class PurpurWorldConfig {
+@@ -2539,6 +2659,7 @@ public class PurpurWorldConfig {
      public boolean villagerBypassMobGriefing = false;
      public boolean villagerTakeDamageFromWater = false;
      public boolean villagerAllowTrading = true;
@@ -2120,7 +2120,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2556,6 +2677,7 @@ public class PurpurWorldConfig {
+@@ -2558,6 +2679,7 @@ public class PurpurWorldConfig {
          villagerBypassMobGriefing = getBoolean("mobs.villager.bypass-mob-griefing", villagerBypassMobGriefing);
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
@@ -2128,7 +2128,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean vindicatorRidable = false;
-@@ -2564,6 +2686,7 @@ public class PurpurWorldConfig {
+@@ -2566,6 +2688,7 @@ public class PurpurWorldConfig {
      public double vindicatorMaxHealth = 24.0D;
      public double vindicatorJohnnySpawnChance = 0D;
      public boolean vindicatorTakeDamageFromWater = false;
@@ -2136,7 +2136,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void vindicatorSettings() {
          vindicatorRidable = getBoolean("mobs.vindicator.ridable", vindicatorRidable);
          vindicatorRidableInWater = getBoolean("mobs.vindicator.ridable-in-water", vindicatorRidableInWater);
-@@ -2576,6 +2699,7 @@ public class PurpurWorldConfig {
+@@ -2578,6 +2701,7 @@ public class PurpurWorldConfig {
          vindicatorMaxHealth = getDouble("mobs.vindicator.attributes.max_health", vindicatorMaxHealth);
          vindicatorJohnnySpawnChance = getDouble("mobs.vindicator.johnny.spawn-chance", vindicatorJohnnySpawnChance);
          vindicatorTakeDamageFromWater = getBoolean("mobs.vindicator.takes-damage-from-water", vindicatorTakeDamageFromWater);
@@ -2144,7 +2144,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean wanderingTraderRidable = false;
-@@ -2586,6 +2710,7 @@ public class PurpurWorldConfig {
+@@ -2588,6 +2712,7 @@ public class PurpurWorldConfig {
      public boolean wanderingTraderCanBeLeashed = false;
      public boolean wanderingTraderTakeDamageFromWater = false;
      public boolean wanderingTraderAllowTrading = true;
@@ -2152,7 +2152,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void wanderingTraderSettings() {
          wanderingTraderRidable = getBoolean("mobs.wandering_trader.ridable", wanderingTraderRidable);
          wanderingTraderRidableInWater = getBoolean("mobs.wandering_trader.ridable-in-water", wanderingTraderRidableInWater);
-@@ -2600,6 +2725,7 @@ public class PurpurWorldConfig {
+@@ -2602,6 +2727,7 @@ public class PurpurWorldConfig {
          wanderingTraderCanBeLeashed = getBoolean("mobs.wandering_trader.can-be-leashed", wanderingTraderCanBeLeashed);
          wanderingTraderTakeDamageFromWater = getBoolean("mobs.wandering_trader.takes-damage-from-water", wanderingTraderTakeDamageFromWater);
          wanderingTraderAllowTrading = getBoolean("mobs.wandering_trader.allow-trading", wanderingTraderAllowTrading);
@@ -2160,7 +2160,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean wardenRidable = false;
-@@ -2616,6 +2742,7 @@ public class PurpurWorldConfig {
+@@ -2618,6 +2744,7 @@ public class PurpurWorldConfig {
      public boolean witchControllable = true;
      public double witchMaxHealth = 26.0D;
      public boolean witchTakeDamageFromWater = false;
@@ -2168,7 +2168,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void witchSettings() {
          witchRidable = getBoolean("mobs.witch.ridable", witchRidable);
          witchRidableInWater = getBoolean("mobs.witch.ridable-in-water", witchRidableInWater);
-@@ -2627,6 +2754,7 @@ public class PurpurWorldConfig {
+@@ -2629,6 +2756,7 @@ public class PurpurWorldConfig {
          }
          witchMaxHealth = getDouble("mobs.witch.attributes.max_health", witchMaxHealth);
          witchTakeDamageFromWater = getBoolean("mobs.witch.takes-damage-from-water", witchTakeDamageFromWater);
@@ -2176,7 +2176,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean witherRidable = false;
-@@ -2641,6 +2769,7 @@ public class PurpurWorldConfig {
+@@ -2643,6 +2771,7 @@ public class PurpurWorldConfig {
      public boolean witherCanRideVehicles = false;
      public float witherExplosionRadius = 1.0F;
      public boolean witherPlaySpawnSound = true;
@@ -2184,7 +2184,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2663,6 +2792,7 @@ public class PurpurWorldConfig {
+@@ -2665,6 +2794,7 @@ public class PurpurWorldConfig {
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);
          witherExplosionRadius = (float) getDouble("mobs.wither.explosion-radius", witherExplosionRadius);
          witherPlaySpawnSound = getBoolean("mobs.wither.play-spawn-sound", witherPlaySpawnSound);
@@ -2192,7 +2192,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean witherSkeletonRidable = false;
-@@ -2670,6 +2800,7 @@ public class PurpurWorldConfig {
+@@ -2672,6 +2802,7 @@ public class PurpurWorldConfig {
      public boolean witherSkeletonControllable = true;
      public double witherSkeletonMaxHealth = 20.0D;
      public boolean witherSkeletonTakeDamageFromWater = false;
@@ -2200,7 +2200,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void witherSkeletonSettings() {
          witherSkeletonRidable = getBoolean("mobs.wither_skeleton.ridable", witherSkeletonRidable);
          witherSkeletonRidableInWater = getBoolean("mobs.wither_skeleton.ridable-in-water", witherSkeletonRidableInWater);
-@@ -2681,6 +2812,7 @@ public class PurpurWorldConfig {
+@@ -2683,6 +2814,7 @@ public class PurpurWorldConfig {
          }
          witherSkeletonMaxHealth = getDouble("mobs.wither_skeleton.attributes.max_health", witherSkeletonMaxHealth);
          witherSkeletonTakeDamageFromWater = getBoolean("mobs.wither_skeleton.takes-damage-from-water", witherSkeletonTakeDamageFromWater);
@@ -2208,7 +2208,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean wolfRidable = false;
-@@ -2692,6 +2824,7 @@ public class PurpurWorldConfig {
+@@ -2694,6 +2826,7 @@ public class PurpurWorldConfig {
      public double wolfNaturalRabid = 0.0D;
      public int wolfBreedingTicks = 6000;
      public boolean wolfTakeDamageFromWater = false;
@@ -2216,7 +2216,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void wolfSettings() {
          wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
          wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
-@@ -2711,6 +2844,7 @@ public class PurpurWorldConfig {
+@@ -2713,6 +2846,7 @@ public class PurpurWorldConfig {
          wolfNaturalRabid = getDouble("mobs.wolf.spawn-rabid-chance", wolfNaturalRabid);
          wolfBreedingTicks = getInt("mobs.wolf.breeding-delay-ticks", wolfBreedingTicks);
          wolfTakeDamageFromWater = getBoolean("mobs.wolf.takes-damage-from-water", wolfTakeDamageFromWater);
@@ -2224,7 +2224,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean zoglinRidable = false;
-@@ -2718,6 +2852,7 @@ public class PurpurWorldConfig {
+@@ -2720,6 +2854,7 @@ public class PurpurWorldConfig {
      public boolean zoglinControllable = true;
      public double zoglinMaxHealth = 40.0D;
      public boolean zoglinTakeDamageFromWater = false;
@@ -2232,7 +2232,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void zoglinSettings() {
          zoglinRidable = getBoolean("mobs.zoglin.ridable", zoglinRidable);
          zoglinRidableInWater = getBoolean("mobs.zoglin.ridable-in-water", zoglinRidableInWater);
-@@ -2729,6 +2864,7 @@ public class PurpurWorldConfig {
+@@ -2731,6 +2866,7 @@ public class PurpurWorldConfig {
          }
          zoglinMaxHealth = getDouble("mobs.zoglin.attributes.max_health", zoglinMaxHealth);
          zoglinTakeDamageFromWater = getBoolean("mobs.zoglin.takes-damage-from-water", zoglinTakeDamageFromWater);
@@ -2240,7 +2240,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean zombieRidable = false;
-@@ -2742,6 +2878,7 @@ public class PurpurWorldConfig {
+@@ -2744,6 +2880,7 @@ public class PurpurWorldConfig {
      public boolean zombieAggressiveTowardsVillagerWhenLagging = true;
      public boolean zombieBypassMobGriefing = false;
      public boolean zombieTakeDamageFromWater = false;
@@ -2248,7 +2248,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -2759,6 +2896,7 @@ public class PurpurWorldConfig {
+@@ -2761,6 +2898,7 @@ public class PurpurWorldConfig {
          zombieAggressiveTowardsVillagerWhenLagging = getBoolean("mobs.zombie.aggressive-towards-villager-when-lagging", zombieAggressiveTowardsVillagerWhenLagging);
          zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
          zombieTakeDamageFromWater = getBoolean("mobs.zombie.takes-damage-from-water", zombieTakeDamageFromWater);
@@ -2256,7 +2256,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean zombieHorseRidableInWater = false;
-@@ -2771,6 +2909,7 @@ public class PurpurWorldConfig {
+@@ -2773,6 +2911,7 @@ public class PurpurWorldConfig {
      public double zombieHorseMovementSpeedMax = 0.2D;
      public double zombieHorseSpawnChance = 0.0D;
      public boolean zombieHorseTakeDamageFromWater = false;
@@ -2264,7 +2264,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void zombieHorseSettings() {
          zombieHorseRidableInWater = getBoolean("mobs.zombie_horse.ridable-in-water", zombieHorseRidableInWater);
          zombieHorseCanSwim = getBoolean("mobs.zombie_horse.can-swim", zombieHorseCanSwim);
-@@ -2788,6 +2927,7 @@ public class PurpurWorldConfig {
+@@ -2790,6 +2929,7 @@ public class PurpurWorldConfig {
          zombieHorseMovementSpeedMax = getDouble("mobs.zombie_horse.attributes.movement_speed.max", zombieHorseMovementSpeedMax);
          zombieHorseSpawnChance = getDouble("mobs.zombie_horse.spawn-chance", zombieHorseSpawnChance);
          zombieHorseTakeDamageFromWater = getBoolean("mobs.zombie_horse.takes-damage-from-water", zombieHorseTakeDamageFromWater);
@@ -2272,7 +2272,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean zombieVillagerRidable = false;
-@@ -2802,6 +2942,7 @@ public class PurpurWorldConfig {
+@@ -2804,6 +2944,7 @@ public class PurpurWorldConfig {
      public int zombieVillagerCuringTimeMin = 3600;
      public int zombieVillagerCuringTimeMax = 6000;
      public boolean zombieVillagerCureEnabled = true;
@@ -2280,7 +2280,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2820,6 +2961,7 @@ public class PurpurWorldConfig {
+@@ -2822,6 +2963,7 @@ public class PurpurWorldConfig {
          zombieVillagerCuringTimeMin = getInt("mobs.zombie_villager.curing_time.min", zombieVillagerCuringTimeMin);
          zombieVillagerCuringTimeMax = getInt("mobs.zombie_villager.curing_time.max", zombieVillagerCuringTimeMax);
          zombieVillagerCureEnabled = getBoolean("mobs.zombie_villager.cure.enabled", zombieVillagerCureEnabled);
@@ -2288,7 +2288,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      }
  
      public boolean zombifiedPiglinRidable = false;
-@@ -2832,6 +2974,7 @@ public class PurpurWorldConfig {
+@@ -2834,6 +2976,7 @@ public class PurpurWorldConfig {
      public boolean zombifiedPiglinJockeyTryExistingChickens = true;
      public boolean zombifiedPiglinCountAsPlayerKillWhenAngry = true;
      public boolean zombifiedPiglinTakeDamageFromWater = false;
@@ -2296,7 +2296,7 @@ index b35a52ac5acc8b61a2af17babae53cbcacc957fa..63a073ed252419b52217fe4b404e6efb
      private void zombifiedPiglinSettings() {
          zombifiedPiglinRidable = getBoolean("mobs.zombified_piglin.ridable", zombifiedPiglinRidable);
          zombifiedPiglinRidableInWater = getBoolean("mobs.zombified_piglin.ridable-in-water", zombifiedPiglinRidableInWater);
-@@ -2848,6 +2991,7 @@ public class PurpurWorldConfig {
+@@ -2850,6 +2993,7 @@ public class PurpurWorldConfig {
          zombifiedPiglinJockeyTryExistingChickens = getBoolean("mobs.zombified_piglin.jockey.try-existing-chickens", zombifiedPiglinJockeyTryExistingChickens);
          zombifiedPiglinCountAsPlayerKillWhenAngry = getBoolean("mobs.zombified_piglin.count-as-player-kill-when-angry", zombifiedPiglinCountAsPlayerKillWhenAngry);
          zombifiedPiglinTakeDamageFromWater = getBoolean("mobs.zombified_piglin.takes-damage-from-water", zombifiedPiglinTakeDamageFromWater);

--- a/patches/server/0230-Mobs-always-drop-experience.patch
+++ b/patches/server/0230-Mobs-always-drop-experience.patch
@@ -1157,10 +1157,10 @@ index e06f3ee85dde587f1146d4a3d70e8a2e5b9a128b..2e9dd920e5c3943cba4c53ec2a2b48ee
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614dbd4f33547 100644
+index 6496bd5297acf36a38994a39c97c4615179993e4..599328c1adb0f285d32f41f4f5f2949003416179 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1015,12 +1015,14 @@ public class PurpurWorldConfig {
+@@ -1017,12 +1017,14 @@ public class PurpurWorldConfig {
      public double axolotlMaxHealth = 14.0D;
      public int axolotlBreedingTicks = 6000;
      public boolean axolotlTakeDamageFromWater = false;
@@ -1175,7 +1175,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean batRidable = false;
-@@ -1036,6 +1038,7 @@ public class PurpurWorldConfig {
+@@ -1038,6 +1040,7 @@ public class PurpurWorldConfig {
      public double batArmorToughness = 0.0D;
      public double batAttackKnockback = 0.0D;
      public boolean batTakeDamageFromWater = false;
@@ -1183,7 +1183,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void batSettings() {
          batRidable = getBoolean("mobs.bat.ridable", batRidable);
          batRidableInWater = getBoolean("mobs.bat.ridable-in-water", batRidableInWater);
-@@ -1048,6 +1051,7 @@ public class PurpurWorldConfig {
+@@ -1050,6 +1053,7 @@ public class PurpurWorldConfig {
          }
          batMaxHealth = getDouble("mobs.bat.attributes.max_health", batMaxHealth);
          batTakeDamageFromWater = getBoolean("mobs.bat.takes-damage-from-water", batTakeDamageFromWater);
@@ -1191,7 +1191,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean beeRidable = false;
-@@ -1059,6 +1063,7 @@ public class PurpurWorldConfig {
+@@ -1061,6 +1065,7 @@ public class PurpurWorldConfig {
      public boolean beeTakeDamageFromWater = false;
      public boolean beeCanWorkAtNight = false;
      public boolean beeCanWorkInRain = false;
@@ -1199,7 +1199,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -1074,6 +1079,7 @@ public class PurpurWorldConfig {
+@@ -1076,6 +1081,7 @@ public class PurpurWorldConfig {
          beeTakeDamageFromWater = getBoolean("mobs.bee.takes-damage-from-water", beeTakeDamageFromWater);
          beeCanWorkAtNight = getBoolean("mobs.bee.can-work-at-night", beeCanWorkAtNight);
          beeCanWorkInRain = getBoolean("mobs.bee.can-work-in-rain", beeCanWorkInRain);
@@ -1207,7 +1207,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean blazeRidable = false;
-@@ -1082,6 +1088,7 @@ public class PurpurWorldConfig {
+@@ -1084,6 +1090,7 @@ public class PurpurWorldConfig {
      public double blazeMaxY = 320D;
      public double blazeMaxHealth = 20.0D;
      public boolean blazeTakeDamageFromWater = true;
@@ -1215,7 +1215,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void blazeSettings() {
          blazeRidable = getBoolean("mobs.blaze.ridable", blazeRidable);
          blazeRidableInWater = getBoolean("mobs.blaze.ridable-in-water", blazeRidableInWater);
-@@ -1094,6 +1101,7 @@ public class PurpurWorldConfig {
+@@ -1096,6 +1103,7 @@ public class PurpurWorldConfig {
          }
          blazeMaxHealth = getDouble("mobs.blaze.attributes.max_health", blazeMaxHealth);
          blazeTakeDamageFromWater = getBoolean("mobs.blaze.takes-damage-from-water", blazeTakeDamageFromWater);
@@ -1223,7 +1223,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public int camelBreedingTicks = 6000;
-@@ -1123,6 +1131,7 @@ public class PurpurWorldConfig {
+@@ -1125,6 +1133,7 @@ public class PurpurWorldConfig {
      public int catBreedingTicks = 6000;
      public DyeColor catDefaultCollarColor = DyeColor.RED;
      public boolean catTakeDamageFromWater = false;
@@ -1231,7 +1231,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void catSettings() {
          catRidable = getBoolean("mobs.cat.ridable", catRidable);
          catRidableInWater = getBoolean("mobs.cat.ridable-in-water", catRidableInWater);
-@@ -1143,6 +1152,7 @@ public class PurpurWorldConfig {
+@@ -1145,6 +1154,7 @@ public class PurpurWorldConfig {
              catDefaultCollarColor = DyeColor.RED;
          }
          catTakeDamageFromWater = getBoolean("mobs.cat.takes-damage-from-water", catTakeDamageFromWater);
@@ -1239,7 +1239,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean caveSpiderRidable = false;
-@@ -1150,6 +1160,7 @@ public class PurpurWorldConfig {
+@@ -1152,6 +1162,7 @@ public class PurpurWorldConfig {
      public boolean caveSpiderControllable = true;
      public double caveSpiderMaxHealth = 12.0D;
      public boolean caveSpiderTakeDamageFromWater = false;
@@ -1247,7 +1247,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void caveSpiderSettings() {
          caveSpiderRidable = getBoolean("mobs.cave_spider.ridable", caveSpiderRidable);
          caveSpiderRidableInWater = getBoolean("mobs.cave_spider.ridable-in-water", caveSpiderRidableInWater);
-@@ -1161,6 +1172,7 @@ public class PurpurWorldConfig {
+@@ -1163,6 +1174,7 @@ public class PurpurWorldConfig {
          }
          caveSpiderMaxHealth = getDouble("mobs.cave_spider.attributes.max_health", caveSpiderMaxHealth);
          caveSpiderTakeDamageFromWater = getBoolean("mobs.cave_spider.takes-damage-from-water", caveSpiderTakeDamageFromWater);
@@ -1255,7 +1255,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean chickenRidable = false;
-@@ -1170,6 +1182,7 @@ public class PurpurWorldConfig {
+@@ -1172,6 +1184,7 @@ public class PurpurWorldConfig {
      public boolean chickenRetaliate = false;
      public int chickenBreedingTicks = 6000;
      public boolean chickenTakeDamageFromWater = false;
@@ -1263,7 +1263,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void chickenSettings() {
          chickenRidable = getBoolean("mobs.chicken.ridable", chickenRidable);
          chickenRidableInWater = getBoolean("mobs.chicken.ridable-in-water", chickenRidableInWater);
-@@ -1183,12 +1196,14 @@ public class PurpurWorldConfig {
+@@ -1185,12 +1198,14 @@ public class PurpurWorldConfig {
          chickenRetaliate = getBoolean("mobs.chicken.retaliate", chickenRetaliate);
          chickenBreedingTicks = getInt("mobs.chicken.breeding-delay-ticks", chickenBreedingTicks);
          chickenTakeDamageFromWater = getBoolean("mobs.chicken.takes-damage-from-water", chickenTakeDamageFromWater);
@@ -1278,7 +1278,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void codSettings() {
          codRidable = getBoolean("mobs.cod.ridable", codRidable);
          codControllable = getBoolean("mobs.cod.controllable", codControllable);
-@@ -1199,6 +1214,7 @@ public class PurpurWorldConfig {
+@@ -1201,6 +1216,7 @@ public class PurpurWorldConfig {
          }
          codMaxHealth = getDouble("mobs.cod.attributes.max_health", codMaxHealth);
          codTakeDamageFromWater = getBoolean("mobs.cod.takes-damage-from-water", codTakeDamageFromWater);
@@ -1286,7 +1286,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean cowRidable = false;
-@@ -1210,6 +1226,7 @@ public class PurpurWorldConfig {
+@@ -1212,6 +1228,7 @@ public class PurpurWorldConfig {
      public boolean cowTakeDamageFromWater = false;
      public double cowNaturallyAggressiveToPlayersChance = 0.0D;
      public double cowNaturallyAggressiveToPlayersDamage = 2.0D;
@@ -1294,7 +1294,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void cowSettings() {
          if (PurpurConfig.version < 22) {
              double oldValue = getDouble("mobs.cow.naturally-aggressive-to-players-chance", cowNaturallyAggressiveToPlayersChance);
-@@ -1230,6 +1247,7 @@ public class PurpurWorldConfig {
+@@ -1232,6 +1249,7 @@ public class PurpurWorldConfig {
          cowTakeDamageFromWater = getBoolean("mobs.cow.takes-damage-from-water", cowTakeDamageFromWater);
          cowNaturallyAggressiveToPlayersChance = getDouble("mobs.cow.naturally-aggressive-to-players.chance", cowNaturallyAggressiveToPlayersChance);
          cowNaturallyAggressiveToPlayersDamage = getDouble("mobs.cow.naturally-aggressive-to-players.damage", cowNaturallyAggressiveToPlayersDamage);
@@ -1302,7 +1302,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean creeperRidable = false;
-@@ -1242,6 +1260,7 @@ public class PurpurWorldConfig {
+@@ -1244,6 +1262,7 @@ public class PurpurWorldConfig {
      public boolean creeperTakeDamageFromWater = false;
      public boolean creeperExplodeWhenKilled = false;
      public boolean creeperHealthRadius = false;
@@ -1310,7 +1310,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1258,6 +1277,7 @@ public class PurpurWorldConfig {
+@@ -1260,6 +1279,7 @@ public class PurpurWorldConfig {
          creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
@@ -1318,7 +1318,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean dolphinRidable = false;
-@@ -1269,6 +1289,7 @@ public class PurpurWorldConfig {
+@@ -1271,6 +1291,7 @@ public class PurpurWorldConfig {
      public boolean dolphinDisableTreasureSearching = false;
      public boolean dolphinTakeDamageFromWater = false;
      public double dolphinNaturallyAggressiveToPlayersChance = 0.0D;
@@ -1326,7 +1326,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void dolphinSettings() {
          dolphinRidable = getBoolean("mobs.dolphin.ridable", dolphinRidable);
          dolphinControllable = getBoolean("mobs.dolphin.controllable", dolphinControllable);
-@@ -1284,6 +1305,7 @@ public class PurpurWorldConfig {
+@@ -1286,6 +1307,7 @@ public class PurpurWorldConfig {
          dolphinDisableTreasureSearching = getBoolean("mobs.dolphin.disable-treasure-searching", dolphinDisableTreasureSearching);
          dolphinTakeDamageFromWater = getBoolean("mobs.dolphin.takes-damage-from-water", dolphinTakeDamageFromWater);
          dolphinNaturallyAggressiveToPlayersChance = getDouble("mobs.dolphin.naturally-aggressive-to-players-chance", dolphinNaturallyAggressiveToPlayersChance);
@@ -1334,7 +1334,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean donkeyRidableInWater = false;
-@@ -1295,6 +1317,7 @@ public class PurpurWorldConfig {
+@@ -1297,6 +1319,7 @@ public class PurpurWorldConfig {
      public double donkeyMovementSpeedMax = 0.175D;
      public int donkeyBreedingTicks = 6000;
      public boolean donkeyTakeDamageFromWater = false;
@@ -1342,7 +1342,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void donkeySettings() {
          donkeyRidableInWater = getBoolean("mobs.donkey.ridable-in-water", donkeyRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1312,6 +1335,7 @@ public class PurpurWorldConfig {
+@@ -1314,6 +1337,7 @@ public class PurpurWorldConfig {
          donkeyMovementSpeedMax = getDouble("mobs.donkey.attributes.movement_speed.max", donkeyMovementSpeedMax);
          donkeyBreedingTicks = getInt("mobs.donkey.breeding-delay-ticks", donkeyBreedingTicks);
          donkeyTakeDamageFromWater = getBoolean("mobs.donkey.takes-damage-from-water", donkeyTakeDamageFromWater);
@@ -1350,7 +1350,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean drownedRidable = false;
-@@ -1324,6 +1348,7 @@ public class PurpurWorldConfig {
+@@ -1326,6 +1350,7 @@ public class PurpurWorldConfig {
      public boolean drownedJockeyTryExistingChickens = true;
      public boolean drownedTakeDamageFromWater = false;
      public boolean drownedBreakDoors = false;
@@ -1358,7 +1358,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void drownedSettings() {
          drownedRidable = getBoolean("mobs.drowned.ridable", drownedRidable);
          drownedRidableInWater = getBoolean("mobs.drowned.ridable-in-water", drownedRidableInWater);
-@@ -1340,12 +1365,14 @@ public class PurpurWorldConfig {
+@@ -1342,12 +1367,14 @@ public class PurpurWorldConfig {
          drownedJockeyTryExistingChickens = getBoolean("mobs.drowned.jockey.try-existing-chickens", drownedJockeyTryExistingChickens);
          drownedTakeDamageFromWater = getBoolean("mobs.drowned.takes-damage-from-water", drownedTakeDamageFromWater);
          drownedBreakDoors = getBoolean("mobs.drowned.can-break-doors", drownedBreakDoors);
@@ -1373,7 +1373,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void elderGuardianSettings() {
          elderGuardianRidable = getBoolean("mobs.elder_guardian.ridable", elderGuardianRidable);
          elderGuardianControllable = getBoolean("mobs.elder_guardian.controllable", elderGuardianControllable);
-@@ -1356,6 +1383,7 @@ public class PurpurWorldConfig {
+@@ -1358,6 +1385,7 @@ public class PurpurWorldConfig {
          }
          elderGuardianMaxHealth = getDouble("mobs.elder_guardian.attributes.max_health", elderGuardianMaxHealth);
          elderGuardianTakeDamageFromWater = getBoolean("mobs.elder_guardian.takes-damage-from-water", elderGuardianTakeDamageFromWater);
@@ -1381,7 +1381,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean enderDragonRidable = false;
-@@ -1401,6 +1429,7 @@ public class PurpurWorldConfig {
+@@ -1403,6 +1431,7 @@ public class PurpurWorldConfig {
      public boolean endermanIgnorePlayerDragonHead = false;
      public boolean endermanDisableStareAggro = false;
      public boolean endermanIgnoreProjectiles = false;
@@ -1389,7 +1389,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void endermanSettings() {
          endermanRidable = getBoolean("mobs.enderman.ridable", endermanRidable);
          endermanRidableInWater = getBoolean("mobs.enderman.ridable-in-water", endermanRidableInWater);
-@@ -1424,6 +1453,7 @@ public class PurpurWorldConfig {
+@@ -1426,6 +1455,7 @@ public class PurpurWorldConfig {
          endermanIgnorePlayerDragonHead = getBoolean("mobs.enderman.ignore-players-wearing-dragon-head", endermanIgnorePlayerDragonHead);
          endermanDisableStareAggro = getBoolean("mobs.enderman.disable-player-stare-aggression", endermanDisableStareAggro);
          endermanIgnoreProjectiles = getBoolean("mobs.enderman.ignore-projectiles", endermanIgnoreProjectiles);
@@ -1397,7 +1397,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean endermiteRidable = false;
-@@ -1431,6 +1461,7 @@ public class PurpurWorldConfig {
+@@ -1433,6 +1463,7 @@ public class PurpurWorldConfig {
      public boolean endermiteControllable = true;
      public double endermiteMaxHealth = 8.0D;
      public boolean endermiteTakeDamageFromWater = false;
@@ -1405,7 +1405,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void endermiteSettings() {
          endermiteRidable = getBoolean("mobs.endermite.ridable", endermiteRidable);
          endermiteRidableInWater = getBoolean("mobs.endermite.ridable-in-water", endermiteRidableInWater);
-@@ -1442,6 +1473,7 @@ public class PurpurWorldConfig {
+@@ -1444,6 +1475,7 @@ public class PurpurWorldConfig {
          }
          endermiteMaxHealth = getDouble("mobs.endermite.attributes.max_health", endermiteMaxHealth);
          endermiteTakeDamageFromWater = getBoolean("mobs.endermite.takes-damage-from-water", endermiteTakeDamageFromWater);
@@ -1413,7 +1413,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean evokerRidable = false;
-@@ -1450,6 +1482,7 @@ public class PurpurWorldConfig {
+@@ -1452,6 +1484,7 @@ public class PurpurWorldConfig {
      public double evokerMaxHealth = 24.0D;
      public boolean evokerBypassMobGriefing = false;
      public boolean evokerTakeDamageFromWater = false;
@@ -1421,7 +1421,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void evokerSettings() {
          evokerRidable = getBoolean("mobs.evoker.ridable", evokerRidable);
          evokerRidableInWater = getBoolean("mobs.evoker.ridable-in-water", evokerRidableInWater);
-@@ -1462,6 +1495,7 @@ public class PurpurWorldConfig {
+@@ -1464,6 +1497,7 @@ public class PurpurWorldConfig {
          evokerMaxHealth = getDouble("mobs.evoker.attributes.max_health", evokerMaxHealth);
          evokerBypassMobGriefing = getBoolean("mobs.evoker.bypass-mob-griefing", evokerBypassMobGriefing);
          evokerTakeDamageFromWater = getBoolean("mobs.evoker.takes-damage-from-water", evokerTakeDamageFromWater);
@@ -1429,7 +1429,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean foxRidable = false;
-@@ -1472,6 +1506,7 @@ public class PurpurWorldConfig {
+@@ -1474,6 +1508,7 @@ public class PurpurWorldConfig {
      public int foxBreedingTicks = 6000;
      public boolean foxBypassMobGriefing = false;
      public boolean foxTakeDamageFromWater = false;
@@ -1437,7 +1437,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void foxSettings() {
          foxRidable = getBoolean("mobs.fox.ridable", foxRidable);
          foxRidableInWater = getBoolean("mobs.fox.ridable-in-water", foxRidableInWater);
-@@ -1486,6 +1521,7 @@ public class PurpurWorldConfig {
+@@ -1488,6 +1523,7 @@ public class PurpurWorldConfig {
          foxBreedingTicks = getInt("mobs.fox.breeding-delay-ticks", foxBreedingTicks);
          foxBypassMobGriefing = getBoolean("mobs.fox.bypass-mob-griefing", foxBypassMobGriefing);
          foxTakeDamageFromWater = getBoolean("mobs.fox.takes-damage-from-water", foxTakeDamageFromWater);
@@ -1445,7 +1445,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean frogRidable = false;
-@@ -1507,6 +1543,7 @@ public class PurpurWorldConfig {
+@@ -1509,6 +1545,7 @@ public class PurpurWorldConfig {
      public double ghastMaxY = 320D;
      public double ghastMaxHealth = 10.0D;
      public boolean ghastTakeDamageFromWater = false;
@@ -1453,7 +1453,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void ghastSettings() {
          ghastRidable = getBoolean("mobs.ghast.ridable", ghastRidable);
          ghastRidableInWater = getBoolean("mobs.ghast.ridable-in-water", ghastRidableInWater);
-@@ -1519,6 +1556,7 @@ public class PurpurWorldConfig {
+@@ -1521,6 +1558,7 @@ public class PurpurWorldConfig {
          }
          ghastMaxHealth = getDouble("mobs.ghast.attributes.max_health", ghastMaxHealth);
          ghastTakeDamageFromWater = getBoolean("mobs.ghast.takes-damage-from-water", ghastTakeDamageFromWater);
@@ -1461,7 +1461,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean giantRidable = false;
-@@ -1532,6 +1570,7 @@ public class PurpurWorldConfig {
+@@ -1534,6 +1572,7 @@ public class PurpurWorldConfig {
      public boolean giantHaveAI = false;
      public boolean giantHaveHostileAI = false;
      public boolean giantTakeDamageFromWater = false;
@@ -1469,7 +1469,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void giantSettings() {
          giantRidable = getBoolean("mobs.giant.ridable", giantRidable);
          giantRidableInWater = getBoolean("mobs.giant.ridable-in-water", giantRidableInWater);
-@@ -1553,6 +1592,7 @@ public class PurpurWorldConfig {
+@@ -1555,6 +1594,7 @@ public class PurpurWorldConfig {
          giantHaveAI = getBoolean("mobs.giant.have-ai", giantHaveAI);
          giantHaveHostileAI = getBoolean("mobs.giant.have-hostile-ai", giantHaveHostileAI);
          giantTakeDamageFromWater = getBoolean("mobs.giant.takes-damage-from-water", giantTakeDamageFromWater);
@@ -1477,7 +1477,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean glowSquidRidable = false;
-@@ -1560,12 +1600,14 @@ public class PurpurWorldConfig {
+@@ -1562,12 +1602,14 @@ public class PurpurWorldConfig {
      public double glowSquidMaxHealth = 10.0D;
      public boolean glowSquidsCanFly = false;
      public boolean glowSquidTakeDamageFromWater = false;
@@ -1492,7 +1492,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean goatRidable = false;
-@@ -1574,6 +1616,7 @@ public class PurpurWorldConfig {
+@@ -1576,6 +1618,7 @@ public class PurpurWorldConfig {
      public double goatMaxHealth = 10.0D;
      public int goatBreedingTicks = 6000;
      public boolean goatTakeDamageFromWater = false;
@@ -1500,7 +1500,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void goatSettings() {
          goatRidable = getBoolean("mobs.goat.ridable", goatRidable);
          goatRidableInWater = getBoolean("mobs.goat.ridable-in-water", goatRidableInWater);
-@@ -1581,12 +1624,14 @@ public class PurpurWorldConfig {
+@@ -1583,12 +1626,14 @@ public class PurpurWorldConfig {
          goatMaxHealth = getDouble("mobs.goat.attributes.max_health", goatMaxHealth);
          goatBreedingTicks = getInt("mobs.goat.breeding-delay-ticks", goatBreedingTicks);
          goatTakeDamageFromWater = getBoolean("mobs.goat.takes-damage-from-water", goatTakeDamageFromWater);
@@ -1515,7 +1515,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void guardianSettings() {
          guardianRidable = getBoolean("mobs.guardian.ridable", guardianRidable);
          guardianControllable = getBoolean("mobs.guardian.controllable", guardianControllable);
-@@ -1597,6 +1642,7 @@ public class PurpurWorldConfig {
+@@ -1599,6 +1644,7 @@ public class PurpurWorldConfig {
          }
          guardianMaxHealth = getDouble("mobs.guardian.attributes.max_health", guardianMaxHealth);
          guardianTakeDamageFromWater = getBoolean("mobs.guardian.takes-damage-from-water", guardianTakeDamageFromWater);
@@ -1523,7 +1523,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean forceHalloweenSeason = false;
-@@ -1612,6 +1658,7 @@ public class PurpurWorldConfig {
+@@ -1614,6 +1660,7 @@ public class PurpurWorldConfig {
      public double hoglinMaxHealth = 40.0D;
      public int hoglinBreedingTicks = 6000;
      public boolean hoglinTakeDamageFromWater = false;
@@ -1531,7 +1531,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void hoglinSettings() {
          hoglinRidable = getBoolean("mobs.hoglin.ridable", hoglinRidable);
          hoglinRidableInWater = getBoolean("mobs.hoglin.ridable-in-water", hoglinRidableInWater);
-@@ -1624,6 +1671,7 @@ public class PurpurWorldConfig {
+@@ -1626,6 +1673,7 @@ public class PurpurWorldConfig {
          hoglinMaxHealth = getDouble("mobs.hoglin.attributes.max_health", hoglinMaxHealth);
          hoglinBreedingTicks = getInt("mobs.hoglin.breeding-delay-ticks", hoglinBreedingTicks);
          hoglinTakeDamageFromWater = getBoolean("mobs.hoglin.takes-damage-from-water", hoglinTakeDamageFromWater);
@@ -1539,7 +1539,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean horseRidableInWater = false;
-@@ -1635,6 +1683,7 @@ public class PurpurWorldConfig {
+@@ -1637,6 +1685,7 @@ public class PurpurWorldConfig {
      public double horseMovementSpeedMax = 0.3375D;
      public int horseBreedingTicks = 6000;
      public boolean horseTakeDamageFromWater = false;
@@ -1547,7 +1547,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void horseSettings() {
          horseRidableInWater = getBoolean("mobs.horse.ridable-in-water", horseRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1652,6 +1701,7 @@ public class PurpurWorldConfig {
+@@ -1654,6 +1703,7 @@ public class PurpurWorldConfig {
          horseMovementSpeedMax = getDouble("mobs.horse.attributes.movement_speed.max", horseMovementSpeedMax);
          horseBreedingTicks = getInt("mobs.horse.breeding-delay-ticks", horseBreedingTicks);
          horseTakeDamageFromWater = getBoolean("mobs.horse.takes-damage-from-water", horseTakeDamageFromWater);
@@ -1555,7 +1555,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean huskRidable = false;
-@@ -1663,6 +1713,7 @@ public class PurpurWorldConfig {
+@@ -1665,6 +1715,7 @@ public class PurpurWorldConfig {
      public double huskJockeyChance = 0.05D;
      public boolean huskJockeyTryExistingChickens = true;
      public boolean huskTakeDamageFromWater = false;
@@ -1563,7 +1563,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void huskSettings() {
          huskRidable = getBoolean("mobs.husk.ridable", huskRidable);
          huskRidableInWater = getBoolean("mobs.husk.ridable-in-water", huskRidableInWater);
-@@ -1678,6 +1729,7 @@ public class PurpurWorldConfig {
+@@ -1680,6 +1731,7 @@ public class PurpurWorldConfig {
          huskJockeyChance = getDouble("mobs.husk.jockey.chance", huskJockeyChance);
          huskJockeyTryExistingChickens = getBoolean("mobs.husk.jockey.try-existing-chickens", huskJockeyTryExistingChickens);
          huskTakeDamageFromWater = getBoolean("mobs.husk.takes-damage-from-water", huskTakeDamageFromWater);
@@ -1571,7 +1571,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean illusionerRidable = false;
-@@ -1687,6 +1739,7 @@ public class PurpurWorldConfig {
+@@ -1689,6 +1741,7 @@ public class PurpurWorldConfig {
      public double illusionerFollowRange = 18.0D;
      public double illusionerMaxHealth = 32.0D;
      public boolean illusionerTakeDamageFromWater = false;
@@ -1579,7 +1579,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void illusionerSettings() {
          illusionerRidable = getBoolean("mobs.illusioner.ridable", illusionerRidable);
          illusionerRidableInWater = getBoolean("mobs.illusioner.ridable-in-water", illusionerRidableInWater);
-@@ -1704,6 +1757,7 @@ public class PurpurWorldConfig {
+@@ -1706,6 +1759,7 @@ public class PurpurWorldConfig {
          }
          illusionerMaxHealth = getDouble("mobs.illusioner.attributes.max_health", illusionerMaxHealth);
          illusionerTakeDamageFromWater = getBoolean("mobs.illusioner.takes-damage-from-water", illusionerTakeDamageFromWater);
@@ -1587,7 +1587,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean ironGolemRidable = false;
-@@ -1714,6 +1768,7 @@ public class PurpurWorldConfig {
+@@ -1716,6 +1770,7 @@ public class PurpurWorldConfig {
      public boolean ironGolemTakeDamageFromWater = false;
      public boolean ironGolemPoppyCalm = false;
      public boolean ironGolemHealCalm = false;
@@ -1595,7 +1595,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void ironGolemSettings() {
          ironGolemRidable = getBoolean("mobs.iron_golem.ridable", ironGolemRidable);
          ironGolemRidableInWater = getBoolean("mobs.iron_golem.ridable-in-water", ironGolemRidableInWater);
-@@ -1728,6 +1783,7 @@ public class PurpurWorldConfig {
+@@ -1730,6 +1785,7 @@ public class PurpurWorldConfig {
          ironGolemTakeDamageFromWater = getBoolean("mobs.iron_golem.takes-damage-from-water", ironGolemTakeDamageFromWater);
          ironGolemPoppyCalm = getBoolean("mobs.iron_golem.poppy-calms-anger", ironGolemPoppyCalm);
          ironGolemHealCalm = getBoolean("mobs.iron_golem.healing-calms-anger", ironGolemHealCalm);
@@ -1603,7 +1603,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean llamaRidable = false;
-@@ -1742,6 +1798,7 @@ public class PurpurWorldConfig {
+@@ -1744,6 +1800,7 @@ public class PurpurWorldConfig {
      public int llamaBreedingTicks = 6000;
      public boolean llamaTakeDamageFromWater = false;
      public boolean llamaJoinCaravans = true;
@@ -1611,7 +1611,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void llamaSettings() {
          llamaRidable = getBoolean("mobs.llama.ridable", llamaRidable);
          llamaRidableInWater = getBoolean("mobs.llama.ridable-in-water", llamaRidableInWater);
-@@ -1762,6 +1819,7 @@ public class PurpurWorldConfig {
+@@ -1764,6 +1821,7 @@ public class PurpurWorldConfig {
          llamaBreedingTicks = getInt("mobs.llama.breeding-delay-ticks", llamaBreedingTicks);
          llamaTakeDamageFromWater = getBoolean("mobs.llama.takes-damage-from-water", llamaTakeDamageFromWater);
          llamaJoinCaravans = getBoolean("mobs.llama.join-caravans", llamaJoinCaravans);
@@ -1619,7 +1619,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean magmaCubeRidable = false;
-@@ -1772,6 +1830,7 @@ public class PurpurWorldConfig {
+@@ -1774,6 +1832,7 @@ public class PurpurWorldConfig {
      public Map<Integer, Double> magmaCubeMaxHealthCache = new HashMap<>();
      public Map<Integer, Double> magmaCubeAttackDamageCache = new HashMap<>();
      public boolean magmaCubeTakeDamageFromWater = false;
@@ -1627,7 +1627,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void magmaCubeSettings() {
          magmaCubeRidable = getBoolean("mobs.magma_cube.ridable", magmaCubeRidable);
          magmaCubeRidableInWater = getBoolean("mobs.magma_cube.ridable-in-water", magmaCubeRidableInWater);
-@@ -1786,6 +1845,7 @@ public class PurpurWorldConfig {
+@@ -1788,6 +1847,7 @@ public class PurpurWorldConfig {
          magmaCubeMaxHealthCache.clear();
          magmaCubeAttackDamageCache.clear();
          magmaCubeTakeDamageFromWater = getBoolean("mobs.magma_cube.takes-damage-from-water", magmaCubeTakeDamageFromWater);
@@ -1635,7 +1635,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean mooshroomRidable = false;
-@@ -1794,6 +1854,7 @@ public class PurpurWorldConfig {
+@@ -1796,6 +1856,7 @@ public class PurpurWorldConfig {
      public double mooshroomMaxHealth = 10.0D;
      public int mooshroomBreedingTicks = 6000;
      public boolean mooshroomTakeDamageFromWater = false;
@@ -1643,7 +1643,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void mooshroomSettings() {
          mooshroomRidable = getBoolean("mobs.mooshroom.ridable", mooshroomRidable);
          mooshroomRidableInWater = getBoolean("mobs.mooshroom.ridable-in-water", mooshroomRidableInWater);
-@@ -1806,6 +1867,7 @@ public class PurpurWorldConfig {
+@@ -1808,6 +1869,7 @@ public class PurpurWorldConfig {
          mooshroomMaxHealth = getDouble("mobs.mooshroom.attributes.max_health", mooshroomMaxHealth);
          mooshroomBreedingTicks = getInt("mobs.mooshroom.breeding-delay-ticks", mooshroomBreedingTicks);
          mooshroomTakeDamageFromWater = getBoolean("mobs.mooshroom.takes-damage-from-water", mooshroomTakeDamageFromWater);
@@ -1651,7 +1651,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean muleRidableInWater = false;
-@@ -1817,6 +1879,7 @@ public class PurpurWorldConfig {
+@@ -1819,6 +1881,7 @@ public class PurpurWorldConfig {
      public double muleMovementSpeedMax = 0.175D;
      public int muleBreedingTicks = 6000;
      public boolean muleTakeDamageFromWater = false;
@@ -1659,7 +1659,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void muleSettings() {
          muleRidableInWater = getBoolean("mobs.mule.ridable-in-water", muleRidableInWater);
          if (PurpurConfig.version < 10) {
-@@ -1834,6 +1897,7 @@ public class PurpurWorldConfig {
+@@ -1836,6 +1899,7 @@ public class PurpurWorldConfig {
          muleMovementSpeedMax = getDouble("mobs.mule.attributes.movement_speed.max", muleMovementSpeedMax);
          muleBreedingTicks = getInt("mobs.mule.breeding-delay-ticks", muleBreedingTicks);
          muleTakeDamageFromWater = getBoolean("mobs.mule.takes-damage-from-water", muleTakeDamageFromWater);
@@ -1667,7 +1667,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean ocelotRidable = false;
-@@ -1842,6 +1906,7 @@ public class PurpurWorldConfig {
+@@ -1844,6 +1908,7 @@ public class PurpurWorldConfig {
      public double ocelotMaxHealth = 10.0D;
      public int ocelotBreedingTicks = 6000;
      public boolean ocelotTakeDamageFromWater = false;
@@ -1675,7 +1675,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void ocelotSettings() {
          ocelotRidable = getBoolean("mobs.ocelot.ridable", ocelotRidable);
          ocelotRidableInWater = getBoolean("mobs.ocelot.ridable-in-water", ocelotRidableInWater);
-@@ -1854,6 +1919,7 @@ public class PurpurWorldConfig {
+@@ -1856,6 +1921,7 @@ public class PurpurWorldConfig {
          ocelotMaxHealth = getDouble("mobs.ocelot.attributes.max_health", ocelotMaxHealth);
          ocelotBreedingTicks = getInt("mobs.ocelot.breeding-delay-ticks", ocelotBreedingTicks);
          ocelotTakeDamageFromWater = getBoolean("mobs.ocelot.takes-damage-from-water", ocelotTakeDamageFromWater);
@@ -1683,7 +1683,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean pandaRidable = false;
-@@ -1862,6 +1928,7 @@ public class PurpurWorldConfig {
+@@ -1864,6 +1930,7 @@ public class PurpurWorldConfig {
      public double pandaMaxHealth = 20.0D;
      public int pandaBreedingTicks = 6000;
      public boolean pandaTakeDamageFromWater = false;
@@ -1691,7 +1691,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void pandaSettings() {
          pandaRidable = getBoolean("mobs.panda.ridable", pandaRidable);
          pandaRidableInWater = getBoolean("mobs.panda.ridable-in-water", pandaRidableInWater);
-@@ -1874,6 +1941,7 @@ public class PurpurWorldConfig {
+@@ -1876,6 +1943,7 @@ public class PurpurWorldConfig {
          pandaMaxHealth = getDouble("mobs.panda.attributes.max_health", pandaMaxHealth);
          pandaBreedingTicks = getInt("mobs.panda.breeding-delay-ticks", pandaBreedingTicks);
          pandaTakeDamageFromWater = getBoolean("mobs.panda.takes-damage-from-water", pandaTakeDamageFromWater);
@@ -1699,7 +1699,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean parrotRidable = false;
-@@ -1883,6 +1951,7 @@ public class PurpurWorldConfig {
+@@ -1885,6 +1953,7 @@ public class PurpurWorldConfig {
      public double parrotMaxHealth = 6.0D;
      public boolean parrotTakeDamageFromWater = false;
      public boolean parrotBreedable = false;
@@ -1707,7 +1707,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void parrotSettings() {
          parrotRidable = getBoolean("mobs.parrot.ridable", parrotRidable);
          parrotRidableInWater = getBoolean("mobs.parrot.ridable-in-water", parrotRidableInWater);
-@@ -1896,6 +1965,7 @@ public class PurpurWorldConfig {
+@@ -1898,6 +1967,7 @@ public class PurpurWorldConfig {
          parrotMaxHealth = getDouble("mobs.parrot.attributes.max_health", parrotMaxHealth);
          parrotTakeDamageFromWater = getBoolean("mobs.parrot.takes-damage-from-water", parrotTakeDamageFromWater);
          parrotBreedable = getBoolean("mobs.parrot.can-breed", parrotBreedable);
@@ -1715,7 +1715,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean phantomRidable = false;
-@@ -1923,6 +1993,7 @@ public class PurpurWorldConfig {
+@@ -1925,6 +1995,7 @@ public class PurpurWorldConfig {
      public boolean phantomBurnInDaylight = true;
      public boolean phantomFlamesOnSwoop = false;
      public boolean phantomTakeDamageFromWater = false;
@@ -1723,7 +1723,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void phantomSettings() {
          phantomRidable = getBoolean("mobs.phantom.ridable", phantomRidable);
          phantomRidableInWater = getBoolean("mobs.phantom.ridable-in-water", phantomRidableInWater);
-@@ -1958,6 +2029,7 @@ public class PurpurWorldConfig {
+@@ -1960,6 +2031,7 @@ public class PurpurWorldConfig {
          phantomIgnorePlayersWithTorch = getBoolean("mobs.phantom.ignore-players-with-torch", phantomIgnorePlayersWithTorch);
          phantomFlamesOnSwoop = getBoolean("mobs.phantom.flames-on-swoop", phantomFlamesOnSwoop);
          phantomTakeDamageFromWater = getBoolean("mobs.phantom.takes-damage-from-water", phantomTakeDamageFromWater);
@@ -1731,7 +1731,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean pigRidable = false;
-@@ -1967,6 +2039,7 @@ public class PurpurWorldConfig {
+@@ -1969,6 +2041,7 @@ public class PurpurWorldConfig {
      public boolean pigGiveSaddleBack = false;
      public int pigBreedingTicks = 6000;
      public boolean pigTakeDamageFromWater = false;
@@ -1739,7 +1739,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void pigSettings() {
          pigRidable = getBoolean("mobs.pig.ridable", pigRidable);
          pigRidableInWater = getBoolean("mobs.pig.ridable-in-water", pigRidableInWater);
-@@ -1980,6 +2053,7 @@ public class PurpurWorldConfig {
+@@ -1982,6 +2055,7 @@ public class PurpurWorldConfig {
          pigGiveSaddleBack = getBoolean("mobs.pig.give-saddle-back", pigGiveSaddleBack);
          pigBreedingTicks = getInt("mobs.pig.breeding-delay-ticks", pigBreedingTicks);
          pigTakeDamageFromWater = getBoolean("mobs.pig.takes-damage-from-water", pigTakeDamageFromWater);
@@ -1747,7 +1747,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean piglinRidable = false;
-@@ -1989,6 +2063,7 @@ public class PurpurWorldConfig {
+@@ -1991,6 +2065,7 @@ public class PurpurWorldConfig {
      public boolean piglinBypassMobGriefing = false;
      public boolean piglinTakeDamageFromWater = false;
      public int piglinPortalSpawnModifier = 2000;
@@ -1755,7 +1755,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -2002,6 +2077,7 @@ public class PurpurWorldConfig {
+@@ -2004,6 +2079,7 @@ public class PurpurWorldConfig {
          piglinBypassMobGriefing = getBoolean("mobs.piglin.bypass-mob-griefing", piglinBypassMobGriefing);
          piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);
          piglinPortalSpawnModifier = getInt("mobs.piglin.portal-spawn-modifier", piglinPortalSpawnModifier);
@@ -1763,7 +1763,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean piglinBruteRidable = false;
-@@ -2009,6 +2085,7 @@ public class PurpurWorldConfig {
+@@ -2011,6 +2087,7 @@ public class PurpurWorldConfig {
      public boolean piglinBruteControllable = true;
      public double piglinBruteMaxHealth = 50.0D;
      public boolean piglinBruteTakeDamageFromWater = false;
@@ -1771,7 +1771,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void piglinBruteSettings() {
          piglinBruteRidable = getBoolean("mobs.piglin_brute.ridable", piglinBruteRidable);
          piglinBruteRidableInWater = getBoolean("mobs.piglin_brute.ridable-in-water", piglinBruteRidableInWater);
-@@ -2020,6 +2097,7 @@ public class PurpurWorldConfig {
+@@ -2022,6 +2099,7 @@ public class PurpurWorldConfig {
          }
          piglinBruteMaxHealth = getDouble("mobs.piglin_brute.attributes.max_health", piglinBruteMaxHealth);
          piglinBruteTakeDamageFromWater = getBoolean("mobs.piglin_brute.takes-damage-from-water", piglinBruteTakeDamageFromWater);
@@ -1779,7 +1779,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean pillagerRidable = false;
-@@ -2028,6 +2106,7 @@ public class PurpurWorldConfig {
+@@ -2030,6 +2108,7 @@ public class PurpurWorldConfig {
      public double pillagerMaxHealth = 24.0D;
      public boolean pillagerBypassMobGriefing = false;
      public boolean pillagerTakeDamageFromWater = false;
@@ -1787,7 +1787,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void pillagerSettings() {
          pillagerRidable = getBoolean("mobs.pillager.ridable", pillagerRidable);
          pillagerRidableInWater = getBoolean("mobs.pillager.ridable-in-water", pillagerRidableInWater);
-@@ -2040,6 +2119,7 @@ public class PurpurWorldConfig {
+@@ -2042,6 +2121,7 @@ public class PurpurWorldConfig {
          pillagerMaxHealth = getDouble("mobs.pillager.attributes.max_health", pillagerMaxHealth);
          pillagerBypassMobGriefing = getBoolean("mobs.pillager.bypass-mob-griefing", pillagerBypassMobGriefing);
          pillagerTakeDamageFromWater = getBoolean("mobs.pillager.takes-damage-from-water", pillagerTakeDamageFromWater);
@@ -1795,7 +1795,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean polarBearRidable = false;
-@@ -2050,6 +2130,7 @@ public class PurpurWorldConfig {
+@@ -2052,6 +2132,7 @@ public class PurpurWorldConfig {
      public Item polarBearBreedableItem = null;
      public int polarBearBreedingTicks = 6000;
      public boolean polarBearTakeDamageFromWater = false;
@@ -1803,7 +1803,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void polarBearSettings() {
          polarBearRidable = getBoolean("mobs.polar_bear.ridable", polarBearRidable);
          polarBearRidableInWater = getBoolean("mobs.polar_bear.ridable-in-water", polarBearRidableInWater);
-@@ -2065,12 +2146,14 @@ public class PurpurWorldConfig {
+@@ -2067,12 +2148,14 @@ public class PurpurWorldConfig {
          if (item != Items.AIR) polarBearBreedableItem = item;
          polarBearBreedingTicks = getInt("mobs.polar_bear.breeding-delay-ticks", polarBearBreedingTicks);
          polarBearTakeDamageFromWater = getBoolean("mobs.polar_bear.takes-damage-from-water", polarBearTakeDamageFromWater);
@@ -1818,7 +1818,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void pufferfishSettings() {
          pufferfishRidable = getBoolean("mobs.pufferfish.ridable", pufferfishRidable);
          pufferfishControllable = getBoolean("mobs.pufferfish.controllable", pufferfishControllable);
-@@ -2081,6 +2164,7 @@ public class PurpurWorldConfig {
+@@ -2083,6 +2166,7 @@ public class PurpurWorldConfig {
          }
          pufferfishMaxHealth = getDouble("mobs.pufferfish.attributes.max_health", pufferfishMaxHealth);
          pufferfishTakeDamageFromWater = getBoolean("mobs.pufferfish.takes-damage-from-water", pufferfishTakeDamageFromWater);
@@ -1826,7 +1826,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean rabbitRidable = false;
-@@ -2092,6 +2176,7 @@ public class PurpurWorldConfig {
+@@ -2094,6 +2178,7 @@ public class PurpurWorldConfig {
      public int rabbitBreedingTicks = 6000;
      public boolean rabbitBypassMobGriefing = false;
      public boolean rabbitTakeDamageFromWater = false;
@@ -1834,7 +1834,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void rabbitSettings() {
          rabbitRidable = getBoolean("mobs.rabbit.ridable", rabbitRidable);
          rabbitRidableInWater = getBoolean("mobs.rabbit.ridable-in-water", rabbitRidableInWater);
-@@ -2107,6 +2192,7 @@ public class PurpurWorldConfig {
+@@ -2109,6 +2194,7 @@ public class PurpurWorldConfig {
          rabbitBreedingTicks = getInt("mobs.rabbit.breeding-delay-ticks", rabbitBreedingTicks);
          rabbitBypassMobGriefing = getBoolean("mobs.rabbit.bypass-mob-griefing", rabbitBypassMobGriefing);
          rabbitTakeDamageFromWater = getBoolean("mobs.rabbit.takes-damage-from-water", rabbitTakeDamageFromWater);
@@ -1842,7 +1842,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean ravagerRidable = false;
-@@ -2116,6 +2202,7 @@ public class PurpurWorldConfig {
+@@ -2118,6 +2204,7 @@ public class PurpurWorldConfig {
      public boolean ravagerBypassMobGriefing = false;
      public boolean ravagerTakeDamageFromWater = false;
      public List<Block> ravagerGriefableBlocks = new ArrayList<>();
@@ -1850,7 +1850,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void ravagerSettings() {
          ravagerRidable = getBoolean("mobs.ravager.ridable", ravagerRidable);
          ravagerRidableInWater = getBoolean("mobs.ravager.ridable-in-water", ravagerRidableInWater);
-@@ -2145,12 +2232,14 @@ public class PurpurWorldConfig {
+@@ -2147,12 +2234,14 @@ public class PurpurWorldConfig {
                  ravagerGriefableBlocks.add(block);
              }
          });
@@ -1865,7 +1865,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void salmonSettings() {
          salmonRidable = getBoolean("mobs.salmon.ridable", salmonRidable);
          salmonControllable = getBoolean("mobs.salmon.controllable", salmonControllable);
-@@ -2161,6 +2250,7 @@ public class PurpurWorldConfig {
+@@ -2163,6 +2252,7 @@ public class PurpurWorldConfig {
          }
          salmonMaxHealth = getDouble("mobs.salmon.attributes.max_health", salmonMaxHealth);
          salmonTakeDamageFromWater = getBoolean("mobs.salmon.takes-damage-from-water", salmonTakeDamageFromWater);
@@ -1873,7 +1873,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean sheepRidable = false;
-@@ -2170,6 +2260,7 @@ public class PurpurWorldConfig {
+@@ -2172,6 +2262,7 @@ public class PurpurWorldConfig {
      public int sheepBreedingTicks = 6000;
      public boolean sheepBypassMobGriefing = false;
      public boolean sheepTakeDamageFromWater = false;
@@ -1881,7 +1881,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -2183,6 +2274,7 @@ public class PurpurWorldConfig {
+@@ -2185,6 +2276,7 @@ public class PurpurWorldConfig {
          sheepBreedingTicks = getInt("mobs.sheep.breeding-delay-ticks", sheepBreedingTicks);
          sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
          sheepTakeDamageFromWater = getBoolean("mobs.sheep.takes-damage-from-water", sheepTakeDamageFromWater);
@@ -1889,7 +1889,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean shulkerRidable = false;
-@@ -2196,6 +2288,7 @@ public class PurpurWorldConfig {
+@@ -2198,6 +2290,7 @@ public class PurpurWorldConfig {
      public String shulkerSpawnFromBulletNearbyEquation = "(nearby - 1) / 5.0";
      public boolean shulkerSpawnFromBulletRandomColor = false;
      public boolean shulkerChangeColorWithDye = false;
@@ -1897,7 +1897,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void shulkerSettings() {
          shulkerRidable = getBoolean("mobs.shulker.ridable", shulkerRidable);
          shulkerRidableInWater = getBoolean("mobs.shulker.ridable-in-water", shulkerRidableInWater);
-@@ -2213,6 +2306,7 @@ public class PurpurWorldConfig {
+@@ -2215,6 +2308,7 @@ public class PurpurWorldConfig {
          shulkerSpawnFromBulletNearbyEquation = getString("mobs.shulker.spawn-from-bullet.nearby-equation", shulkerSpawnFromBulletNearbyEquation);
          shulkerSpawnFromBulletRandomColor = getBoolean("mobs.shulker.spawn-from-bullet.random-color", shulkerSpawnFromBulletRandomColor);
          shulkerChangeColorWithDye = getBoolean("mobs.shulker.change-color-with-dye", shulkerChangeColorWithDye);
@@ -1905,7 +1905,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean silverfishRidable = false;
-@@ -2221,6 +2315,7 @@ public class PurpurWorldConfig {
+@@ -2223,6 +2317,7 @@ public class PurpurWorldConfig {
      public double silverfishMaxHealth = 8.0D;
      public boolean silverfishBypassMobGriefing = false;
      public boolean silverfishTakeDamageFromWater = false;
@@ -1913,7 +1913,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void silverfishSettings() {
          silverfishRidable = getBoolean("mobs.silverfish.ridable", silverfishRidable);
          silverfishRidableInWater = getBoolean("mobs.silverfish.ridable-in-water", silverfishRidableInWater);
-@@ -2233,6 +2328,7 @@ public class PurpurWorldConfig {
+@@ -2235,6 +2330,7 @@ public class PurpurWorldConfig {
          silverfishMaxHealth = getDouble("mobs.silverfish.attributes.max_health", silverfishMaxHealth);
          silverfishBypassMobGriefing = getBoolean("mobs.silverfish.bypass-mob-griefing", silverfishBypassMobGriefing);
          silverfishTakeDamageFromWater = getBoolean("mobs.silverfish.takes-damage-from-water", silverfishTakeDamageFromWater);
@@ -1921,7 +1921,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean skeletonRidable = false;
-@@ -2240,6 +2336,7 @@ public class PurpurWorldConfig {
+@@ -2242,6 +2338,7 @@ public class PurpurWorldConfig {
      public boolean skeletonControllable = true;
      public double skeletonMaxHealth = 20.0D;
      public boolean skeletonTakeDamageFromWater = false;
@@ -1929,7 +1929,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2251,6 +2348,7 @@ public class PurpurWorldConfig {
+@@ -2253,6 +2350,7 @@ public class PurpurWorldConfig {
          }
          skeletonMaxHealth = getDouble("mobs.skeleton.attributes.max_health", skeletonMaxHealth);
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
@@ -1937,7 +1937,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean skeletonHorseRidableInWater = true;
-@@ -2262,6 +2360,7 @@ public class PurpurWorldConfig {
+@@ -2264,6 +2362,7 @@ public class PurpurWorldConfig {
      public double skeletonHorseMovementSpeedMin = 0.2D;
      public double skeletonHorseMovementSpeedMax = 0.2D;
      public boolean skeletonHorseTakeDamageFromWater = false;
@@ -1945,7 +1945,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void skeletonHorseSettings() {
          skeletonHorseRidableInWater = getBoolean("mobs.skeleton_horse.ridable-in-water", skeletonHorseRidableInWater);
          skeletonHorseCanSwim = getBoolean("mobs.skeleton_horse.can-swim", skeletonHorseCanSwim);
-@@ -2278,6 +2377,7 @@ public class PurpurWorldConfig {
+@@ -2280,6 +2379,7 @@ public class PurpurWorldConfig {
          skeletonHorseMovementSpeedMin = getDouble("mobs.skeleton_horse.attributes.movement_speed.min", skeletonHorseMovementSpeedMin);
          skeletonHorseMovementSpeedMax = getDouble("mobs.skeleton_horse.attributes.movement_speed.max", skeletonHorseMovementSpeedMax);
          skeletonHorseTakeDamageFromWater = getBoolean("mobs.skeleton_horse.takes-damage-from-water", skeletonHorseTakeDamageFromWater);
@@ -1953,7 +1953,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean slimeRidable = false;
-@@ -2288,6 +2388,7 @@ public class PurpurWorldConfig {
+@@ -2290,6 +2390,7 @@ public class PurpurWorldConfig {
      public Map<Integer, Double> slimeMaxHealthCache = new HashMap<>();
      public Map<Integer, Double> slimeAttackDamageCache = new HashMap<>();
      public boolean slimeTakeDamageFromWater = false;
@@ -1961,7 +1961,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void slimeSettings() {
          slimeRidable = getBoolean("mobs.slime.ridable", slimeRidable);
          slimeRidableInWater = getBoolean("mobs.slime.ridable-in-water", slimeRidableInWater);
-@@ -2302,6 +2403,7 @@ public class PurpurWorldConfig {
+@@ -2304,6 +2405,7 @@ public class PurpurWorldConfig {
          slimeMaxHealthCache.clear();
          slimeAttackDamageCache.clear();
          slimeTakeDamageFromWater = getBoolean("mobs.slime.takes-damage-from-water", slimeTakeDamageFromWater);
@@ -1969,7 +1969,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean snowGolemRidable = false;
-@@ -2317,6 +2419,7 @@ public class PurpurWorldConfig {
+@@ -2319,6 +2421,7 @@ public class PurpurWorldConfig {
      public double snowGolemAttackDistance = 1.25D;
      public boolean snowGolemBypassMobGriefing = false;
      public boolean snowGolemTakeDamageFromWater = true;
@@ -1977,7 +1977,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void snowGolemSettings() {
          snowGolemRidable = getBoolean("mobs.snow_golem.ridable", snowGolemRidable);
          snowGolemRidableInWater = getBoolean("mobs.snow_golem.ridable-in-water", snowGolemRidableInWater);
-@@ -2336,6 +2439,7 @@ public class PurpurWorldConfig {
+@@ -2338,6 +2441,7 @@ public class PurpurWorldConfig {
          snowGolemAttackDistance = getDouble("mobs.snow_golem.attack-distance", snowGolemAttackDistance);
          snowGolemBypassMobGriefing = getBoolean("mobs.snow_golem.bypass-mob-griefing", snowGolemBypassMobGriefing);
          snowGolemTakeDamageFromWater = getBoolean("mobs.snow_golem.takes-damage-from-water", snowGolemTakeDamageFromWater);
@@ -1985,7 +1985,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean snifferRidable = false;
-@@ -2356,6 +2460,7 @@ public class PurpurWorldConfig {
+@@ -2358,6 +2462,7 @@ public class PurpurWorldConfig {
      public double squidOffsetWaterCheck = 0.0D;
      public boolean squidsCanFly = false;
      public boolean squidTakeDamageFromWater = false;
@@ -1993,7 +1993,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void squidSettings() {
          squidRidable = getBoolean("mobs.squid.ridable", squidRidable);
          squidControllable = getBoolean("mobs.squid.controllable", squidControllable);
-@@ -2369,6 +2474,7 @@ public class PurpurWorldConfig {
+@@ -2371,6 +2476,7 @@ public class PurpurWorldConfig {
          squidOffsetWaterCheck = getDouble("mobs.squid.water-offset-check", squidOffsetWaterCheck);
          squidsCanFly = getBoolean("mobs.squid.can-fly", squidsCanFly);
          squidTakeDamageFromWater = getBoolean("mobs.squid.takes-damage-from-water", squidTakeDamageFromWater);
@@ -2001,7 +2001,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean spiderRidable = false;
-@@ -2376,6 +2482,7 @@ public class PurpurWorldConfig {
+@@ -2378,6 +2484,7 @@ public class PurpurWorldConfig {
      public boolean spiderControllable = true;
      public double spiderMaxHealth = 16.0D;
      public boolean spiderTakeDamageFromWater = false;
@@ -2009,7 +2009,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void spiderSettings() {
          spiderRidable = getBoolean("mobs.spider.ridable", spiderRidable);
          spiderRidableInWater = getBoolean("mobs.spider.ridable-in-water", spiderRidableInWater);
-@@ -2387,6 +2494,7 @@ public class PurpurWorldConfig {
+@@ -2389,6 +2496,7 @@ public class PurpurWorldConfig {
          }
          spiderMaxHealth = getDouble("mobs.spider.attributes.max_health", spiderMaxHealth);
          spiderTakeDamageFromWater = getBoolean("mobs.spider.takes-damage-from-water", spiderTakeDamageFromWater);
@@ -2017,7 +2017,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean strayRidable = false;
-@@ -2394,6 +2502,7 @@ public class PurpurWorldConfig {
+@@ -2396,6 +2504,7 @@ public class PurpurWorldConfig {
      public boolean strayControllable = true;
      public double strayMaxHealth = 20.0D;
      public boolean strayTakeDamageFromWater = false;
@@ -2025,7 +2025,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void straySettings() {
          strayRidable = getBoolean("mobs.stray.ridable", strayRidable);
          strayRidableInWater = getBoolean("mobs.stray.ridable-in-water", strayRidableInWater);
-@@ -2405,6 +2514,7 @@ public class PurpurWorldConfig {
+@@ -2407,6 +2516,7 @@ public class PurpurWorldConfig {
          }
          strayMaxHealth = getDouble("mobs.stray.attributes.max_health", strayMaxHealth);
          strayTakeDamageFromWater = getBoolean("mobs.stray.takes-damage-from-water", strayTakeDamageFromWater);
@@ -2033,7 +2033,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean striderRidable = false;
-@@ -2414,6 +2524,7 @@ public class PurpurWorldConfig {
+@@ -2416,6 +2526,7 @@ public class PurpurWorldConfig {
      public int striderBreedingTicks = 6000;
      public boolean striderGiveSaddleBack = false;
      public boolean striderTakeDamageFromWater = true;
@@ -2041,7 +2041,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void striderSettings() {
          striderRidable = getBoolean("mobs.strider.ridable", striderRidable);
          striderRidableInWater = getBoolean("mobs.strider.ridable-in-water", striderRidableInWater);
-@@ -2427,6 +2538,7 @@ public class PurpurWorldConfig {
+@@ -2429,6 +2540,7 @@ public class PurpurWorldConfig {
          striderBreedingTicks = getInt("mobs.strider.breeding-delay-ticks", striderBreedingTicks);
          striderGiveSaddleBack = getBoolean("mobs.strider.give-saddle-back", striderGiveSaddleBack);
          striderTakeDamageFromWater = getBoolean("mobs.strider.takes-damage-from-water", striderTakeDamageFromWater);
@@ -2049,7 +2049,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean tadpoleRidable = false;
-@@ -2449,6 +2561,7 @@ public class PurpurWorldConfig {
+@@ -2451,6 +2563,7 @@ public class PurpurWorldConfig {
      public double traderLlamaMovementSpeedMax = 0.175D;
      public int traderLlamaBreedingTicks = 6000;
      public boolean traderLlamaTakeDamageFromWater = false;
@@ -2057,7 +2057,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void traderLlamaSettings() {
          traderLlamaRidable = getBoolean("mobs.trader_llama.ridable", traderLlamaRidable);
          traderLlamaRidableInWater = getBoolean("mobs.trader_llama.ridable-in-water", traderLlamaRidableInWater);
-@@ -2468,12 +2581,14 @@ public class PurpurWorldConfig {
+@@ -2470,12 +2583,14 @@ public class PurpurWorldConfig {
          traderLlamaMovementSpeedMax = getDouble("mobs.trader_llama.attributes.movement_speed.max", traderLlamaMovementSpeedMax);
          traderLlamaBreedingTicks = getInt("mobs.trader_llama.breeding-delay-ticks", traderLlamaBreedingTicks);
          traderLlamaTakeDamageFromWater = getBoolean("mobs.trader_llama.takes-damage-from-water", traderLlamaTakeDamageFromWater);
@@ -2072,7 +2072,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void tropicalFishSettings() {
          tropicalFishRidable = getBoolean("mobs.tropical_fish.ridable", tropicalFishRidable);
          tropicalFishControllable = getBoolean("mobs.tropical_fish.controllable", tropicalFishControllable);
-@@ -2484,6 +2599,7 @@ public class PurpurWorldConfig {
+@@ -2486,6 +2601,7 @@ public class PurpurWorldConfig {
          }
          tropicalFishMaxHealth = getDouble("mobs.tropical_fish.attributes.max_health", tropicalFishMaxHealth);
          tropicalFishTakeDamageFromWater = getBoolean("mobs.tropical_fish.takes-damage-from-water", tropicalFishTakeDamageFromWater);
@@ -2080,7 +2080,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean turtleRidable = false;
-@@ -2492,6 +2608,7 @@ public class PurpurWorldConfig {
+@@ -2494,6 +2610,7 @@ public class PurpurWorldConfig {
      public double turtleMaxHealth = 30.0D;
      public int turtleBreedingTicks = 6000;
      public boolean turtleTakeDamageFromWater = false;
@@ -2088,7 +2088,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void turtleSettings() {
          turtleRidable = getBoolean("mobs.turtle.ridable", turtleRidable);
          turtleRidableInWater = getBoolean("mobs.turtle.ridable-in-water", turtleRidableInWater);
-@@ -2504,6 +2621,7 @@ public class PurpurWorldConfig {
+@@ -2506,6 +2623,7 @@ public class PurpurWorldConfig {
          turtleMaxHealth = getDouble("mobs.turtle.attributes.max_health", turtleMaxHealth);
          turtleBreedingTicks = getInt("mobs.turtle.breeding-delay-ticks", turtleBreedingTicks);
          turtleTakeDamageFromWater = getBoolean("mobs.turtle.takes-damage-from-water", turtleTakeDamageFromWater);
@@ -2096,7 +2096,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean vexRidable = false;
-@@ -2512,6 +2630,7 @@ public class PurpurWorldConfig {
+@@ -2514,6 +2632,7 @@ public class PurpurWorldConfig {
      public double vexMaxY = 320D;
      public double vexMaxHealth = 14.0D;
      public boolean vexTakeDamageFromWater = false;
@@ -2104,7 +2104,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void vexSettings() {
          vexRidable = getBoolean("mobs.vex.ridable", vexRidable);
          vexRidableInWater = getBoolean("mobs.vex.ridable-in-water", vexRidableInWater);
-@@ -2524,6 +2643,7 @@ public class PurpurWorldConfig {
+@@ -2526,6 +2645,7 @@ public class PurpurWorldConfig {
          }
          vexMaxHealth = getDouble("mobs.vex.attributes.max_health", vexMaxHealth);
          vexTakeDamageFromWater = getBoolean("mobs.vex.takes-damage-from-water", vexTakeDamageFromWater);
@@ -2112,7 +2112,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean villagerRidable = false;
-@@ -2539,6 +2659,7 @@ public class PurpurWorldConfig {
+@@ -2541,6 +2661,7 @@ public class PurpurWorldConfig {
      public boolean villagerBypassMobGriefing = false;
      public boolean villagerTakeDamageFromWater = false;
      public boolean villagerAllowTrading = true;
@@ -2120,7 +2120,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2558,6 +2679,7 @@ public class PurpurWorldConfig {
+@@ -2560,6 +2681,7 @@ public class PurpurWorldConfig {
          villagerBypassMobGriefing = getBoolean("mobs.villager.bypass-mob-griefing", villagerBypassMobGriefing);
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
@@ -2128,7 +2128,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean vindicatorRidable = false;
-@@ -2566,6 +2688,7 @@ public class PurpurWorldConfig {
+@@ -2568,6 +2690,7 @@ public class PurpurWorldConfig {
      public double vindicatorMaxHealth = 24.0D;
      public double vindicatorJohnnySpawnChance = 0D;
      public boolean vindicatorTakeDamageFromWater = false;
@@ -2136,7 +2136,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void vindicatorSettings() {
          vindicatorRidable = getBoolean("mobs.vindicator.ridable", vindicatorRidable);
          vindicatorRidableInWater = getBoolean("mobs.vindicator.ridable-in-water", vindicatorRidableInWater);
-@@ -2578,6 +2701,7 @@ public class PurpurWorldConfig {
+@@ -2580,6 +2703,7 @@ public class PurpurWorldConfig {
          vindicatorMaxHealth = getDouble("mobs.vindicator.attributes.max_health", vindicatorMaxHealth);
          vindicatorJohnnySpawnChance = getDouble("mobs.vindicator.johnny.spawn-chance", vindicatorJohnnySpawnChance);
          vindicatorTakeDamageFromWater = getBoolean("mobs.vindicator.takes-damage-from-water", vindicatorTakeDamageFromWater);
@@ -2144,7 +2144,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean wanderingTraderRidable = false;
-@@ -2588,6 +2712,7 @@ public class PurpurWorldConfig {
+@@ -2590,6 +2714,7 @@ public class PurpurWorldConfig {
      public boolean wanderingTraderCanBeLeashed = false;
      public boolean wanderingTraderTakeDamageFromWater = false;
      public boolean wanderingTraderAllowTrading = true;
@@ -2152,7 +2152,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void wanderingTraderSettings() {
          wanderingTraderRidable = getBoolean("mobs.wandering_trader.ridable", wanderingTraderRidable);
          wanderingTraderRidableInWater = getBoolean("mobs.wandering_trader.ridable-in-water", wanderingTraderRidableInWater);
-@@ -2602,6 +2727,7 @@ public class PurpurWorldConfig {
+@@ -2604,6 +2729,7 @@ public class PurpurWorldConfig {
          wanderingTraderCanBeLeashed = getBoolean("mobs.wandering_trader.can-be-leashed", wanderingTraderCanBeLeashed);
          wanderingTraderTakeDamageFromWater = getBoolean("mobs.wandering_trader.takes-damage-from-water", wanderingTraderTakeDamageFromWater);
          wanderingTraderAllowTrading = getBoolean("mobs.wandering_trader.allow-trading", wanderingTraderAllowTrading);
@@ -2160,7 +2160,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean wardenRidable = false;
-@@ -2618,6 +2744,7 @@ public class PurpurWorldConfig {
+@@ -2620,6 +2746,7 @@ public class PurpurWorldConfig {
      public boolean witchControllable = true;
      public double witchMaxHealth = 26.0D;
      public boolean witchTakeDamageFromWater = false;
@@ -2168,7 +2168,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void witchSettings() {
          witchRidable = getBoolean("mobs.witch.ridable", witchRidable);
          witchRidableInWater = getBoolean("mobs.witch.ridable-in-water", witchRidableInWater);
-@@ -2629,6 +2756,7 @@ public class PurpurWorldConfig {
+@@ -2631,6 +2758,7 @@ public class PurpurWorldConfig {
          }
          witchMaxHealth = getDouble("mobs.witch.attributes.max_health", witchMaxHealth);
          witchTakeDamageFromWater = getBoolean("mobs.witch.takes-damage-from-water", witchTakeDamageFromWater);
@@ -2176,7 +2176,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean witherRidable = false;
-@@ -2643,6 +2771,7 @@ public class PurpurWorldConfig {
+@@ -2645,6 +2773,7 @@ public class PurpurWorldConfig {
      public boolean witherCanRideVehicles = false;
      public float witherExplosionRadius = 1.0F;
      public boolean witherPlaySpawnSound = true;
@@ -2184,7 +2184,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void witherSettings() {
          witherRidable = getBoolean("mobs.wither.ridable", witherRidable);
          witherRidableInWater = getBoolean("mobs.wither.ridable-in-water", witherRidableInWater);
-@@ -2665,6 +2794,7 @@ public class PurpurWorldConfig {
+@@ -2667,6 +2796,7 @@ public class PurpurWorldConfig {
          witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);
          witherExplosionRadius = (float) getDouble("mobs.wither.explosion-radius", witherExplosionRadius);
          witherPlaySpawnSound = getBoolean("mobs.wither.play-spawn-sound", witherPlaySpawnSound);
@@ -2192,7 +2192,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean witherSkeletonRidable = false;
-@@ -2672,6 +2802,7 @@ public class PurpurWorldConfig {
+@@ -2674,6 +2804,7 @@ public class PurpurWorldConfig {
      public boolean witherSkeletonControllable = true;
      public double witherSkeletonMaxHealth = 20.0D;
      public boolean witherSkeletonTakeDamageFromWater = false;
@@ -2200,7 +2200,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void witherSkeletonSettings() {
          witherSkeletonRidable = getBoolean("mobs.wither_skeleton.ridable", witherSkeletonRidable);
          witherSkeletonRidableInWater = getBoolean("mobs.wither_skeleton.ridable-in-water", witherSkeletonRidableInWater);
-@@ -2683,6 +2814,7 @@ public class PurpurWorldConfig {
+@@ -2685,6 +2816,7 @@ public class PurpurWorldConfig {
          }
          witherSkeletonMaxHealth = getDouble("mobs.wither_skeleton.attributes.max_health", witherSkeletonMaxHealth);
          witherSkeletonTakeDamageFromWater = getBoolean("mobs.wither_skeleton.takes-damage-from-water", witherSkeletonTakeDamageFromWater);
@@ -2208,7 +2208,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean wolfRidable = false;
-@@ -2694,6 +2826,7 @@ public class PurpurWorldConfig {
+@@ -2696,6 +2828,7 @@ public class PurpurWorldConfig {
      public double wolfNaturalRabid = 0.0D;
      public int wolfBreedingTicks = 6000;
      public boolean wolfTakeDamageFromWater = false;
@@ -2216,7 +2216,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void wolfSettings() {
          wolfRidable = getBoolean("mobs.wolf.ridable", wolfRidable);
          wolfRidableInWater = getBoolean("mobs.wolf.ridable-in-water", wolfRidableInWater);
-@@ -2713,6 +2846,7 @@ public class PurpurWorldConfig {
+@@ -2715,6 +2848,7 @@ public class PurpurWorldConfig {
          wolfNaturalRabid = getDouble("mobs.wolf.spawn-rabid-chance", wolfNaturalRabid);
          wolfBreedingTicks = getInt("mobs.wolf.breeding-delay-ticks", wolfBreedingTicks);
          wolfTakeDamageFromWater = getBoolean("mobs.wolf.takes-damage-from-water", wolfTakeDamageFromWater);
@@ -2224,7 +2224,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean zoglinRidable = false;
-@@ -2720,6 +2854,7 @@ public class PurpurWorldConfig {
+@@ -2722,6 +2856,7 @@ public class PurpurWorldConfig {
      public boolean zoglinControllable = true;
      public double zoglinMaxHealth = 40.0D;
      public boolean zoglinTakeDamageFromWater = false;
@@ -2232,7 +2232,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void zoglinSettings() {
          zoglinRidable = getBoolean("mobs.zoglin.ridable", zoglinRidable);
          zoglinRidableInWater = getBoolean("mobs.zoglin.ridable-in-water", zoglinRidableInWater);
-@@ -2731,6 +2866,7 @@ public class PurpurWorldConfig {
+@@ -2733,6 +2868,7 @@ public class PurpurWorldConfig {
          }
          zoglinMaxHealth = getDouble("mobs.zoglin.attributes.max_health", zoglinMaxHealth);
          zoglinTakeDamageFromWater = getBoolean("mobs.zoglin.takes-damage-from-water", zoglinTakeDamageFromWater);
@@ -2240,7 +2240,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean zombieRidable = false;
-@@ -2744,6 +2880,7 @@ public class PurpurWorldConfig {
+@@ -2746,6 +2882,7 @@ public class PurpurWorldConfig {
      public boolean zombieAggressiveTowardsVillagerWhenLagging = true;
      public boolean zombieBypassMobGriefing = false;
      public boolean zombieTakeDamageFromWater = false;
@@ -2248,7 +2248,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -2761,6 +2898,7 @@ public class PurpurWorldConfig {
+@@ -2763,6 +2900,7 @@ public class PurpurWorldConfig {
          zombieAggressiveTowardsVillagerWhenLagging = getBoolean("mobs.zombie.aggressive-towards-villager-when-lagging", zombieAggressiveTowardsVillagerWhenLagging);
          zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
          zombieTakeDamageFromWater = getBoolean("mobs.zombie.takes-damage-from-water", zombieTakeDamageFromWater);
@@ -2256,7 +2256,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean zombieHorseRidableInWater = false;
-@@ -2773,6 +2911,7 @@ public class PurpurWorldConfig {
+@@ -2775,6 +2913,7 @@ public class PurpurWorldConfig {
      public double zombieHorseMovementSpeedMax = 0.2D;
      public double zombieHorseSpawnChance = 0.0D;
      public boolean zombieHorseTakeDamageFromWater = false;
@@ -2264,7 +2264,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void zombieHorseSettings() {
          zombieHorseRidableInWater = getBoolean("mobs.zombie_horse.ridable-in-water", zombieHorseRidableInWater);
          zombieHorseCanSwim = getBoolean("mobs.zombie_horse.can-swim", zombieHorseCanSwim);
-@@ -2790,6 +2929,7 @@ public class PurpurWorldConfig {
+@@ -2792,6 +2931,7 @@ public class PurpurWorldConfig {
          zombieHorseMovementSpeedMax = getDouble("mobs.zombie_horse.attributes.movement_speed.max", zombieHorseMovementSpeedMax);
          zombieHorseSpawnChance = getDouble("mobs.zombie_horse.spawn-chance", zombieHorseSpawnChance);
          zombieHorseTakeDamageFromWater = getBoolean("mobs.zombie_horse.takes-damage-from-water", zombieHorseTakeDamageFromWater);
@@ -2272,7 +2272,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean zombieVillagerRidable = false;
-@@ -2804,6 +2944,7 @@ public class PurpurWorldConfig {
+@@ -2806,6 +2946,7 @@ public class PurpurWorldConfig {
      public int zombieVillagerCuringTimeMin = 3600;
      public int zombieVillagerCuringTimeMax = 6000;
      public boolean zombieVillagerCureEnabled = true;
@@ -2280,7 +2280,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void zombieVillagerSettings() {
          zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
          zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
-@@ -2822,6 +2963,7 @@ public class PurpurWorldConfig {
+@@ -2824,6 +2965,7 @@ public class PurpurWorldConfig {
          zombieVillagerCuringTimeMin = getInt("mobs.zombie_villager.curing_time.min", zombieVillagerCuringTimeMin);
          zombieVillagerCuringTimeMax = getInt("mobs.zombie_villager.curing_time.max", zombieVillagerCuringTimeMax);
          zombieVillagerCureEnabled = getBoolean("mobs.zombie_villager.cure.enabled", zombieVillagerCureEnabled);
@@ -2288,7 +2288,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      }
  
      public boolean zombifiedPiglinRidable = false;
-@@ -2834,6 +2976,7 @@ public class PurpurWorldConfig {
+@@ -2836,6 +2978,7 @@ public class PurpurWorldConfig {
      public boolean zombifiedPiglinJockeyTryExistingChickens = true;
      public boolean zombifiedPiglinCountAsPlayerKillWhenAngry = true;
      public boolean zombifiedPiglinTakeDamageFromWater = false;
@@ -2296,7 +2296,7 @@ index 80462267cc43e5f66acc2fb1e0b48fd5848127a4..5f91c7decdda55135eaee84c53a614db
      private void zombifiedPiglinSettings() {
          zombifiedPiglinRidable = getBoolean("mobs.zombified_piglin.ridable", zombifiedPiglinRidable);
          zombifiedPiglinRidableInWater = getBoolean("mobs.zombified_piglin.ridable-in-water", zombifiedPiglinRidableInWater);
-@@ -2850,6 +2993,7 @@ public class PurpurWorldConfig {
+@@ -2852,6 +2995,7 @@ public class PurpurWorldConfig {
          zombifiedPiglinJockeyTryExistingChickens = getBoolean("mobs.zombified_piglin.jockey.try-existing-chickens", zombifiedPiglinJockeyTryExistingChickens);
          zombifiedPiglinCountAsPlayerKillWhenAngry = getBoolean("mobs.zombified_piglin.count-as-player-kill-when-angry", zombifiedPiglinCountAsPlayerKillWhenAngry);
          zombifiedPiglinTakeDamageFromWater = getBoolean("mobs.zombified_piglin.takes-damage-from-water", zombifiedPiglinTakeDamageFromWater);

--- a/patches/server/0233-Ability-for-hoe-to-replant-crops-and-nether-warts.patch
+++ b/patches/server/0233-Ability-for-hoe-to-replant-crops-and-nether-warts.patch
@@ -74,10 +74,10 @@ index e55720c4d2fbdf6aae526910e87a67c29cf906fd..0e4026e9d39735b840f12e59f84469b9
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index cc5b1dfd4f28823a40185ea70928a5b90a3e9835..d3fd9a7ad777543811d95044ed461d26ba9c1195 100644
+index 5f91c7decdda55135eaee84c53a614dbd4f33547..9cf06ce6040c2fe79a68e7afb9f5272492a16209 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -555,6 +555,8 @@ public class PurpurWorldConfig {
+@@ -557,6 +557,8 @@ public class PurpurWorldConfig {
      public Map<Block, Waxable> axeWaxables = new HashMap<>();
      public Map<Block, Weatherable> axeWeatherables = new HashMap<>();
      public Map<Block, Tillable> hoeTillables = new HashMap<>();
@@ -86,7 +86,7 @@ index cc5b1dfd4f28823a40185ea70928a5b90a3e9835..d3fd9a7ad777543811d95044ed461d26
      private void toolSettings() {
          axeStrippables.clear();
          axeWaxables.clear();
-@@ -702,6 +704,8 @@ public class PurpurWorldConfig {
+@@ -704,6 +706,8 @@ public class PurpurWorldConfig {
              });
              hoeTillables.put(block, new Tillable(condition, into, drops));
          });

--- a/patches/server/0233-Ability-for-hoe-to-replant-crops-and-nether-warts.patch
+++ b/patches/server/0233-Ability-for-hoe-to-replant-crops-and-nether-warts.patch
@@ -74,10 +74,10 @@ index e55720c4d2fbdf6aae526910e87a67c29cf906fd..0e4026e9d39735b840f12e59f84469b9
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5f91c7decdda55135eaee84c53a614dbd4f33547..9cf06ce6040c2fe79a68e7afb9f5272492a16209 100644
+index 599328c1adb0f285d32f41f4f5f2949003416179..ee8ff3e63f7b91804a75a49ac242013c12503b62 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -557,6 +557,8 @@ public class PurpurWorldConfig {
+@@ -559,6 +559,8 @@ public class PurpurWorldConfig {
      public Map<Block, Waxable> axeWaxables = new HashMap<>();
      public Map<Block, Weatherable> axeWeatherables = new HashMap<>();
      public Map<Block, Tillable> hoeTillables = new HashMap<>();
@@ -86,7 +86,7 @@ index 5f91c7decdda55135eaee84c53a614dbd4f33547..9cf06ce6040c2fe79a68e7afb9f52724
      private void toolSettings() {
          axeStrippables.clear();
          axeWaxables.clear();
-@@ -704,6 +706,8 @@ public class PurpurWorldConfig {
+@@ -706,6 +708,8 @@ public class PurpurWorldConfig {
              });
              hoeTillables.put(block, new Tillable(condition, into, drops));
          });

--- a/patches/server/0234-Shearing-jeb-produces-random-color-wool.patch
+++ b/patches/server/0234-Shearing-jeb-produces-random-color-wool.patch
@@ -18,10 +18,10 @@ index 507526b0961f0f22f6ac67d60bb1de039d1ccf10..f168b84507a821f279a3341460dbd8dc
  
              if (entityitem != null) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9cf06ce6040c2fe79a68e7afb9f5272492a16209..847c72817d97b7cf8f00032ef91331b3d8ebc9df 100644
+index ee8ff3e63f7b91804a75a49ac242013c12503b62..133d2c70ee57ff59726be47982d8744a6c728970 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2265,6 +2265,7 @@ public class PurpurWorldConfig {
+@@ -2267,6 +2267,7 @@ public class PurpurWorldConfig {
      public boolean sheepBypassMobGriefing = false;
      public boolean sheepTakeDamageFromWater = false;
      public boolean sheepAlwaysDropExp = false;
@@ -29,7 +29,7 @@ index 9cf06ce6040c2fe79a68e7afb9f5272492a16209..847c72817d97b7cf8f00032ef91331b3
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -2279,6 +2280,7 @@ public class PurpurWorldConfig {
+@@ -2281,6 +2282,7 @@ public class PurpurWorldConfig {
          sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
          sheepTakeDamageFromWater = getBoolean("mobs.sheep.takes-damage-from-water", sheepTakeDamageFromWater);
          sheepAlwaysDropExp = getBoolean("mobs.sheep.always-drop-exp", sheepAlwaysDropExp);

--- a/patches/server/0234-Shearing-jeb-produces-random-color-wool.patch
+++ b/patches/server/0234-Shearing-jeb-produces-random-color-wool.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Shearing jeb produces random color wool
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Sheep.java b/src/main/java/net/minecraft/world/entity/animal/Sheep.java
-index 411fa176dd1b6368437da593140204fdec7721f8..004552b0730a2b35e6a2c973a9f9f8fa9e487967 100644
+index 507526b0961f0f22f6ac67d60bb1de039d1ccf10..f168b84507a821f279a3341460dbd8dce0a5569c 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Sheep.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Sheep.java
 @@ -314,7 +314,7 @@ public class Sheep extends Animal implements Shearable {
@@ -18,10 +18,10 @@ index 411fa176dd1b6368437da593140204fdec7721f8..004552b0730a2b35e6a2c973a9f9f8fa
  
              if (entityitem != null) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d3fd9a7ad777543811d95044ed461d26ba9c1195..32701d1c4456059b61a034879bd837e5b27b8f50 100644
+index 9cf06ce6040c2fe79a68e7afb9f5272492a16209..847c72817d97b7cf8f00032ef91331b3d8ebc9df 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2263,6 +2263,7 @@ public class PurpurWorldConfig {
+@@ -2265,6 +2265,7 @@ public class PurpurWorldConfig {
      public boolean sheepBypassMobGriefing = false;
      public boolean sheepTakeDamageFromWater = false;
      public boolean sheepAlwaysDropExp = false;
@@ -29,7 +29,7 @@ index d3fd9a7ad777543811d95044ed461d26ba9c1195..32701d1c4456059b61a034879bd837e5
      private void sheepSettings() {
          sheepRidable = getBoolean("mobs.sheep.ridable", sheepRidable);
          sheepRidableInWater = getBoolean("mobs.sheep.ridable-in-water", sheepRidableInWater);
-@@ -2277,6 +2278,7 @@ public class PurpurWorldConfig {
+@@ -2279,6 +2280,7 @@ public class PurpurWorldConfig {
          sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
          sheepTakeDamageFromWater = getBoolean("mobs.sheep.takes-damage-from-water", sheepTakeDamageFromWater);
          sheepAlwaysDropExp = getBoolean("mobs.sheep.always-drop-exp", sheepAlwaysDropExp);

--- a/patches/server/0235-Turtle-eggs-random-tick-crack-chance.patch
+++ b/patches/server/0235-Turtle-eggs-random-tick-crack-chance.patch
@@ -18,10 +18,10 @@ index 7495e0e8beedad59fff24ebf189b58b307f7d796..70997b83fd7631ebf3c5bda67ef77bef
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 32701d1c4456059b61a034879bd837e5b27b8f50..077c1769df4dbebfe5d0c5759b9766d12ee8b601 100644
+index 847c72817d97b7cf8f00032ef91331b3d8ebc9df..ce8ceab972f2f7fe498dd6152ce123cf7e39e464 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -982,11 +982,13 @@ public class PurpurWorldConfig {
+@@ -984,11 +984,13 @@ public class PurpurWorldConfig {
      public boolean turtleEggsBreakFromItems = true;
      public boolean turtleEggsBreakFromMinecarts = true;
      public boolean turtleEggsBypassMobGriefing = false;

--- a/patches/server/0235-Turtle-eggs-random-tick-crack-chance.patch
+++ b/patches/server/0235-Turtle-eggs-random-tick-crack-chance.patch
@@ -18,10 +18,10 @@ index 7495e0e8beedad59fff24ebf189b58b307f7d796..70997b83fd7631ebf3c5bda67ef77bef
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 847c72817d97b7cf8f00032ef91331b3d8ebc9df..ce8ceab972f2f7fe498dd6152ce123cf7e39e464 100644
+index 133d2c70ee57ff59726be47982d8744a6c728970..d380c5881400bdddb75f2bff98d9230ad404b961 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -984,11 +984,13 @@ public class PurpurWorldConfig {
+@@ -986,11 +986,13 @@ public class PurpurWorldConfig {
      public boolean turtleEggsBreakFromItems = true;
      public boolean turtleEggsBreakFromMinecarts = true;
      public boolean turtleEggsBypassMobGriefing = false;

--- a/patches/server/0236-Mob-head-visibility-percent.patch
+++ b/patches/server/0236-Mob-head-visibility-percent.patch
@@ -32,10 +32,10 @@ index 10dbf4f3fb5b5acb87496c0f06da1d29f7a26521..6da57caf6ed0deb17bb99d0ba0a7344f
              // Purpur start
              if (entity instanceof LivingEntity entityliving) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f2b9ad0a778390e4de54075be0f4404260349c4d..004936fc906b0c463625d780341d3da4ef80c9c3 100644
+index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cfc41169df 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1265,6 +1265,7 @@ public class PurpurWorldConfig {
+@@ -1267,6 +1267,7 @@ public class PurpurWorldConfig {
      public boolean creeperExplodeWhenKilled = false;
      public boolean creeperHealthRadius = false;
      public boolean creeperAlwaysDropExp = false;
@@ -43,7 +43,7 @@ index f2b9ad0a778390e4de54075be0f4404260349c4d..004936fc906b0c463625d780341d3da4
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1282,6 +1283,7 @@ public class PurpurWorldConfig {
+@@ -1284,6 +1285,7 @@ public class PurpurWorldConfig {
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
          creeperAlwaysDropExp = getBoolean("mobs.creeper.always-drop-exp", creeperAlwaysDropExp);
@@ -51,7 +51,7 @@ index f2b9ad0a778390e4de54075be0f4404260349c4d..004936fc906b0c463625d780341d3da4
      }
  
      public boolean dolphinRidable = false;
-@@ -2068,6 +2070,7 @@ public class PurpurWorldConfig {
+@@ -2070,6 +2072,7 @@ public class PurpurWorldConfig {
      public boolean piglinTakeDamageFromWater = false;
      public int piglinPortalSpawnModifier = 2000;
      public boolean piglinAlwaysDropExp = false;
@@ -59,7 +59,7 @@ index f2b9ad0a778390e4de54075be0f4404260349c4d..004936fc906b0c463625d780341d3da4
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -2082,6 +2085,7 @@ public class PurpurWorldConfig {
+@@ -2084,6 +2087,7 @@ public class PurpurWorldConfig {
          piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);
          piglinPortalSpawnModifier = getInt("mobs.piglin.portal-spawn-modifier", piglinPortalSpawnModifier);
          piglinAlwaysDropExp = getBoolean("mobs.piglin.always-drop-exp", piglinAlwaysDropExp);
@@ -67,7 +67,7 @@ index f2b9ad0a778390e4de54075be0f4404260349c4d..004936fc906b0c463625d780341d3da4
      }
  
      public boolean piglinBruteRidable = false;
-@@ -2343,6 +2347,7 @@ public class PurpurWorldConfig {
+@@ -2345,6 +2349,7 @@ public class PurpurWorldConfig {
      public double skeletonMaxHealth = 20.0D;
      public boolean skeletonTakeDamageFromWater = false;
      public boolean skeletonAlwaysDropExp = false;
@@ -75,7 +75,7 @@ index f2b9ad0a778390e4de54075be0f4404260349c4d..004936fc906b0c463625d780341d3da4
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2355,6 +2360,7 @@ public class PurpurWorldConfig {
+@@ -2357,6 +2362,7 @@ public class PurpurWorldConfig {
          skeletonMaxHealth = getDouble("mobs.skeleton.attributes.max_health", skeletonMaxHealth);
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
@@ -83,7 +83,7 @@ index f2b9ad0a778390e4de54075be0f4404260349c4d..004936fc906b0c463625d780341d3da4
      }
  
      public boolean skeletonHorseRidableInWater = true;
-@@ -2887,6 +2893,7 @@ public class PurpurWorldConfig {
+@@ -2889,6 +2895,7 @@ public class PurpurWorldConfig {
      public boolean zombieBypassMobGriefing = false;
      public boolean zombieTakeDamageFromWater = false;
      public boolean zombieAlwaysDropExp = false;
@@ -91,7 +91,7 @@ index f2b9ad0a778390e4de54075be0f4404260349c4d..004936fc906b0c463625d780341d3da4
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -2905,6 +2912,7 @@ public class PurpurWorldConfig {
+@@ -2907,6 +2914,7 @@ public class PurpurWorldConfig {
          zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
          zombieTakeDamageFromWater = getBoolean("mobs.zombie.takes-damage-from-water", zombieTakeDamageFromWater);
          zombieAlwaysDropExp = getBoolean("mobs.zombie.always-drop-exp", zombieAlwaysDropExp);

--- a/patches/server/0236-Mob-head-visibility-percent.patch
+++ b/patches/server/0236-Mob-head-visibility-percent.patch
@@ -32,10 +32,10 @@ index 10dbf4f3fb5b5acb87496c0f06da1d29f7a26521..6da57caf6ed0deb17bb99d0ba0a7344f
              // Purpur start
              if (entity instanceof LivingEntity entityliving) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cfc41169df 100644
+index d380c5881400bdddb75f2bff98d9230ad404b961..3635da728b6444a05a5eaf378f04ad3a6f3cb0a5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1267,6 +1267,7 @@ public class PurpurWorldConfig {
+@@ -1269,6 +1269,7 @@ public class PurpurWorldConfig {
      public boolean creeperExplodeWhenKilled = false;
      public boolean creeperHealthRadius = false;
      public boolean creeperAlwaysDropExp = false;
@@ -43,7 +43,7 @@ index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cf
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1284,6 +1285,7 @@ public class PurpurWorldConfig {
+@@ -1286,6 +1287,7 @@ public class PurpurWorldConfig {
          creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
          creeperAlwaysDropExp = getBoolean("mobs.creeper.always-drop-exp", creeperAlwaysDropExp);
@@ -51,7 +51,7 @@ index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cf
      }
  
      public boolean dolphinRidable = false;
-@@ -2070,6 +2072,7 @@ public class PurpurWorldConfig {
+@@ -2072,6 +2074,7 @@ public class PurpurWorldConfig {
      public boolean piglinTakeDamageFromWater = false;
      public int piglinPortalSpawnModifier = 2000;
      public boolean piglinAlwaysDropExp = false;
@@ -59,7 +59,7 @@ index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cf
      private void piglinSettings() {
          piglinRidable = getBoolean("mobs.piglin.ridable", piglinRidable);
          piglinRidableInWater = getBoolean("mobs.piglin.ridable-in-water", piglinRidableInWater);
-@@ -2084,6 +2087,7 @@ public class PurpurWorldConfig {
+@@ -2086,6 +2089,7 @@ public class PurpurWorldConfig {
          piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);
          piglinPortalSpawnModifier = getInt("mobs.piglin.portal-spawn-modifier", piglinPortalSpawnModifier);
          piglinAlwaysDropExp = getBoolean("mobs.piglin.always-drop-exp", piglinAlwaysDropExp);
@@ -67,7 +67,7 @@ index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cf
      }
  
      public boolean piglinBruteRidable = false;
-@@ -2345,6 +2349,7 @@ public class PurpurWorldConfig {
+@@ -2347,6 +2351,7 @@ public class PurpurWorldConfig {
      public double skeletonMaxHealth = 20.0D;
      public boolean skeletonTakeDamageFromWater = false;
      public boolean skeletonAlwaysDropExp = false;
@@ -75,7 +75,7 @@ index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cf
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2357,6 +2362,7 @@ public class PurpurWorldConfig {
+@@ -2359,6 +2364,7 @@ public class PurpurWorldConfig {
          skeletonMaxHealth = getDouble("mobs.skeleton.attributes.max_health", skeletonMaxHealth);
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
@@ -83,7 +83,7 @@ index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cf
      }
  
      public boolean skeletonHorseRidableInWater = true;
-@@ -2889,6 +2895,7 @@ public class PurpurWorldConfig {
+@@ -2891,6 +2897,7 @@ public class PurpurWorldConfig {
      public boolean zombieBypassMobGriefing = false;
      public boolean zombieTakeDamageFromWater = false;
      public boolean zombieAlwaysDropExp = false;
@@ -91,7 +91,7 @@ index ce8ceab972f2f7fe498dd6152ce123cf7e39e464..112e08f8c8f5daffa0017ede32d752cf
      private void zombieSettings() {
          zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
          zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
-@@ -2907,6 +2914,7 @@ public class PurpurWorldConfig {
+@@ -2909,6 +2916,7 @@ public class PurpurWorldConfig {
          zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
          zombieTakeDamageFromWater = getBoolean("mobs.zombie.takes-damage-from-water", zombieTakeDamageFromWater);
          zombieAlwaysDropExp = getBoolean("mobs.zombie.always-drop-exp", zombieAlwaysDropExp);

--- a/patches/server/0239-Stop-bees-from-dying-after-stinging.patch
+++ b/patches/server/0239-Stop-bees-from-dying-after-stinging.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Stop bees from dying after stinging
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Bee.java b/src/main/java/net/minecraft/world/entity/animal/Bee.java
-index 2c3967d2b9d3e7999def21af521bfc443f50c02f..7d7f95d8197214505a8309f947aba1a7c8b780e4 100644
+index d87b3bca72d4e4866d41053b47adb96555851b3a..0660eb12f47f02cfff9ded1cdb965acbacb0d077 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Bee.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Bee.java
 @@ -455,6 +455,7 @@ public class Bee extends Animal implements NeutralMob, FlyingAnimal {
@@ -17,10 +17,10 @@ index 2c3967d2b9d3e7999def21af521bfc443f50c02f..7d7f95d8197214505a8309f947aba1a7
              ++this.timeSinceSting;
              if (this.timeSinceSting % 5 == 0 && this.random.nextInt(Mth.clamp(1200 - this.timeSinceSting, 1, 1200)) == 0) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 559c010dcb476ba7a54b64550a384634180c2a09..c8c1b23c2a3147c236ed1d71a64703697ad7e91f 100644
+index 112e08f8c8f5daffa0017ede32d752cfc41169df..af4e8db58db86e409125e4168984fbdd38ed5448 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1068,6 +1068,7 @@ public class PurpurWorldConfig {
+@@ -1070,6 +1070,7 @@ public class PurpurWorldConfig {
      public boolean beeCanWorkAtNight = false;
      public boolean beeCanWorkInRain = false;
      public boolean beeAlwaysDropExp = false;
@@ -28,7 +28,7 @@ index 559c010dcb476ba7a54b64550a384634180c2a09..c8c1b23c2a3147c236ed1d71a6470369
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -1084,6 +1085,7 @@ public class PurpurWorldConfig {
+@@ -1086,6 +1087,7 @@ public class PurpurWorldConfig {
          beeCanWorkAtNight = getBoolean("mobs.bee.can-work-at-night", beeCanWorkAtNight);
          beeCanWorkInRain = getBoolean("mobs.bee.can-work-in-rain", beeCanWorkInRain);
          beeAlwaysDropExp = getBoolean("mobs.bee.always-drop-exp", beeAlwaysDropExp);

--- a/patches/server/0239-Stop-bees-from-dying-after-stinging.patch
+++ b/patches/server/0239-Stop-bees-from-dying-after-stinging.patch
@@ -17,10 +17,10 @@ index d87b3bca72d4e4866d41053b47adb96555851b3a..0660eb12f47f02cfff9ded1cdb965acb
              ++this.timeSinceSting;
              if (this.timeSinceSting % 5 == 0 && this.random.nextInt(Mth.clamp(1200 - this.timeSinceSting, 1, 1200)) == 0) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 112e08f8c8f5daffa0017ede32d752cfc41169df..af4e8db58db86e409125e4168984fbdd38ed5448 100644
+index 3635da728b6444a05a5eaf378f04ad3a6f3cb0a5..3da3083ed4603590751602c4d9baf79db8c52181 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1070,6 +1070,7 @@ public class PurpurWorldConfig {
+@@ -1072,6 +1072,7 @@ public class PurpurWorldConfig {
      public boolean beeCanWorkAtNight = false;
      public boolean beeCanWorkInRain = false;
      public boolean beeAlwaysDropExp = false;
@@ -28,7 +28,7 @@ index 112e08f8c8f5daffa0017ede32d752cfc41169df..af4e8db58db86e409125e4168984fbdd
      private void beeSettings() {
          beeRidable = getBoolean("mobs.bee.ridable", beeRidable);
          beeRidableInWater = getBoolean("mobs.bee.ridable-in-water", beeRidableInWater);
-@@ -1086,6 +1087,7 @@ public class PurpurWorldConfig {
+@@ -1088,6 +1089,7 @@ public class PurpurWorldConfig {
          beeCanWorkAtNight = getBoolean("mobs.bee.can-work-at-night", beeCanWorkAtNight);
          beeCanWorkInRain = getBoolean("mobs.bee.can-work-in-rain", beeCanWorkInRain);
          beeAlwaysDropExp = getBoolean("mobs.bee.always-drop-exp", beeAlwaysDropExp);

--- a/patches/server/0241-Configurable-farmland-trample-height.patch
+++ b/patches/server/0241-Configurable-farmland-trample-height.patch
@@ -35,10 +35,10 @@ index eed062c9cf1103d7ac96695e3620d4276edcd2aa..69cc276fecd4cac51d38bd3cc7de490a
              org.bukkit.event.Cancellable cancellable;
              if (entity instanceof Player) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index c8c1b23c2a3147c236ed1d71a64703697ad7e91f..5de3a54fa24576b0badb77cd08a97d9c7f63afa8 100644
+index af4e8db58db86e409125e4168984fbdd38ed5448..5b61421e1e02240ee44ded03d2e503e50517e49f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -860,6 +860,7 @@ public class PurpurWorldConfig {
+@@ -862,6 +862,7 @@ public class PurpurWorldConfig {
      public boolean farmlandTramplingDisabled = false;
      public boolean farmlandTramplingOnlyPlayers = false;
      public boolean farmlandTramplingFeatherFalling = false;
@@ -46,7 +46,7 @@ index c8c1b23c2a3147c236ed1d71a64703697ad7e91f..5de3a54fa24576b0badb77cd08a97d9c
      private void farmlandSettings() {
          farmlandBypassMobGriefing = getBoolean("blocks.farmland.bypass-mob-griefing", farmlandBypassMobGriefing);
          farmlandGetsMoistFromBelow = getBoolean("blocks.farmland.gets-moist-from-below", farmlandGetsMoistFromBelow);
-@@ -867,6 +868,7 @@ public class PurpurWorldConfig {
+@@ -869,6 +870,7 @@ public class PurpurWorldConfig {
          farmlandTramplingDisabled = getBoolean("blocks.farmland.disable-trampling", farmlandTramplingDisabled);
          farmlandTramplingOnlyPlayers = getBoolean("blocks.farmland.only-players-trample", farmlandTramplingOnlyPlayers);
          farmlandTramplingFeatherFalling = getBoolean("blocks.farmland.feather-fall-distance-affects-trampling", farmlandTramplingFeatherFalling);

--- a/patches/server/0241-Configurable-farmland-trample-height.patch
+++ b/patches/server/0241-Configurable-farmland-trample-height.patch
@@ -35,10 +35,10 @@ index eed062c9cf1103d7ac96695e3620d4276edcd2aa..69cc276fecd4cac51d38bd3cc7de490a
              org.bukkit.event.Cancellable cancellable;
              if (entity instanceof Player) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index af4e8db58db86e409125e4168984fbdd38ed5448..5b61421e1e02240ee44ded03d2e503e50517e49f 100644
+index 3da3083ed4603590751602c4d9baf79db8c52181..de89176bf6ab9311fbd5572795afc0361894615a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -862,6 +862,7 @@ public class PurpurWorldConfig {
+@@ -864,6 +864,7 @@ public class PurpurWorldConfig {
      public boolean farmlandTramplingDisabled = false;
      public boolean farmlandTramplingOnlyPlayers = false;
      public boolean farmlandTramplingFeatherFalling = false;
@@ -46,7 +46,7 @@ index af4e8db58db86e409125e4168984fbdd38ed5448..5b61421e1e02240ee44ded03d2e503e5
      private void farmlandSettings() {
          farmlandBypassMobGriefing = getBoolean("blocks.farmland.bypass-mob-griefing", farmlandBypassMobGriefing);
          farmlandGetsMoistFromBelow = getBoolean("blocks.farmland.gets-moist-from-below", farmlandGetsMoistFromBelow);
-@@ -869,6 +870,7 @@ public class PurpurWorldConfig {
+@@ -871,6 +872,7 @@ public class PurpurWorldConfig {
          farmlandTramplingDisabled = getBoolean("blocks.farmland.disable-trampling", farmlandTramplingDisabled);
          farmlandTramplingOnlyPlayers = getBoolean("blocks.farmland.only-players-trample", farmlandTramplingOnlyPlayers);
          farmlandTramplingFeatherFalling = getBoolean("blocks.farmland.feather-fall-distance-affects-trampling", farmlandTramplingFeatherFalling);

--- a/patches/server/0242-Configurable-player-pickup-exp-delay.patch
+++ b/patches/server/0242-Configurable-player-pickup-exp-delay.patch
@@ -24,7 +24,7 @@ index 7043f15f84d6c847bf376025c8e2150bdf650457..df8d8f85f8db396b7db9fa6e46aa55c9
                  int i = this.repairPlayerItems(player, this.value);
  
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index bc6aef5141ce87e96d2c267ad10a12fc2858a186..e61f7ab7fb711e2567ddae4bf7580d9d26aa6037 100644
+index 8e088b2a9b10ca0f1188469a7dd360b209cdde87..cac03bf0c4fc0f4936e3d3eb6bfd9315a2bfdace 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -624,7 +624,7 @@ public abstract class Player extends LivingEntity {
@@ -37,10 +37,10 @@ index bc6aef5141ce87e96d2c267ad10a12fc2858a186..e61f7ab7fb711e2567ddae4bf7580d9d
                  } else if (!entity.isRemoved()) {
                      this.touch(entity);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5de3a54fa24576b0badb77cd08a97d9c7f63afa8..e2c06ca454ea6dc56f24a3848f5cd14997185ab1 100644
+index 5b61421e1e02240ee44ded03d2e503e50517e49f..1c760d685caf17bc31dae14c710524791b960eb6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -420,6 +420,7 @@ public class PurpurWorldConfig {
+@@ -422,6 +422,7 @@ public class PurpurWorldConfig {
      public boolean playerRidableInWater = false;
      public boolean playerRemoveBindingWithWeakness = false;
      public int shiftRightClickRepairsMendingPoints = 0;
@@ -48,7 +48,7 @@ index 5de3a54fa24576b0badb77cd08a97d9c7f63afa8..e2c06ca454ea6dc56f24a3848f5cd149
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -447,6 +448,7 @@ public class PurpurWorldConfig {
+@@ -449,6 +450,7 @@ public class PurpurWorldConfig {
          playerRidableInWater = getBoolean("gameplay-mechanics.player.ridable-in-water", playerRidableInWater);
          playerRemoveBindingWithWeakness = getBoolean("gameplay-mechanics.player.curse-of-binding.remove-with-weakness", playerRemoveBindingWithWeakness);
          shiftRightClickRepairsMendingPoints = getInt("gameplay-mechanics.player.shift-right-click-repairs-mending-points", shiftRightClickRepairsMendingPoints);

--- a/patches/server/0242-Configurable-player-pickup-exp-delay.patch
+++ b/patches/server/0242-Configurable-player-pickup-exp-delay.patch
@@ -37,10 +37,10 @@ index 8e088b2a9b10ca0f1188469a7dd360b209cdde87..cac03bf0c4fc0f4936e3d3eb6bfd9315
                  } else if (!entity.isRemoved()) {
                      this.touch(entity);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5b61421e1e02240ee44ded03d2e503e50517e49f..1c760d685caf17bc31dae14c710524791b960eb6 100644
+index de89176bf6ab9311fbd5572795afc0361894615a..d247051a1023474e7524554767a0d4551c3c164c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -422,6 +422,7 @@ public class PurpurWorldConfig {
+@@ -424,6 +424,7 @@ public class PurpurWorldConfig {
      public boolean playerRidableInWater = false;
      public boolean playerRemoveBindingWithWeakness = false;
      public int shiftRightClickRepairsMendingPoints = 0;
@@ -48,7 +48,7 @@ index 5b61421e1e02240ee44ded03d2e503e50517e49f..1c760d685caf17bc31dae14c71052479
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -449,6 +450,7 @@ public class PurpurWorldConfig {
+@@ -451,6 +452,7 @@ public class PurpurWorldConfig {
          playerRidableInWater = getBoolean("gameplay-mechanics.player.ridable-in-water", playerRidableInWater);
          playerRemoveBindingWithWeakness = getBoolean("gameplay-mechanics.player.curse-of-binding.remove-with-weakness", playerRemoveBindingWithWeakness);
          shiftRightClickRepairsMendingPoints = getInt("gameplay-mechanics.player.shift-right-click-repairs-mending-points", shiftRightClickRepairsMendingPoints);

--- a/patches/server/0243-Allow-void-trading.patch
+++ b/patches/server/0243-Allow-void-trading.patch
@@ -18,10 +18,10 @@ index 59d07b07ea81e5462ff7e57c6bc9e6f8d7213b79..2d61a0c7dfeb868403d64abbf847121f
                  }
                  // Paper end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e2c06ca454ea6dc56f24a3848f5cd14997185ab1..abed53c92f4face32811aa0979c595cbd34d4901 100644
+index 1c760d685caf17bc31dae14c710524791b960eb6..82eb4f60bc51196414a83ea7124d8002677c9ac6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -421,6 +421,7 @@ public class PurpurWorldConfig {
+@@ -423,6 +423,7 @@ public class PurpurWorldConfig {
      public boolean playerRemoveBindingWithWeakness = false;
      public int shiftRightClickRepairsMendingPoints = 0;
      public int playerExpPickupDelay = 2;
@@ -29,7 +29,7 @@ index e2c06ca454ea6dc56f24a3848f5cd14997185ab1..abed53c92f4face32811aa0979c595cb
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -449,6 +450,7 @@ public class PurpurWorldConfig {
+@@ -451,6 +452,7 @@ public class PurpurWorldConfig {
          playerRemoveBindingWithWeakness = getBoolean("gameplay-mechanics.player.curse-of-binding.remove-with-weakness", playerRemoveBindingWithWeakness);
          shiftRightClickRepairsMendingPoints = getInt("gameplay-mechanics.player.shift-right-click-repairs-mending-points", shiftRightClickRepairsMendingPoints);
          playerExpPickupDelay = getInt("gameplay-mechanics.player.exp-pickup-delay-ticks", playerExpPickupDelay);

--- a/patches/server/0243-Allow-void-trading.patch
+++ b/patches/server/0243-Allow-void-trading.patch
@@ -18,10 +18,10 @@ index 59d07b07ea81e5462ff7e57c6bc9e6f8d7213b79..2d61a0c7dfeb868403d64abbf847121f
                  }
                  // Paper end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1c760d685caf17bc31dae14c710524791b960eb6..82eb4f60bc51196414a83ea7124d8002677c9ac6 100644
+index d247051a1023474e7524554767a0d4551c3c164c..14167b1123cc085bd91dc9ad2a6ad8e96676ccba 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -423,6 +423,7 @@ public class PurpurWorldConfig {
+@@ -425,6 +425,7 @@ public class PurpurWorldConfig {
      public boolean playerRemoveBindingWithWeakness = false;
      public int shiftRightClickRepairsMendingPoints = 0;
      public int playerExpPickupDelay = 2;
@@ -29,7 +29,7 @@ index 1c760d685caf17bc31dae14c710524791b960eb6..82eb4f60bc51196414a83ea7124d8002
      private void playerSettings() {
          if (PurpurConfig.version < 19) {
              boolean oldVal = getBoolean("gameplay-mechanics.player.idle-timeout.mods-target", idleTimeoutTargetPlayer);
-@@ -451,6 +452,7 @@ public class PurpurWorldConfig {
+@@ -453,6 +454,7 @@ public class PurpurWorldConfig {
          playerRemoveBindingWithWeakness = getBoolean("gameplay-mechanics.player.curse-of-binding.remove-with-weakness", playerRemoveBindingWithWeakness);
          shiftRightClickRepairsMendingPoints = getInt("gameplay-mechanics.player.shift-right-click-repairs-mending-points", shiftRightClickRepairsMendingPoints);
          playerExpPickupDelay = getInt("gameplay-mechanics.player.exp-pickup-delay-ticks", playerExpPickupDelay);

--- a/patches/server/0245-Configurable-phantom-size.patch
+++ b/patches/server/0245-Configurable-phantom-size.patch
@@ -22,10 +22,10 @@ index 87ebdf7f5126365d112b1ea91b8202a036637f09..6c157dfc2f730d1a8afbc0a37f247305
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 98eb6672911f9fb1aec63c1a352b1dfef69e7ad5..b76778dde88408667e43c0ea54906051157067b0 100644
+index 82eb4f60bc51196414a83ea7124d8002677c9ac6..48e82ed302ad43bc6dc5ca71ad402f4849ab340f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2008,6 +2008,8 @@ public class PurpurWorldConfig {
+@@ -2010,6 +2010,8 @@ public class PurpurWorldConfig {
      public boolean phantomFlamesOnSwoop = false;
      public boolean phantomTakeDamageFromWater = false;
      public boolean phantomAlwaysDropExp = false;
@@ -34,7 +34,7 @@ index 98eb6672911f9fb1aec63c1a352b1dfef69e7ad5..b76778dde88408667e43c0ea54906051
      private void phantomSettings() {
          phantomRidable = getBoolean("mobs.phantom.ridable", phantomRidable);
          phantomRidableInWater = getBoolean("mobs.phantom.ridable-in-water", phantomRidableInWater);
-@@ -2044,6 +2046,13 @@ public class PurpurWorldConfig {
+@@ -2046,6 +2048,13 @@ public class PurpurWorldConfig {
          phantomFlamesOnSwoop = getBoolean("mobs.phantom.flames-on-swoop", phantomFlamesOnSwoop);
          phantomTakeDamageFromWater = getBoolean("mobs.phantom.takes-damage-from-water", phantomTakeDamageFromWater);
          phantomAlwaysDropExp = getBoolean("mobs.phantom.always-drop-exp", phantomAlwaysDropExp);

--- a/patches/server/0245-Configurable-phantom-size.patch
+++ b/patches/server/0245-Configurable-phantom-size.patch
@@ -22,10 +22,10 @@ index 87ebdf7f5126365d112b1ea91b8202a036637f09..6c157dfc2f730d1a8afbc0a37f247305
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 82eb4f60bc51196414a83ea7124d8002677c9ac6..48e82ed302ad43bc6dc5ca71ad402f4849ab340f 100644
+index 14167b1123cc085bd91dc9ad2a6ad8e96676ccba..9c26165d36bf392767f4e6dfb4d1e813a75d8d30 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2010,6 +2010,8 @@ public class PurpurWorldConfig {
+@@ -2012,6 +2012,8 @@ public class PurpurWorldConfig {
      public boolean phantomFlamesOnSwoop = false;
      public boolean phantomTakeDamageFromWater = false;
      public boolean phantomAlwaysDropExp = false;
@@ -34,7 +34,7 @@ index 82eb4f60bc51196414a83ea7124d8002677c9ac6..48e82ed302ad43bc6dc5ca71ad402f48
      private void phantomSettings() {
          phantomRidable = getBoolean("mobs.phantom.ridable", phantomRidable);
          phantomRidableInWater = getBoolean("mobs.phantom.ridable-in-water", phantomRidableInWater);
-@@ -2046,6 +2048,13 @@ public class PurpurWorldConfig {
+@@ -2048,6 +2050,13 @@ public class PurpurWorldConfig {
          phantomFlamesOnSwoop = getBoolean("mobs.phantom.flames-on-swoop", phantomFlamesOnSwoop);
          phantomTakeDamageFromWater = getBoolean("mobs.phantom.takes-damage-from-water", phantomTakeDamageFromWater);
          phantomAlwaysDropExp = getBoolean("mobs.phantom.always-drop-exp", phantomAlwaysDropExp);

--- a/patches/server/0248-Configurable-minimum-demand-for-trades.patch
+++ b/patches/server/0248-Configurable-minimum-demand-for-trades.patch
@@ -40,10 +40,10 @@ index fd50d1c2435b82215bc5b3fdbe5044d426bc342e..68ffea572045634f1ad67a6954d480e6
  
      public ItemStack assemble() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index db54150501636ed4ea06b271f3041787933ec2b4..d8e070261c1043a7ec612deb4561b361dbc3939d 100644
+index 48e82ed302ad43bc6dc5ca71ad402f4849ab340f..5cbe91062ea1ad67a745ac942490541993551f2c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2689,6 +2689,7 @@ public class PurpurWorldConfig {
+@@ -2691,6 +2691,7 @@ public class PurpurWorldConfig {
      public boolean villagerTakeDamageFromWater = false;
      public boolean villagerAllowTrading = true;
      public boolean villagerAlwaysDropExp = false;
@@ -51,7 +51,7 @@ index db54150501636ed4ea06b271f3041787933ec2b4..d8e070261c1043a7ec612deb4561b361
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2709,6 +2710,7 @@ public class PurpurWorldConfig {
+@@ -2711,6 +2712,7 @@ public class PurpurWorldConfig {
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
          villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);

--- a/patches/server/0248-Configurable-minimum-demand-for-trades.patch
+++ b/patches/server/0248-Configurable-minimum-demand-for-trades.patch
@@ -40,10 +40,10 @@ index fd50d1c2435b82215bc5b3fdbe5044d426bc342e..68ffea572045634f1ad67a6954d480e6
  
      public ItemStack assemble() {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 48e82ed302ad43bc6dc5ca71ad402f4849ab340f..5cbe91062ea1ad67a745ac942490541993551f2c 100644
+index 9c26165d36bf392767f4e6dfb4d1e813a75d8d30..e88f55c61d502f691fbeb1ebd0ed31ecbfe0a819 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2691,6 +2691,7 @@ public class PurpurWorldConfig {
+@@ -2693,6 +2693,7 @@ public class PurpurWorldConfig {
      public boolean villagerTakeDamageFromWater = false;
      public boolean villagerAllowTrading = true;
      public boolean villagerAlwaysDropExp = false;
@@ -51,7 +51,7 @@ index 48e82ed302ad43bc6dc5ca71ad402f4849ab340f..5cbe91062ea1ad67a745ac9424905419
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2711,6 +2712,7 @@ public class PurpurWorldConfig {
+@@ -2713,6 +2714,7 @@ public class PurpurWorldConfig {
          villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
          villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);

--- a/patches/server/0249-Lobotomize-stuck-villagers.patch
+++ b/patches/server/0249-Lobotomize-stuck-villagers.patch
@@ -108,10 +108,10 @@ index a1a8ac55e572156671e47317ba061855be79e5ac..ec3fb8865211bd7625103c37af7b96df
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d8e070261c1043a7ec612deb4561b361dbc3939d..bb1f800a4e621b2d283f196e2208a9e4ee2db11f 100644
+index 5cbe91062ea1ad67a745ac942490541993551f2c..aa3a6e5a3f55b942e26ea1b40be6d98d32d8fd4e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2690,6 +2690,8 @@ public class PurpurWorldConfig {
+@@ -2692,6 +2692,8 @@ public class PurpurWorldConfig {
      public boolean villagerAllowTrading = true;
      public boolean villagerAlwaysDropExp = false;
      public int villagerMinimumDemand = 0;
@@ -120,7 +120,7 @@ index d8e070261c1043a7ec612deb4561b361dbc3939d..bb1f800a4e621b2d283f196e2208a9e4
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2711,6 +2713,17 @@ public class PurpurWorldConfig {
+@@ -2713,6 +2715,17 @@ public class PurpurWorldConfig {
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
          villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);
          villagerMinimumDemand = getInt("mobs.villager.minimum-demand", villagerMinimumDemand);

--- a/patches/server/0249-Lobotomize-stuck-villagers.patch
+++ b/patches/server/0249-Lobotomize-stuck-villagers.patch
@@ -108,10 +108,10 @@ index a1a8ac55e572156671e47317ba061855be79e5ac..ec3fb8865211bd7625103c37af7b96df
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5cbe91062ea1ad67a745ac942490541993551f2c..aa3a6e5a3f55b942e26ea1b40be6d98d32d8fd4e 100644
+index e88f55c61d502f691fbeb1ebd0ed31ecbfe0a819..7fd4af2288fcd91d7f845b0a76cdf76d2ca92c3b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2692,6 +2692,8 @@ public class PurpurWorldConfig {
+@@ -2694,6 +2694,8 @@ public class PurpurWorldConfig {
      public boolean villagerAllowTrading = true;
      public boolean villagerAlwaysDropExp = false;
      public int villagerMinimumDemand = 0;
@@ -120,7 +120,7 @@ index 5cbe91062ea1ad67a745ac942490541993551f2c..aa3a6e5a3f55b942e26ea1b40be6d98d
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2713,6 +2715,17 @@ public class PurpurWorldConfig {
+@@ -2715,6 +2717,17 @@ public class PurpurWorldConfig {
          villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
          villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);
          villagerMinimumDemand = getInt("mobs.villager.minimum-demand", villagerMinimumDemand);

--- a/patches/server/0250-Option-for-villager-display-trade-item.patch
+++ b/patches/server/0250-Option-for-villager-display-trade-item.patch
@@ -17,10 +17,10 @@ index 98373e013748817209b811d4adbb40a8787242a6..567b501f4de7556e55e2418d2f5700b4
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index bb1f800a4e621b2d283f196e2208a9e4ee2db11f..f61af2b223f687ec3d64441c37fb6b47c6b513ec 100644
+index aa3a6e5a3f55b942e26ea1b40be6d98d32d8fd4e..7df40442d8b457647170a0cf74ada54e65b7ed9b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2692,6 +2692,7 @@ public class PurpurWorldConfig {
+@@ -2694,6 +2694,7 @@ public class PurpurWorldConfig {
      public int villagerMinimumDemand = 0;
      public boolean villagerLobotomizeEnabled = false;
      public int villagerLobotomizeCheckInterval = 100;
@@ -28,7 +28,7 @@ index bb1f800a4e621b2d283f196e2208a9e4ee2db11f..f61af2b223f687ec3d64441c37fb6b47
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2724,6 +2725,7 @@ public class PurpurWorldConfig {
+@@ -2726,6 +2727,7 @@ public class PurpurWorldConfig {
          }
          villagerLobotomizeEnabled = getBoolean("mobs.villager.lobotomize.enabled", villagerLobotomizeEnabled);
          villagerLobotomizeCheckInterval = getInt("mobs.villager.lobotomize.check-interval", villagerLobotomizeCheckInterval);

--- a/patches/server/0250-Option-for-villager-display-trade-item.patch
+++ b/patches/server/0250-Option-for-villager-display-trade-item.patch
@@ -17,10 +17,10 @@ index 98373e013748817209b811d4adbb40a8787242a6..567b501f4de7556e55e2418d2f5700b4
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index aa3a6e5a3f55b942e26ea1b40be6d98d32d8fd4e..7df40442d8b457647170a0cf74ada54e65b7ed9b 100644
+index 7fd4af2288fcd91d7f845b0a76cdf76d2ca92c3b..ce7d7aafcdd59618c13b7cbb0c037601014db26f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2694,6 +2694,7 @@ public class PurpurWorldConfig {
+@@ -2696,6 +2696,7 @@ public class PurpurWorldConfig {
      public int villagerMinimumDemand = 0;
      public boolean villagerLobotomizeEnabled = false;
      public int villagerLobotomizeCheckInterval = 100;
@@ -28,7 +28,7 @@ index aa3a6e5a3f55b942e26ea1b40be6d98d32d8fd4e..7df40442d8b457647170a0cf74ada54e
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2726,6 +2727,7 @@ public class PurpurWorldConfig {
+@@ -2728,6 +2729,7 @@ public class PurpurWorldConfig {
          }
          villagerLobotomizeEnabled = getBoolean("mobs.villager.lobotomize.enabled", villagerLobotomizeEnabled);
          villagerLobotomizeCheckInterval = getInt("mobs.villager.lobotomize.check-interval", villagerLobotomizeCheckInterval);

--- a/patches/server/0251-MC-238526-Fix-spawner-not-spawning-water-animals-cor.patch
+++ b/patches/server/0251-MC-238526-Fix-spawner-not-spawning-water-animals-cor.patch
@@ -17,10 +17,10 @@ index 35cfa366baf6747105faa93f1220bb9cc31a5bd5..ff3a6755d04f2280a36bd363ab1722e0
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6a94ed9fc3a40b95dfba420935b0103098bcdbc6..a874dbc550040d6f802408661640f8111600bfd4 100644
+index 7df40442d8b457647170a0cf74ada54e65b7ed9b..1b4228f3937f2a4fd6741195233d8e40238066a0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -971,8 +971,10 @@ public class PurpurWorldConfig {
+@@ -973,8 +973,10 @@ public class PurpurWorldConfig {
      }
  
      public boolean spawnerDeactivateByRedstone = false;

--- a/patches/server/0251-MC-238526-Fix-spawner-not-spawning-water-animals-cor.patch
+++ b/patches/server/0251-MC-238526-Fix-spawner-not-spawning-water-animals-cor.patch
@@ -17,10 +17,10 @@ index 35cfa366baf6747105faa93f1220bb9cc31a5bd5..ff3a6755d04f2280a36bd363ab1722e0
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7df40442d8b457647170a0cf74ada54e65b7ed9b..1b4228f3937f2a4fd6741195233d8e40238066a0 100644
+index ce7d7aafcdd59618c13b7cbb0c037601014db26f..dba6e60aa3c998964b64fbb5ac82a58732eeee54 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -973,8 +973,10 @@ public class PurpurWorldConfig {
+@@ -975,8 +975,10 @@ public class PurpurWorldConfig {
      }
  
      public boolean spawnerDeactivateByRedstone = false;

--- a/patches/server/0253-Anvil-repair-damage-options.patch
+++ b/patches/server/0253-Anvil-repair-damage-options.patch
@@ -64,10 +64,10 @@ index 5c5a3b169795bf8a527b316c666cbc2105c66622..020afeca950d2c7fb6c7b179d424548f
              return InteractionResult.SUCCESS;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7125f8af5c76ce43128bb747c9f2cd869117dbe6..100c12b51b1122cc2eea567df575a848ace71f15 100644
+index 507b3ccd38de7cb98e6e7d1c3eaad054f04e9ac3..7d33ef478c41ec3f8994456dc29fab31e8605ce5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -716,9 +716,13 @@ public class PurpurWorldConfig {
+@@ -718,9 +718,13 @@ public class PurpurWorldConfig {
  
      public boolean anvilAllowColors = false;
      public boolean anvilColorsUseMiniMessage;

--- a/patches/server/0253-Anvil-repair-damage-options.patch
+++ b/patches/server/0253-Anvil-repair-damage-options.patch
@@ -64,10 +64,10 @@ index 5c5a3b169795bf8a527b316c666cbc2105c66622..020afeca950d2c7fb6c7b179d424548f
              return InteractionResult.SUCCESS;
          } else {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 507b3ccd38de7cb98e6e7d1c3eaad054f04e9ac3..7d33ef478c41ec3f8994456dc29fab31e8605ce5 100644
+index 5e318050a59db7dbb18f96a176726d9134de4cd6..73d2caf7eccc2c5904f81e6cf9aba2d37f7c5d32 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -718,9 +718,13 @@ public class PurpurWorldConfig {
+@@ -720,9 +720,13 @@ public class PurpurWorldConfig {
  
      public boolean anvilAllowColors = false;
      public boolean anvilColorsUseMiniMessage;

--- a/patches/server/0255-Option-to-disable-turtle-egg-trampling-with-feather-.patch
+++ b/patches/server/0255-Option-to-disable-turtle-egg-trampling-with-feather-.patch
@@ -24,10 +24,10 @@ index 70997b83fd7631ebf3c5bda67ef77bef605eb464..a8c227e2cb62cfa8225798329cde9078
          return world.purpurConfig.turtleEggsBypassMobGriefing || world.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
          // Purpur end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 100c12b51b1122cc2eea567df575a848ace71f15..6167910078b7beb8a8a56e2a5794e8c882fdc6a1 100644
+index 7d33ef478c41ec3f8994456dc29fab31e8605ce5..71aa72fdfe69b0d3d023b993543e9fe3093afb03 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -997,12 +997,14 @@ public class PurpurWorldConfig {
+@@ -999,12 +999,14 @@ public class PurpurWorldConfig {
      public boolean turtleEggsBreakFromMinecarts = true;
      public boolean turtleEggsBypassMobGriefing = false;
      public int turtleEggsRandomTickCrackChance = 500;

--- a/patches/server/0255-Option-to-disable-turtle-egg-trampling-with-feather-.patch
+++ b/patches/server/0255-Option-to-disable-turtle-egg-trampling-with-feather-.patch
@@ -24,10 +24,10 @@ index 70997b83fd7631ebf3c5bda67ef77bef605eb464..a8c227e2cb62cfa8225798329cde9078
          return world.purpurConfig.turtleEggsBypassMobGriefing || world.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
          // Purpur end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7d33ef478c41ec3f8994456dc29fab31e8605ce5..71aa72fdfe69b0d3d023b993543e9fe3093afb03 100644
+index 73d2caf7eccc2c5904f81e6cf9aba2d37f7c5d32..6c0077316aa3fc284d93ad9b21d3e3760ec1e183 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -999,12 +999,14 @@ public class PurpurWorldConfig {
+@@ -1001,12 +1001,14 @@ public class PurpurWorldConfig {
      public boolean turtleEggsBreakFromMinecarts = true;
      public boolean turtleEggsBypassMobGriefing = false;
      public int turtleEggsRandomTickCrackChance = 500;

--- a/patches/server/0258-Implement-configurable-search-radius-for-villagers-t.patch
+++ b/patches/server/0258-Implement-configurable-search-radius-for-villagers-t.patch
@@ -18,10 +18,10 @@ index 45579a592f519b54df5761a22f4abb0deff7feb6..d5fce1215d99de3393d06fdc65939920
              AABB axisalignedbb = this.getBoundingBox().inflate(10.0D, 10.0D, 10.0D);
              List<Villager> list = world.getEntitiesOfClass(Villager.class, axisalignedbb);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 71aa72fdfe69b0d3d023b993543e9fe3093afb03..0aaf18e53434c66425ec9bcd7ab5e2284d02a1a7 100644
+index 6c0077316aa3fc284d93ad9b21d3e3760ec1e183..29ad2bdcc29b3758369acc130517c64d4ce56fa0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2705,6 +2705,8 @@ public class PurpurWorldConfig {
+@@ -2707,6 +2707,8 @@ public class PurpurWorldConfig {
      public boolean villagerLobotomizeEnabled = false;
      public int villagerLobotomizeCheckInterval = 100;
      public boolean villagerDisplayTradeItem = true;
@@ -30,7 +30,7 @@ index 71aa72fdfe69b0d3d023b993543e9fe3093afb03..0aaf18e53434c66425ec9bcd7ab5e228
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2738,6 +2740,8 @@ public class PurpurWorldConfig {
+@@ -2740,6 +2742,8 @@ public class PurpurWorldConfig {
          villagerLobotomizeEnabled = getBoolean("mobs.villager.lobotomize.enabled", villagerLobotomizeEnabled);
          villagerLobotomizeCheckInterval = getInt("mobs.villager.lobotomize.check-interval", villagerLobotomizeCheckInterval);
          villagerDisplayTradeItem = getBoolean("mobs.villager.display-trade-item", villagerDisplayTradeItem);

--- a/patches/server/0258-Implement-configurable-search-radius-for-villagers-t.patch
+++ b/patches/server/0258-Implement-configurable-search-radius-for-villagers-t.patch
@@ -18,10 +18,10 @@ index 45579a592f519b54df5761a22f4abb0deff7feb6..d5fce1215d99de3393d06fdc65939920
              AABB axisalignedbb = this.getBoundingBox().inflate(10.0D, 10.0D, 10.0D);
              List<Villager> list = world.getEntitiesOfClass(Villager.class, axisalignedbb);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1d1712d2f766939edc7eedbfbdf1e54d17005d1e..a5a40aab0a23bb2d3f39ed156aed682570f6b344 100644
+index 71aa72fdfe69b0d3d023b993543e9fe3093afb03..0aaf18e53434c66425ec9bcd7ab5e2284d02a1a7 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2703,6 +2703,8 @@ public class PurpurWorldConfig {
+@@ -2705,6 +2705,8 @@ public class PurpurWorldConfig {
      public boolean villagerLobotomizeEnabled = false;
      public int villagerLobotomizeCheckInterval = 100;
      public boolean villagerDisplayTradeItem = true;
@@ -30,7 +30,7 @@ index 1d1712d2f766939edc7eedbfbdf1e54d17005d1e..a5a40aab0a23bb2d3f39ed156aed6825
      private void villagerSettings() {
          villagerRidable = getBoolean("mobs.villager.ridable", villagerRidable);
          villagerRidableInWater = getBoolean("mobs.villager.ridable-in-water", villagerRidableInWater);
-@@ -2736,6 +2738,8 @@ public class PurpurWorldConfig {
+@@ -2738,6 +2740,8 @@ public class PurpurWorldConfig {
          villagerLobotomizeEnabled = getBoolean("mobs.villager.lobotomize.enabled", villagerLobotomizeEnabled);
          villagerLobotomizeCheckInterval = getInt("mobs.villager.lobotomize.check-interval", villagerLobotomizeCheckInterval);
          villagerDisplayTradeItem = getBoolean("mobs.villager.display-trade-item", villagerDisplayTradeItem);

--- a/patches/server/0259-Stonecutter-damage.patch
+++ b/patches/server/0259-Stonecutter-damage.patch
@@ -63,10 +63,10 @@ index 636c032127c2026509764745f805ae0693e4a983..3734f6279005872eac6697e6e22c3a2e
  
      public static boolean advancementOnlyBroadcastToAffectedPlayer = false;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a333c3daae7e6416ec1ff897ca5fc6629c31a9c8..608db11e2569ea93b5192cc443c580ebf837f70d 100644
+index 0aaf18e53434c66425ec9bcd7ab5e2284d02a1a7..ba2d5b5971f4d61d12e8619180743104949e3c57 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -992,6 +992,11 @@ public class PurpurWorldConfig {
+@@ -994,6 +994,11 @@ public class PurpurWorldConfig {
          spongeAbsorbsLava = getBoolean("blocks.sponge.absorbs-lava", spongeAbsorbsLava);
      }
  

--- a/patches/server/0259-Stonecutter-damage.patch
+++ b/patches/server/0259-Stonecutter-damage.patch
@@ -63,10 +63,10 @@ index 636c032127c2026509764745f805ae0693e4a983..3734f6279005872eac6697e6e22c3a2e
  
      public static boolean advancementOnlyBroadcastToAffectedPlayer = false;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 0aaf18e53434c66425ec9bcd7ab5e2284d02a1a7..ba2d5b5971f4d61d12e8619180743104949e3c57 100644
+index 29ad2bdcc29b3758369acc130517c64d4ce56fa0..ffde66cb0ffa0651ac308f9020591277c267ca2a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -994,6 +994,11 @@ public class PurpurWorldConfig {
+@@ -996,6 +996,11 @@ public class PurpurWorldConfig {
          spongeAbsorbsLava = getBoolean("blocks.sponge.absorbs-lava", spongeAbsorbsLava);
      }
  

--- a/patches/server/0260-Configurable-damage-settings-for-magma-blocks.patch
+++ b/patches/server/0260-Configurable-damage-settings-for-magma-blocks.patch
@@ -18,10 +18,10 @@ index 12ffb5714f088f4aeafa1ad6a36f5b64a86c4c96..293aa5c8f91a997045f8d9f2951fe3a7
              entity.hurt(world.damageSources().hotFloor(), 1.0F);
              org.bukkit.craftbukkit.event.CraftEventFactory.blockDamage = null; // CraftBukkit
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index ba2d5b5971f4d61d12e8619180743104949e3c57..b9be8e637f382fb8a2b68b6ee422ebd78edc5369 100644
+index ffde66cb0ffa0651ac308f9020591277c267ca2a..c9d125d372978859aaac0ebcf7173ad17ea77c28 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -925,6 +925,13 @@ public class PurpurWorldConfig {
+@@ -927,6 +927,13 @@ public class PurpurWorldConfig {
          pistonBlockPushLimit = getInt("blocks.piston.block-push-limit", pistonBlockPushLimit);
      }
  

--- a/patches/server/0260-Configurable-damage-settings-for-magma-blocks.patch
+++ b/patches/server/0260-Configurable-damage-settings-for-magma-blocks.patch
@@ -18,10 +18,10 @@ index 12ffb5714f088f4aeafa1ad6a36f5b64a86c4c96..293aa5c8f91a997045f8d9f2951fe3a7
              entity.hurt(world.damageSources().hotFloor(), 1.0F);
              org.bukkit.craftbukkit.event.CraftEventFactory.blockDamage = null; // CraftBukkit
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 89323ca8142bea7125c18720bbf26dddbf9f94e5..62c5179454c787369daccd8a5e5a084f771db33e 100644
+index ba2d5b5971f4d61d12e8619180743104949e3c57..b9be8e637f382fb8a2b68b6ee422ebd78edc5369 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -923,6 +923,13 @@ public class PurpurWorldConfig {
+@@ -925,6 +925,13 @@ public class PurpurWorldConfig {
          pistonBlockPushLimit = getInt("blocks.piston.block-push-limit", pistonBlockPushLimit);
      }
  

--- a/patches/server/0261-Add-config-for-snow-on-blue-ice.patch
+++ b/patches/server/0261-Add-config-for-snow-on-blue-ice.patch
@@ -22,10 +22,10 @@ index 14e00c7feb1c051d56a3d27cd00dcef072dd771a..4952fb1aaaafb55baa0fddb389f966a1
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b9be8e637f382fb8a2b68b6ee422ebd78edc5369..5fc31721bd123dee6d72e26d9e1f251e2a94c6ac 100644
+index c9d125d372978859aaac0ebcf7173ad17ea77c28..9b10778c3ea1bd0228faef3ce3b90fc18fadbca8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -906,9 +906,11 @@ public class PurpurWorldConfig {
+@@ -908,9 +908,11 @@ public class PurpurWorldConfig {
  
      public boolean mobsSpawnOnPackedIce = true;
      public boolean mobsSpawnOnBlueIce = true;

--- a/patches/server/0261-Add-config-for-snow-on-blue-ice.patch
+++ b/patches/server/0261-Add-config-for-snow-on-blue-ice.patch
@@ -22,10 +22,10 @@ index 14e00c7feb1c051d56a3d27cd00dcef072dd771a..4952fb1aaaafb55baa0fddb389f966a1
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 62c5179454c787369daccd8a5e5a084f771db33e..9b71955ad0416fcfd074c01c296fa5d67a937b0d 100644
+index b9be8e637f382fb8a2b68b6ee422ebd78edc5369..5fc31721bd123dee6d72e26d9e1f251e2a94c6ac 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -904,9 +904,11 @@ public class PurpurWorldConfig {
+@@ -906,9 +906,11 @@ public class PurpurWorldConfig {
  
      public boolean mobsSpawnOnPackedIce = true;
      public boolean mobsSpawnOnBlueIce = true;

--- a/patches/server/0262-Skeletons-eat-wither-roses.patch
+++ b/patches/server/0262-Skeletons-eat-wither-roses.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Skeletons eat wither roses
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Skeleton.java b/src/main/java/net/minecraft/world/entity/monster/Skeleton.java
-index f5e8fbccd819f6fb66918bceb93d000da038d7ef..e0352f073c95f8caf47d6789c0bd10e5a8c329c8 100644
+index 875f1ae6a16301b48ddcf7005c601a161dee124d..35146853e991420f1c97921699d0d220a7f51dc0 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Skeleton.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Skeleton.java
 @@ -14,6 +14,16 @@ import net.minecraft.world.item.Items;
@@ -94,10 +94,10 @@ index f5e8fbccd819f6fb66918bceb93d000da038d7ef..e0352f073c95f8caf47d6789c0bd10e5
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9b71955ad0416fcfd074c01c296fa5d67a937b0d..b18b30020d14260cc8417aafdcf4978cac31dc15 100644
+index 5fc31721bd123dee6d72e26d9e1f251e2a94c6ac..a18ca04dd0a2d586d65685f4c38beb21056f3fdd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2389,6 +2389,7 @@ public class PurpurWorldConfig {
+@@ -2391,6 +2391,7 @@ public class PurpurWorldConfig {
      public boolean skeletonTakeDamageFromWater = false;
      public boolean skeletonAlwaysDropExp = false;
      public double skeletonHeadVisibilityPercent = 0.5D;
@@ -105,7 +105,7 @@ index 9b71955ad0416fcfd074c01c296fa5d67a937b0d..b18b30020d14260cc8417aafdcf4978c
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2402,6 +2403,7 @@ public class PurpurWorldConfig {
+@@ -2404,6 +2405,7 @@ public class PurpurWorldConfig {
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
          skeletonHeadVisibilityPercent = getDouble("mobs.skeleton.head-visibility-percent", skeletonHeadVisibilityPercent);

--- a/patches/server/0262-Skeletons-eat-wither-roses.patch
+++ b/patches/server/0262-Skeletons-eat-wither-roses.patch
@@ -94,10 +94,10 @@ index 875f1ae6a16301b48ddcf7005c601a161dee124d..35146853e991420f1c97921699d0d220
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 5fc31721bd123dee6d72e26d9e1f251e2a94c6ac..a18ca04dd0a2d586d65685f4c38beb21056f3fdd 100644
+index 9b10778c3ea1bd0228faef3ce3b90fc18fadbca8..f74d10092590eaaccce753c9ba227f909b78adb2 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2391,6 +2391,7 @@ public class PurpurWorldConfig {
+@@ -2393,6 +2393,7 @@ public class PurpurWorldConfig {
      public boolean skeletonTakeDamageFromWater = false;
      public boolean skeletonAlwaysDropExp = false;
      public double skeletonHeadVisibilityPercent = 0.5D;
@@ -105,7 +105,7 @@ index 5fc31721bd123dee6d72e26d9e1f251e2a94c6ac..a18ca04dd0a2d586d65685f4c38beb21
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2404,6 +2405,7 @@ public class PurpurWorldConfig {
+@@ -2406,6 +2407,7 @@ public class PurpurWorldConfig {
          skeletonTakeDamageFromWater = getBoolean("mobs.skeleton.takes-damage-from-water", skeletonTakeDamageFromWater);
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
          skeletonHeadVisibilityPercent = getDouble("mobs.skeleton.head-visibility-percent", skeletonHeadVisibilityPercent);

--- a/patches/server/0263-Enchantment-Table-Persists-Lapis.patch
+++ b/patches/server/0263-Enchantment-Table-Persists-Lapis.patch
@@ -146,10 +146,10 @@ index 65e1381bb2d10bd212463feb602c60f8fdb9ade1..b7370e64fd0d50e8725d7d5afc30af2e
 +    // Purpur
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b18b30020d14260cc8417aafdcf4978cac31dc15..457abb8a30e622648c40324aae1f2c76a903320e 100644
+index a18ca04dd0a2d586d65685f4c38beb21056f3fdd..30489af181bbc4798c04cd4f43b667a490e7de35 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1424,6 +1424,11 @@ public class PurpurWorldConfig {
+@@ -1426,6 +1426,11 @@ public class PurpurWorldConfig {
          elderGuardianAlwaysDropExp = getBoolean("mobs.elder_guardian.always-drop-exp", elderGuardianAlwaysDropExp);
      }
  

--- a/patches/server/0263-Enchantment-Table-Persists-Lapis.patch
+++ b/patches/server/0263-Enchantment-Table-Persists-Lapis.patch
@@ -146,10 +146,10 @@ index 65e1381bb2d10bd212463feb602c60f8fdb9ade1..b7370e64fd0d50e8725d7d5afc30af2e
 +    // Purpur
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a18ca04dd0a2d586d65685f4c38beb21056f3fdd..30489af181bbc4798c04cd4f43b667a490e7de35 100644
+index f74d10092590eaaccce753c9ba227f909b78adb2..9d040d4dc7b0f1ff7884356d9ca1c0fab62c98cf 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1426,6 +1426,11 @@ public class PurpurWorldConfig {
+@@ -1428,6 +1428,11 @@ public class PurpurWorldConfig {
          elderGuardianAlwaysDropExp = getBoolean("mobs.elder_guardian.always-drop-exp", elderGuardianAlwaysDropExp);
      }
  

--- a/patches/server/0266-Config-for-sculk-shrieker-can_summon-state.patch
+++ b/patches/server/0266-Config-for-sculk-shrieker-can_summon-state.patch
@@ -18,10 +18,10 @@ index 437b44fb68bcbe81d1c431689431225b6a17a1a6..06d091b7c4df949c4abda16c4f73c194
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 30489af181bbc4798c04cd4f43b667a490e7de35..acdd2d60fae102f528b2d3982b27d0c1f33dc8f3 100644
+index 9d040d4dc7b0f1ff7884356d9ca1c0fab62c98cf..5f3f4e4b8dec024816f26103df6eb9e6bdd67f5c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -970,6 +970,11 @@ public class PurpurWorldConfig {
+@@ -972,6 +972,11 @@ public class PurpurWorldConfig {
          fixSandDuping = getBoolean("blocks.sand.fix-duping", fixSandDuping);
      }
  

--- a/patches/server/0266-Config-for-sculk-shrieker-can_summon-state.patch
+++ b/patches/server/0266-Config-for-sculk-shrieker-can_summon-state.patch
@@ -18,10 +18,10 @@ index 437b44fb68bcbe81d1c431689431225b6a17a1a6..06d091b7c4df949c4abda16c4f73c194
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 457abb8a30e622648c40324aae1f2c76a903320e..51679edc97086340a0dbc4d0f0a48bbcd3a35285 100644
+index 30489af181bbc4798c04cd4f43b667a490e7de35..acdd2d60fae102f528b2d3982b27d0c1f33dc8f3 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -968,6 +968,11 @@ public class PurpurWorldConfig {
+@@ -970,6 +970,11 @@ public class PurpurWorldConfig {
          fixSandDuping = getBoolean("blocks.sand.fix-duping", fixSandDuping);
      }
  

--- a/patches/server/0267-Config-to-not-let-coral-die.patch
+++ b/patches/server/0267-Config-to-not-let-coral-die.patch
@@ -29,10 +29,10 @@ index 88faea00be60a519f56f975a5311df5e1eb3e6b8..cbb726ac367be81e27d3a86643baf7c4
          int i = aenumdirection.length;
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 51679edc97086340a0dbc4d0f0a48bbcd3a35285..8be28314335e2242c12f9e4b2e49c614ca7d10b5 100644
+index acdd2d60fae102f528b2d3982b27d0c1f33dc8f3..586c4c6640f379b9df13b2584e4aefdfb685e8b0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -805,6 +805,11 @@ public class PurpurWorldConfig {
+@@ -807,6 +807,11 @@ public class PurpurWorldConfig {
          composterBulkProcess = getBoolean("blocks.composter.sneak-to-bulk-process", composterBulkProcess);
      }
  

--- a/patches/server/0267-Config-to-not-let-coral-die.patch
+++ b/patches/server/0267-Config-to-not-let-coral-die.patch
@@ -29,10 +29,10 @@ index 88faea00be60a519f56f975a5311df5e1eb3e6b8..cbb726ac367be81e27d3a86643baf7c4
          int i = aenumdirection.length;
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index acdd2d60fae102f528b2d3982b27d0c1f33dc8f3..586c4c6640f379b9df13b2584e4aefdfb685e8b0 100644
+index 5f3f4e4b8dec024816f26103df6eb9e6bdd67f5c..5c9ef7afc1afc55958e8a63b30208adfd1576110 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -807,6 +807,11 @@ public class PurpurWorldConfig {
+@@ -809,6 +809,11 @@ public class PurpurWorldConfig {
          composterBulkProcess = getBoolean("blocks.composter.sneak-to-bulk-process", composterBulkProcess);
      }
  

--- a/patches/server/0279-mob-spawning-option-to-ignore-creative-players.patch
+++ b/patches/server/0279-mob-spawning-option-to-ignore-creative-players.patch
@@ -18,10 +18,10 @@ index 6d9af03d434c372f3d306c37809365659122d019..d36e301a1c46c457bc94edb1bab8685f
                              if (entityhuman != null) {
                                  double d2 = entityhuman.distanceToSqr(d0, (double) i, d1);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7f8bfb94cbbe7b8c569a5df638cc5607c2ea5951..1913edafb83663f9aeacb7a525ee0f8f1f6719d6 100644
+index 34cce604a58b68182456be1c9af25795065edaba..7005fe5c8f4553cf2740c6cb3f6bf2f827edf4fb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -375,6 +375,7 @@ public class PurpurWorldConfig {
+@@ -377,6 +377,7 @@ public class PurpurWorldConfig {
      public boolean phantomSpawning;
      public boolean villagerTraderSpawning;
      public boolean villageSiegeSpawning;
@@ -29,7 +29,7 @@ index 7f8bfb94cbbe7b8c569a5df638cc5607c2ea5951..1913edafb83663f9aeacb7a525ee0f8f
      private void mobSpawnerSettings() {
          // values of "default" or null will default to true only if the world environment is normal (aka overworld)
          Predicate<Boolean> predicate = (bool) -> (bool != null && bool) || (bool == null && environment == World.Environment.NORMAL);
-@@ -383,6 +384,7 @@ public class PurpurWorldConfig {
+@@ -385,6 +386,7 @@ public class PurpurWorldConfig {
          phantomSpawning = getBoolean("gameplay-mechanics.mob-spawning.phantoms", predicate);
          villagerTraderSpawning = getBoolean("gameplay-mechanics.mob-spawning.wandering-traders", predicate);
          villageSiegeSpawning = getBoolean("gameplay-mechanics.mob-spawning.village-sieges", predicate);

--- a/patches/server/0279-mob-spawning-option-to-ignore-creative-players.patch
+++ b/patches/server/0279-mob-spawning-option-to-ignore-creative-players.patch
@@ -18,10 +18,10 @@ index 6d9af03d434c372f3d306c37809365659122d019..d36e301a1c46c457bc94edb1bab8685f
                              if (entityhuman != null) {
                                  double d2 = entityhuman.distanceToSqr(d0, (double) i, d1);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 34cce604a58b68182456be1c9af25795065edaba..7005fe5c8f4553cf2740c6cb3f6bf2f827edf4fb 100644
+index 4687c35911b92683cb371d5221ab011371982961..0fd388db152724327853ec5d27a306b427689b03 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -377,6 +377,7 @@ public class PurpurWorldConfig {
+@@ -379,6 +379,7 @@ public class PurpurWorldConfig {
      public boolean phantomSpawning;
      public boolean villagerTraderSpawning;
      public boolean villageSiegeSpawning;
@@ -29,7 +29,7 @@ index 34cce604a58b68182456be1c9af25795065edaba..7005fe5c8f4553cf2740c6cb3f6bf2f8
      private void mobSpawnerSettings() {
          // values of "default" or null will default to true only if the world environment is normal (aka overworld)
          Predicate<Boolean> predicate = (bool) -> (bool != null && bool) || (bool == null && environment == World.Environment.NORMAL);
-@@ -385,6 +386,7 @@ public class PurpurWorldConfig {
+@@ -387,6 +388,7 @@ public class PurpurWorldConfig {
          phantomSpawning = getBoolean("gameplay-mechanics.mob-spawning.phantoms", predicate);
          villagerTraderSpawning = getBoolean("gameplay-mechanics.mob-spawning.wandering-traders", predicate);
          villageSiegeSpawning = getBoolean("gameplay-mechanics.mob-spawning.village-sieges", predicate);

--- a/patches/server/0280-Add-skeleton-bow-accuracy-option.patch
+++ b/patches/server/0280-Add-skeleton-bow-accuracy-option.patch
@@ -18,10 +18,10 @@ index 32a303f9ac9768daf621e3aa561cd6b31e5f5dff..9c8713ef3aeb2ff203bd0328d15d80c2
          org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), entityarrow.getPickupItem(), entityarrow, net.minecraft.world.InteractionHand.MAIN_HAND, 0.8F, true); // Paper
          if (event.isCancelled()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 7005fe5c8f4553cf2740c6cb3f6bf2f827edf4fb..03b004017d23d4418af7adb8215adfb7ed5444d0 100644
+index 0fd388db152724327853ec5d27a306b427689b03..6fa7fd8d188685cbdde6ce737f533b0b5a97b6c2 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2411,6 +2411,8 @@ public class PurpurWorldConfig {
+@@ -2413,6 +2413,8 @@ public class PurpurWorldConfig {
      public boolean skeletonAlwaysDropExp = false;
      public double skeletonHeadVisibilityPercent = 0.5D;
      public int skeletonFeedWitherRoses = 0;
@@ -30,7 +30,7 @@ index 7005fe5c8f4553cf2740c6cb3f6bf2f827edf4fb..03b004017d23d4418af7adb8215adfb7
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2425,6 +2427,18 @@ public class PurpurWorldConfig {
+@@ -2427,6 +2429,18 @@ public class PurpurWorldConfig {
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
          skeletonHeadVisibilityPercent = getDouble("mobs.skeleton.head-visibility-percent", skeletonHeadVisibilityPercent);
          skeletonFeedWitherRoses = getInt("mobs.skeleton.feed-wither-roses", skeletonFeedWitherRoses);

--- a/patches/server/0280-Add-skeleton-bow-accuracy-option.patch
+++ b/patches/server/0280-Add-skeleton-bow-accuracy-option.patch
@@ -18,10 +18,10 @@ index 32a303f9ac9768daf621e3aa561cd6b31e5f5dff..9c8713ef3aeb2ff203bd0328d15d80c2
          org.bukkit.event.entity.EntityShootBowEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityShootBowEvent(this, this.getMainHandItem(), entityarrow.getPickupItem(), entityarrow, net.minecraft.world.InteractionHand.MAIN_HAND, 0.8F, true); // Paper
          if (event.isCancelled()) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d582ebbd7b850bfe4b4e8c56d1ff704a87be3928..ccc6b223090ee71808909bb8e1a13adfdd9fae67 100644
+index 7005fe5c8f4553cf2740c6cb3f6bf2f827edf4fb..03b004017d23d4418af7adb8215adfb7ed5444d0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -2409,6 +2409,8 @@ public class PurpurWorldConfig {
+@@ -2411,6 +2411,8 @@ public class PurpurWorldConfig {
      public boolean skeletonAlwaysDropExp = false;
      public double skeletonHeadVisibilityPercent = 0.5D;
      public int skeletonFeedWitherRoses = 0;
@@ -30,7 +30,7 @@ index d582ebbd7b850bfe4b4e8c56d1ff704a87be3928..ccc6b223090ee71808909bb8e1a13adf
      private void skeletonSettings() {
          skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
          skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
-@@ -2423,6 +2425,18 @@ public class PurpurWorldConfig {
+@@ -2425,6 +2427,18 @@ public class PurpurWorldConfig {
          skeletonAlwaysDropExp = getBoolean("mobs.skeleton.always-drop-exp", skeletonAlwaysDropExp);
          skeletonHeadVisibilityPercent = getDouble("mobs.skeleton.head-visibility-percent", skeletonHeadVisibilityPercent);
          skeletonFeedWitherRoses = getInt("mobs.skeleton.feed-wither-roses", skeletonFeedWitherRoses);

--- a/patches/server/0281-Allay-respect-item-NBT.patch
+++ b/patches/server/0281-Allay-respect-item-NBT.patch
@@ -44,10 +44,10 @@ index afbce4fdece213e456ef4e993f07bfb448bb2dd1..6051737b8e16d0790aec73757d13d786
  
      private boolean allayConsidersItemEqual(ItemStack stack, ItemStack stack2) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 03b004017d23d4418af7adb8215adfb7ed5444d0..9519f09dad261767b70162426ed8fb5db73dd422 100644
+index 6fa7fd8d188685cbdde6ce737f533b0b5a97b6c2..9fcea4b1543fcd97e67b12064b91e69e846a551d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1054,10 +1054,13 @@ public class PurpurWorldConfig {
+@@ -1056,10 +1056,13 @@ public class PurpurWorldConfig {
      public boolean allayRidable = false;
      public boolean allayRidableInWater = false;
      public boolean allayControllable = true;

--- a/patches/server/0281-Allay-respect-item-NBT.patch
+++ b/patches/server/0281-Allay-respect-item-NBT.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allay respect item NBT
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java b/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
-index 4c4b27a762d4faf0467136ee92a3bbba5ab7322d..380cb6baaf934e77a9899647824b5eb96e821a1c 100644
+index afbce4fdece213e456ef4e993f07bfb448bb2dd1..6051737b8e16d0790aec73757d13d7862ad74ef4 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/allay/Allay.java
 @@ -407,9 +407,31 @@ public class Allay extends PathfinderMob implements InventoryCarrier {
@@ -44,10 +44,10 @@ index 4c4b27a762d4faf0467136ee92a3bbba5ab7322d..380cb6baaf934e77a9899647824b5eb9
  
      private boolean allayConsidersItemEqual(ItemStack stack, ItemStack stack2) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3437bdba19c1bf8a711e4d27d9900928c17c2fb5..40aaa43eb061d80d3ec479c53584e96f5018d3e2 100644
+index 03b004017d23d4418af7adb8215adfb7ed5444d0..9519f09dad261767b70162426ed8fb5db73dd422 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1052,10 +1052,13 @@ public class PurpurWorldConfig {
+@@ -1054,10 +1054,13 @@ public class PurpurWorldConfig {
      public boolean allayRidable = false;
      public boolean allayRidableInWater = false;
      public boolean allayControllable = true;

--- a/patches/server/0286-Implement-squid-colors-for-rainglow-fabric-mod.patch
+++ b/patches/server/0286-Implement-squid-colors-for-rainglow-fabric-mod.patch
@@ -40,10 +40,10 @@ index c2309434b4d48a44587590623ac98dbf997b9578..6f723171fa71d74b351b5cf0cd167bb6
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 40aaa43eb061d80d3ec479c53584e96f5018d3e2..80d042bddc4f51eadeca3a8efe190f6936516fc9 100644
+index 9519f09dad261767b70162426ed8fb5db73dd422..b03bd6417b269f5ca92b5029aa1ceb35c81ce51c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1661,6 +1661,7 @@ public class PurpurWorldConfig {
+@@ -1663,6 +1663,7 @@ public class PurpurWorldConfig {
      public boolean glowSquidsCanFly = false;
      public boolean glowSquidTakeDamageFromWater = false;
      public boolean glowSquidAlwaysDropExp = false;
@@ -51,7 +51,7 @@ index 40aaa43eb061d80d3ec479c53584e96f5018d3e2..80d042bddc4f51eadeca3a8efe190f69
      private void glowSquidSettings() {
          glowSquidRidable = getBoolean("mobs.glow_squid.ridable", glowSquidRidable);
          glowSquidControllable = getBoolean("mobs.glow_squid.controllable", glowSquidControllable);
-@@ -1668,6 +1669,7 @@ public class PurpurWorldConfig {
+@@ -1670,6 +1671,7 @@ public class PurpurWorldConfig {
          glowSquidsCanFly = getBoolean("mobs.glow_squid.can-fly", glowSquidsCanFly);
          glowSquidTakeDamageFromWater = getBoolean("mobs.glow_squid.takes-damage-from-water", glowSquidTakeDamageFromWater);
          glowSquidAlwaysDropExp = getBoolean("mobs.glow_squid.always-drop-exp", glowSquidAlwaysDropExp);

--- a/patches/server/0286-Implement-squid-colors-for-rainglow-fabric-mod.patch
+++ b/patches/server/0286-Implement-squid-colors-for-rainglow-fabric-mod.patch
@@ -40,10 +40,10 @@ index c2309434b4d48a44587590623ac98dbf997b9578..6f723171fa71d74b351b5cf0cd167bb6
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9519f09dad261767b70162426ed8fb5db73dd422..b03bd6417b269f5ca92b5029aa1ceb35c81ce51c 100644
+index 9fcea4b1543fcd97e67b12064b91e69e846a551d..c23c279209892ddd78e815828b0b0a8892959d3c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1663,6 +1663,7 @@ public class PurpurWorldConfig {
+@@ -1665,6 +1665,7 @@ public class PurpurWorldConfig {
      public boolean glowSquidsCanFly = false;
      public boolean glowSquidTakeDamageFromWater = false;
      public boolean glowSquidAlwaysDropExp = false;
@@ -51,7 +51,7 @@ index 9519f09dad261767b70162426ed8fb5db73dd422..b03bd6417b269f5ca92b5029aa1ceb35
      private void glowSquidSettings() {
          glowSquidRidable = getBoolean("mobs.glow_squid.ridable", glowSquidRidable);
          glowSquidControllable = getBoolean("mobs.glow_squid.controllable", glowSquidControllable);
-@@ -1670,6 +1671,7 @@ public class PurpurWorldConfig {
+@@ -1672,6 +1673,7 @@ public class PurpurWorldConfig {
          glowSquidsCanFly = getBoolean("mobs.glow_squid.can-fly", glowSquidsCanFly);
          glowSquidTakeDamageFromWater = getBoolean("mobs.glow_squid.takes-damage-from-water", glowSquidTakeDamageFromWater);
          glowSquidAlwaysDropExp = getBoolean("mobs.glow_squid.always-drop-exp", glowSquidAlwaysDropExp);

--- a/patches/server/0295-Add-option-to-allow-creeper-to-encircle-target-when-.patch
+++ b/patches/server/0295-Add-option-to-allow-creeper-to-encircle-target-when-.patch
@@ -24,10 +24,10 @@ index e241ae250f4f04a17ef2c583d00b065a4ca56a4c..02b567e4e808e1a809d285ef39e1abc5
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index c50b9da97da339eb085ec8e87ad63ef85fb1ae0f..3028d4d637e67a63fe7541f596827116ba95b78e 100644
+index 19495d46b71f61ac31fc2354e7b01678e642108f..1e729867df0f3f80a785dd6b3b69a045c21f2156 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1319,6 +1319,7 @@ public class PurpurWorldConfig {
+@@ -1321,6 +1321,7 @@ public class PurpurWorldConfig {
      public boolean creeperHealthRadius = false;
      public boolean creeperAlwaysDropExp = false;
      public double creeperHeadVisibilityPercent = 0.5D;
@@ -35,7 +35,7 @@ index c50b9da97da339eb085ec8e87ad63ef85fb1ae0f..3028d4d637e67a63fe7541f596827116
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1337,6 +1338,7 @@ public class PurpurWorldConfig {
+@@ -1339,6 +1340,7 @@ public class PurpurWorldConfig {
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
          creeperAlwaysDropExp = getBoolean("mobs.creeper.always-drop-exp", creeperAlwaysDropExp);
          creeperHeadVisibilityPercent = getDouble("mobs.creeper.head-visibility-percent", creeperHeadVisibilityPercent);

--- a/patches/server/0295-Add-option-to-allow-creeper-to-encircle-target-when-.patch
+++ b/patches/server/0295-Add-option-to-allow-creeper-to-encircle-target-when-.patch
@@ -24,10 +24,10 @@ index e241ae250f4f04a17ef2c583d00b065a4ca56a4c..02b567e4e808e1a809d285ef39e1abc5
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6c0136eb8c8b7815aa07bc6614e052c8cab257a3..2b9e60201af155bb3f871c53844663504ed2a4a6 100644
+index c50b9da97da339eb085ec8e87ad63ef85fb1ae0f..3028d4d637e67a63fe7541f596827116ba95b78e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -1317,6 +1317,7 @@ public class PurpurWorldConfig {
+@@ -1319,6 +1319,7 @@ public class PurpurWorldConfig {
      public boolean creeperHealthRadius = false;
      public boolean creeperAlwaysDropExp = false;
      public double creeperHeadVisibilityPercent = 0.5D;
@@ -35,7 +35,7 @@ index 6c0136eb8c8b7815aa07bc6614e052c8cab257a3..2b9e60201af155bb3f871c5384466350
      private void creeperSettings() {
          creeperRidable = getBoolean("mobs.creeper.ridable", creeperRidable);
          creeperRidableInWater = getBoolean("mobs.creeper.ridable-in-water", creeperRidableInWater);
-@@ -1335,6 +1336,7 @@ public class PurpurWorldConfig {
+@@ -1337,6 +1338,7 @@ public class PurpurWorldConfig {
          creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
          creeperAlwaysDropExp = getBoolean("mobs.creeper.always-drop-exp", creeperAlwaysDropExp);
          creeperHeadVisibilityPercent = getDouble("mobs.creeper.head-visibility-percent", creeperHeadVisibilityPercent);

--- a/patches/server/0297-Add-option-to-teleport-to-spawn-on-nether-ceiling-da.patch
+++ b/patches/server/0297-Add-option-to-teleport-to-spawn-on-nether-ceiling-da.patch
@@ -30,10 +30,10 @@ index 099b7da30aaf2dca7fe556d26c1395f662fbf80a..3f59268a8e01cebd9e08984ae754e928
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 2b9e60201af155bb3f871c53844663504ed2a4a6..db8e647e043c7d89c8cf7b5c13dd290e7d8b3050 100644
+index 3028d4d637e67a63fe7541f596827116ba95b78e..a4be80c7d76c6183984f49a08ead870af29b6aab 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -417,6 +417,7 @@ public class PurpurWorldConfig {
+@@ -419,6 +419,7 @@ public class PurpurWorldConfig {
      public String playerDeathExpDropEquation = "expLevel * 7";
      public int playerDeathExpDropMax = 100;
      public boolean teleportIfOutsideBorder = false;
@@ -41,7 +41,7 @@ index 2b9e60201af155bb3f871c53844663504ed2a4a6..db8e647e043c7d89c8cf7b5c13dd290e
      public boolean totemOfUndyingWorksInInventory = false;
      public boolean playerFixStuckPortal = false;
      public boolean creativeOnePunch = false;
-@@ -446,6 +447,7 @@ public class PurpurWorldConfig {
+@@ -448,6 +449,7 @@ public class PurpurWorldConfig {
          playerDeathExpDropEquation = getString("gameplay-mechanics.player.exp-dropped-on-death.equation", playerDeathExpDropEquation);
          playerDeathExpDropMax = getInt("gameplay-mechanics.player.exp-dropped-on-death.maximum", playerDeathExpDropMax);
          teleportIfOutsideBorder = getBoolean("gameplay-mechanics.player.teleport-if-outside-border", teleportIfOutsideBorder);

--- a/patches/server/0297-Add-option-to-teleport-to-spawn-on-nether-ceiling-da.patch
+++ b/patches/server/0297-Add-option-to-teleport-to-spawn-on-nether-ceiling-da.patch
@@ -30,10 +30,10 @@ index 099b7da30aaf2dca7fe556d26c1395f662fbf80a..3f59268a8e01cebd9e08984ae754e928
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 3028d4d637e67a63fe7541f596827116ba95b78e..a4be80c7d76c6183984f49a08ead870af29b6aab 100644
+index 1e729867df0f3f80a785dd6b3b69a045c21f2156..44cfe5afb0e5ec087880c0739b1f1c6115d6a05a 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -419,6 +419,7 @@ public class PurpurWorldConfig {
+@@ -421,6 +421,7 @@ public class PurpurWorldConfig {
      public String playerDeathExpDropEquation = "expLevel * 7";
      public int playerDeathExpDropMax = 100;
      public boolean teleportIfOutsideBorder = false;
@@ -41,7 +41,7 @@ index 3028d4d637e67a63fe7541f596827116ba95b78e..a4be80c7d76c6183984f49a08ead870a
      public boolean totemOfUndyingWorksInInventory = false;
      public boolean playerFixStuckPortal = false;
      public boolean creativeOnePunch = false;
-@@ -448,6 +449,7 @@ public class PurpurWorldConfig {
+@@ -450,6 +451,7 @@ public class PurpurWorldConfig {
          playerDeathExpDropEquation = getString("gameplay-mechanics.player.exp-dropped-on-death.equation", playerDeathExpDropEquation);
          playerDeathExpDropMax = getInt("gameplay-mechanics.player.exp-dropped-on-death.maximum", playerDeathExpDropMax);
          teleportIfOutsideBorder = getBoolean("gameplay-mechanics.player.teleport-if-outside-border", teleportIfOutsideBorder);

--- a/patches/server/0300-End-Crystal-Cramming.patch
+++ b/patches/server/0300-End-Crystal-Cramming.patch
@@ -17,10 +17,10 @@ index a4fc0e9cb52bb5937effe5cd09f8bbefcf8dd531..e3fe5f18c77e36479eaeb7edfd2a3eb9
  
          // Purpur start
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 69b04d74e3a44b01fc24c67ce9ce627ce2b5a992..ea8e4ad5ba1d5894747e11674bbc63ba57c9a061 100644
+index a4be80c7d76c6183984f49a08ead870af29b6aab..d76ecc3b33f1a5bfb0334516620eaf37394c4a10 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -848,6 +848,7 @@ public class PurpurWorldConfig {
+@@ -850,6 +850,7 @@ public class PurpurWorldConfig {
      public double basedEndCrystalExplosionPower = 6.0D;
      public boolean basedEndCrystalExplosionFire = false;
      public net.minecraft.world.level.Level.ExplosionInteraction basedEndCrystalExplosionEffect = net.minecraft.world.level.Level.ExplosionInteraction.BLOCK;
@@ -28,7 +28,7 @@ index 69b04d74e3a44b01fc24c67ce9ce627ce2b5a992..ea8e4ad5ba1d5894747e11674bbc63ba
      private void endCrystalSettings() {
          if (PurpurConfig.version < 31) {
              if ("DESTROY".equals(getString("blocks.end-crystal.baseless.explosion-effect", baselessEndCrystalExplosionEffect.name()))) {
-@@ -875,6 +876,7 @@ public class PurpurWorldConfig {
+@@ -877,6 +878,7 @@ public class PurpurWorldConfig {
              log(Level.SEVERE, "Unknown value for `blocks.end-crystal.base.explosion-effect`! Using default of `BLOCK`");
              basedEndCrystalExplosionEffect = net.minecraft.world.level.Level.ExplosionInteraction.BLOCK;
          }

--- a/patches/server/0300-End-Crystal-Cramming.patch
+++ b/patches/server/0300-End-Crystal-Cramming.patch
@@ -17,10 +17,10 @@ index a4fc0e9cb52bb5937effe5cd09f8bbefcf8dd531..e3fe5f18c77e36479eaeb7edfd2a3eb9
  
          // Purpur start
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index a4be80c7d76c6183984f49a08ead870af29b6aab..d76ecc3b33f1a5bfb0334516620eaf37394c4a10 100644
+index 44cfe5afb0e5ec087880c0739b1f1c6115d6a05a..05c8f4ca98b95d883d962db0aa43903e4a0785f0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -850,6 +850,7 @@ public class PurpurWorldConfig {
+@@ -852,6 +852,7 @@ public class PurpurWorldConfig {
      public double basedEndCrystalExplosionPower = 6.0D;
      public boolean basedEndCrystalExplosionFire = false;
      public net.minecraft.world.level.Level.ExplosionInteraction basedEndCrystalExplosionEffect = net.minecraft.world.level.Level.ExplosionInteraction.BLOCK;
@@ -28,7 +28,7 @@ index a4be80c7d76c6183984f49a08ead870af29b6aab..d76ecc3b33f1a5bfb0334516620eaf37
      private void endCrystalSettings() {
          if (PurpurConfig.version < 31) {
              if ("DESTROY".equals(getString("blocks.end-crystal.baseless.explosion-effect", baselessEndCrystalExplosionEffect.name()))) {
-@@ -877,6 +878,7 @@ public class PurpurWorldConfig {
+@@ -879,6 +880,7 @@ public class PurpurWorldConfig {
              log(Level.SEVERE, "Unknown value for `blocks.end-crystal.base.explosion-effect`! Using default of `BLOCK`");
              basedEndCrystalExplosionEffect = net.minecraft.world.level.Level.ExplosionInteraction.BLOCK;
          }

--- a/patches/server/0301-Option-to-allow-beacon-effects-when-covered-by-tinte.patch
+++ b/patches/server/0301-Option-to-allow-beacon-effects-when-covered-by-tinte.patch
@@ -36,10 +36,10 @@ index c787019b5cbadec81dd33ef4021708b9b423485a..8f82b0ce87afc8890c5b3386d5f6e22c
                  BeaconBlockEntity.playSound(world, pos, SoundEvents.BEACON_AMBIENT);
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 9efeff43abf589fbb2ffe865cdc010d1ddf7db63..3ae4c95763caf2b4a815c1e4553ead37ea80eb30 100644
+index d76ecc3b33f1a5bfb0334516620eaf37394c4a10..6f1b21f28a49177539382b8e45fa894b04c293d1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -742,11 +742,13 @@ public class PurpurWorldConfig {
+@@ -744,11 +744,13 @@ public class PurpurWorldConfig {
      public int beaconLevelTwo = 30;
      public int beaconLevelThree = 40;
      public int beaconLevelFour = 50;

--- a/patches/server/0301-Option-to-allow-beacon-effects-when-covered-by-tinte.patch
+++ b/patches/server/0301-Option-to-allow-beacon-effects-when-covered-by-tinte.patch
@@ -36,10 +36,10 @@ index c787019b5cbadec81dd33ef4021708b9b423485a..8f82b0ce87afc8890c5b3386d5f6e22c
                  BeaconBlockEntity.playSound(world, pos, SoundEvents.BEACON_AMBIENT);
              }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d76ecc3b33f1a5bfb0334516620eaf37394c4a10..6f1b21f28a49177539382b8e45fa894b04c293d1 100644
+index 05c8f4ca98b95d883d962db0aa43903e4a0785f0..dce83c76bf4d4e3e0e98dc0c6b34b2fbff3cfee5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -744,11 +744,13 @@ public class PurpurWorldConfig {
+@@ -746,11 +746,13 @@ public class PurpurWorldConfig {
      public int beaconLevelTwo = 30;
      public int beaconLevelThree = 40;
      public int beaconLevelFour = 50;

--- a/patches/server/0304-bonemealable-sugarcane-cactus-and-netherwart.patch
+++ b/patches/server/0304-bonemealable-sugarcane-cactus-and-netherwart.patch
@@ -137,10 +137,10 @@ index 6b400a4759c8c8612a3b5c96ca0d87ef9dc71435..992de1ab2c00a2545a857f1b5533926b
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 401803ac4e2d176d8509f240629ad3fb7d1eabc4..7acc69b1a2c5f862b5520631ac8d2baf815ca4c2 100644
+index 67f2015af23a5ee0534258b2cefdefc0db8a22df..c7b3c73ed9e936ad7e064378e2f795f9c6deb385 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -801,8 +801,20 @@ public class PurpurWorldConfig {
+@@ -803,8 +803,20 @@ public class PurpurWorldConfig {
      }
  
      public boolean cactusBreaksFromSolidNeighbors = true;

--- a/patches/server/0304-bonemealable-sugarcane-cactus-and-netherwart.patch
+++ b/patches/server/0304-bonemealable-sugarcane-cactus-and-netherwart.patch
@@ -137,10 +137,10 @@ index 6b400a4759c8c8612a3b5c96ca0d87ef9dc71435..992de1ab2c00a2545a857f1b5533926b
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 67f2015af23a5ee0534258b2cefdefc0db8a22df..c7b3c73ed9e936ad7e064378e2f795f9c6deb385 100644
+index e7e4511abdfa94b990ceb7accee8a5f9e3bf5291..40a66f4ae7be0abd10a62a8945ba62c603c75470 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -803,8 +803,20 @@ public class PurpurWorldConfig {
+@@ -805,8 +805,20 @@ public class PurpurWorldConfig {
      }
  
      public boolean cactusBreaksFromSolidNeighbors = true;


### PR DESCRIPTION
Added an option to disable scissor damage while in liquid. Some people found it annoying that they take damage when swimming clearing kelp. Made it optional just in case people like to get stabbed while swimming. It is enabled by default, think most players would not like it to be enabled

This is my first PR, please let me know if I did anything wrong. Sorry about the previous PR too, was trying to fix something and accidentally deleted it which closed the PR
