### PR TITLE
Updated Upstream (Paper)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 group = org.purpurmc.purpur
 version = 1.19.4-R0.1-SNAPSHOT
 
-paperCommit = 11ab383e4fb546c8e35b634daa51cfda520b5e70
+paperCommit = 641dafd0a85badcfc5da7f53a99e5f7eac4ec015
 
 org.gradle.caching = true
 org.gradle.parallel = true

--- a/patches/api/0021-ChatColor-conveniences.patch
+++ b/patches/api/0021-ChatColor-conveniences.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ChatColor conveniences
 
 
 diff --git a/src/main/java/org/bukkit/ChatColor.java b/src/main/java/org/bukkit/ChatColor.java
-index e3f185dc982d1c38195a4e01ddd485c13ffa58c0..98c2f73ee5c921dab506fc933a0acff400201537 100644
+index ea4ceb643239c26851bacbf45fc3f2efef3bb4be..3b8395dcb73e3fb251adf7438cbc7e95c4185a3a 100644
 --- a/src/main/java/org/bukkit/ChatColor.java
 +++ b/src/main/java/org/bukkit/ChatColor.java
 @@ -3,6 +3,7 @@ package org.bukkit;
@@ -16,7 +16,7 @@ index e3f185dc982d1c38195a4e01ddd485c13ffa58c0..98c2f73ee5c921dab506fc933a0acff4
  import java.util.regex.Pattern;
  import org.jetbrains.annotations.Contract;
  import org.jetbrains.annotations.NotNull;
-@@ -454,4 +455,77 @@ public enum ChatColor {
+@@ -455,4 +456,77 @@ public enum ChatColor {
              BY_CHAR.put(color.code, color);
          }
      }

--- a/patches/server/0001-Pufferfish-Server-Changes.patch
+++ b/patches/server/0001-Pufferfish-Server-Changes.patch
@@ -1721,7 +1721,7 @@ index b7fd8e70413c38923d0719aff803449e392383ac..d5cb594f0b17ec9dc1a19cdb99bba553
                          this.wasOnGround = this.entity.isOnGround();
                          this.teleportDelay = 0;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5a5ff40df37db9cbd53c584ed26a3ce4888b29c0..ff2862bf1f511196d1e911e2584262ed728e9a81 100644
+index 309ef1b2181eae609737212a50d037a1565daf86..17b1a891073521be51e7c6bf8f53cb4ed79983ce 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -709,6 +709,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1786,10 +1786,10 @@ index 5a5ff40df37db9cbd53c584ed26a3ce4888b29c0..ff2862bf1f511196d1e911e2584262ed
              this.getRandomBlockPosition(j, 0, k, 15, blockposition);
              int normalY = chunk.getHeight(Heightmap.Types.MOTION_BLOCKING, blockposition.getX() & 15, blockposition.getZ() & 15) + 1;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d587b2c4e39bce7e098aa9fab361230f72770658..e6e1c46a01961d47a774e34e430c8eacda22d558 100644
+index 177aac1ab10189bb5a52217e86ba5c8a535b4197..b357953dedc2af39673ad4ef78fed14d5e7235bb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1206,6 +1206,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1214,6 +1214,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handleEditBook(ServerboundEditBookPacket packet) {
@@ -1797,7 +1797,7 @@ index d587b2c4e39bce7e098aa9fab361230f72770658..e6e1c46a01961d47a774e34e430c8eac
          // Paper start
          if (!this.cserver.isPrimaryThread()) {
              List<String> pageList = packet.getPages();
-@@ -2347,6 +2348,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2355,6 +2356,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      }
  
      private boolean updateChatOrder(Instant timestamp) {
@@ -3533,7 +3533,7 @@ index ebe65474a4a05ff1637d7f37ebcfe690af59def5..42142c512b12e5b269c19f1e821c50e7
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f9a9d2bb7b6d1bf4a0931438de4d8c7ee0757479..b2d94582037c091bd6a04451bf62b3f9c4923d19 100644
+index 4cd95134811fd65465681d159b2f30cf77455830..7672fe8e6d08370327bb7ad5fa5ac3292c49e3c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -256,7 +256,7 @@ import javax.annotation.Nullable; // Paper
@@ -3596,7 +3596,7 @@ index 774556a62eb240da42e84db4502e2ed43495be17..80553face9c70c2a3d897681e7761df8
  
          if (stream != null) {
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index e881584d38dc354204479863f004e974a0ac6c07..63d3fcc45be732a4cd2dc8b5347d860fd6577bdd 100644
+index 52780192d6417f8085566e4cdf3a895a83638520..07050c78a2eb6ce0c699101b38961b111d631a41 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -38,6 +38,10 @@ import co.aikar.timings.MinecraftTimings;
@@ -3610,7 +3610,7 @@ index e881584d38dc354204479863f004e974a0ac6c07..63d3fcc45be732a4cd2dc8b5347d860f
  
  public class ActivationRange
  {
-@@ -216,6 +220,25 @@ public class ActivationRange
+@@ -217,6 +221,25 @@ public class ActivationRange
              for (int i = 0; i < entities.size(); i++) {
                  Entity entity = entities.get(i);
                  ActivationRange.activateEntity(entity);
@@ -3636,7 +3636,7 @@ index e881584d38dc354204479863f004e974a0ac6c07..63d3fcc45be732a4cd2dc8b5347d860f
              }
              // Paper end
          }
-@@ -232,12 +255,12 @@ public class ActivationRange
+@@ -233,12 +256,12 @@ public class ActivationRange
          if ( MinecraftServer.currentTick > entity.activatedTick )
          {
              if ( entity.defaultActivationState )
@@ -3651,7 +3651,7 @@ index e881584d38dc354204479863f004e974a0ac6c07..63d3fcc45be732a4cd2dc8b5347d860f
                  entity.activatedTick = MinecraftServer.currentTick;
              }
          }
-@@ -291,7 +314,7 @@ public class ActivationRange
+@@ -292,7 +315,7 @@ public class ActivationRange
          if ( entity instanceof LivingEntity )
          {
              LivingEntity living = (LivingEntity) entity;

--- a/patches/server/0005-Purpur-client-support.patch
+++ b/patches/server/0005-Purpur-client-support.patch
@@ -17,10 +17,10 @@ index 1d4d02f26391ac55c7631817f09d05e2769b0d29..b1c0f5743dfe87e359dbd3a451367aa8
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e6e1c46a01961d47a774e34e430c8eacda22d558..c912c0fdddf4503cb25a0b942fa861ebf4e212a0 100644
+index b357953dedc2af39673ad4ef78fed14d5e7235bb..ed6631d2b104542465d28683cd4fd3222016e5bb 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3526,6 +3526,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3534,6 +3534,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      private static final ResourceLocation CUSTOM_UNREGISTER = new ResourceLocation("unregister");
  
      private static final ResourceLocation MINECRAFT_BRAND = new ResourceLocation("brand"); // Paper - Brand support
@@ -28,7 +28,7 @@ index e6e1c46a01961d47a774e34e430c8eacda22d558..c912c0fdddf4503cb25a0b942fa861eb
  
      @Override
      public void handleCustomPayload(ServerboundCustomPayloadPacket packet) {
-@@ -3550,6 +3551,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3558,6 +3559,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  ServerGamePacketListenerImpl.LOGGER.error("Couldn\'t unregister custom payload", ex);
                  this.disconnect("Invalid payload UNREGISTER!", org.bukkit.event.player.PlayerKickEvent.Cause.INVALID_PAYLOAD); // Paper - kick event cause
              }
@@ -43,10 +43,10 @@ index e6e1c46a01961d47a774e34e430c8eacda22d558..c912c0fdddf4503cb25a0b942fa861eb
              try {
                  byte[] data = new byte[packet.data.readableBytes()];
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0ae1fce0c1a2e3bfbbab756a088fc76545e263fa..7188e31ade709b244d378a685a7188c5aa7dd279 100644
+index 589783e93785196eb9f7ff6890c03e84f3102d93..722ba7f34d4f6c0d470f6a933da61837442e1c68 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3158,4 +3158,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3161,4 +3161,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0007-Component-related-conveniences.patch
+++ b/patches/server/0007-Component-related-conveniences.patch
@@ -36,10 +36,10 @@ index b1c0f5743dfe87e359dbd3a451367aa8a66e57f0..01e52ea23d5481c2df79d2c899b4febf
      public void displayClientMessage(Component message, boolean overlay) {
          this.sendSystemMessage(message, overlay);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c0c14766adaac855112f85a203a6163b8adfdded..c996a28e3d6dd775021b2a1d199ac96d64b798f9 100644
+index a1096ea424c0724af93a2dc65512ee71f4a0bf72..81a6b5e6315d61408f926fd702feadc3034dfa96 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1022,6 +1022,20 @@ public abstract class PlayerList {
+@@ -1026,6 +1026,20 @@ public abstract class PlayerList {
      }
      // CraftBukkit end
  

--- a/patches/server/0008-Ridables.patch
+++ b/patches/server/0008-Ridables.patch
@@ -34,7 +34,7 @@ index 5440cd26b9d6cc3988ced96490539d9a794c3a6b..a6e6dff37efd7b54a3f17c22ba4b4543
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 87d6b8e0cd8fec7959fb052dce1b73feb8cdb967..b40bc54e80dadc8eb426ed6217b879631833e4d7 100644
+index c7c31a901a0bf55cb557de83d1fe1688159c5b69..2f6a7a03bee6a79a45bd281394e721e17156fcf1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -220,6 +220,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -66,10 +66,10 @@ index 01e52ea23d5481c2df79d2c899b4febf3f4a8948..d59e49a4958ebfb2ce0b9ca127b5a98f
  
      public void doTick() {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c912c0fdddf4503cb25a0b942fa861ebf4e212a0..14981211661fdba989adc82e9df12e753ca0ec82 100644
+index ed6631d2b104542465d28683cd4fd3222016e5bb..34072d4d438ca90d921d4af7f4be99f5ee58bc51 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2793,6 +2793,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2801,6 +2801,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
                              ServerGamePacketListenerImpl.this.cserver.getPluginManager().callEvent(event);
  
@@ -2697,7 +2697,7 @@ index e2935115c8d41af1d623da4f0d4f73de80386129..b6e2e7398413296449e8f132a2a6296d
      }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java b/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
-index 89f761871a84f8ab95f2a16aba8340bb8726da30..99adff4f1d4cd19227dff1554ebf40be6c1daa86 100644
+index f6e2348b280eaefc0eb05bf5d962593caa654357..ea0f568819994da042ba3182a66cc6ea2c4287bd 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
 @@ -81,6 +81,23 @@ public class Sniffer extends Animal {

--- a/patches/server/0010-Barrels-and-enderchests-6-rows.patch
+++ b/patches/server/0010-Barrels-and-enderchests-6-rows.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Barrels and enderchests 6 rows
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c996a28e3d6dd775021b2a1d199ac96d64b798f9..86a1f0733ed2aabe09fc748bdf9561d9b9a8286e 100644
+index 81a6b5e6315d61408f926fd702feadc3034dfa96..3af2e1eabfa3e49f2aad676fe1516f749f289285 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1147,6 +1147,27 @@ public abstract class PlayerList {
+@@ -1151,6 +1151,27 @@ public abstract class PlayerList {
          player.getBukkitEntity().recalculatePermissions(); // CraftBukkit
          this.server.getCommands().sendCommands(player);
          } // Paper
@@ -37,7 +37,7 @@ index c996a28e3d6dd775021b2a1d199ac96d64b798f9..86a1f0733ed2aabe09fc748bdf9561d9
  
      public boolean isWhiteListed(GameProfile profile) {
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 9cccd24c096caa7a78f2bafabf0760c7a9112fdb..65cdd155dc71cf0866a28714dc2c6a92886f2755 100644
+index ffcc81c07b5aa45d1471e05676f43e96db13b045..5cc0b0754feb9a78b8a71e0cb22d2a29243ba3d2 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -186,6 +186,7 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0012-AFK-API.patch
+++ b/patches/server/0012-AFK-API.patch
@@ -73,10 +73,10 @@ index d59e49a4958ebfb2ce0b9ca127b5a98fc5d88804..71905201cd42094fa3f545f29ada0f7e
          return this.stats;
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index df46668a78adab398f57b4df98d1347844a6674a..db1ff7b3a5d19171480d065ff827606efecbba0f 100644
+index 34072d4d438ca90d921d4af7f4be99f5ee58bc51..951dfa2b71695d2cf3dd3c14a9f7c9165e5c5a4d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -337,6 +337,20 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -338,6 +338,20 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      private boolean justTeleported = false;
      private boolean hasMoved; // Spigot
  
@@ -97,7 +97,7 @@ index df46668a78adab398f57b4df98d1347844a6674a..db1ff7b3a5d19171480d065ff827606e
      public CraftPlayer getCraftPlayer() {
          return (this.player == null) ? null : (CraftPlayer) this.player.getBukkitEntity();
      }
-@@ -430,6 +444,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -431,6 +445,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          }
  
          if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60) && !this.player.wonGame) { // Paper - Prevent AFK kick while watching end credits.
@@ -110,7 +110,7 @@ index df46668a78adab398f57b4df98d1347844a6674a..db1ff7b3a5d19171480d065ff827606e
              this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
              this.disconnect(Component.translatable("multiplayer.disconnect.idling"), org.bukkit.event.player.PlayerKickEvent.Cause.IDLING); // Paper - kick event cause
          }
-@@ -734,6 +754,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -742,6 +762,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                      this.lastYaw = to.getYaw();
                      this.lastPitch = to.getPitch();
  
@@ -119,7 +119,7 @@ index df46668a78adab398f57b4df98d1347844a6674a..db1ff7b3a5d19171480d065ff827606e
                      // Skip the first time we do this
                      if (true) { // Spigot - don't skip any move events
                          Location oldTo = to.clone();
-@@ -1538,7 +1560,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1546,7 +1568,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
                              if (!this.player.isChangingDimension() && d11 > org.spigotmc.SpigotConfig.movedWronglyThreshold && !this.player.isSleeping() && !this.player.gameMode.isCreative() && this.player.gameMode.getGameModeForPlayer() != GameType.SPECTATOR) { // Spigot
                                  flag2 = true; // Paper - diff on change, this should be moved wrongly
@@ -128,7 +128,7 @@ index df46668a78adab398f57b4df98d1347844a6674a..db1ff7b3a5d19171480d065ff827606e
                              }
  
                              this.player.absMoveTo(d0, d1, d2, f, f1);
-@@ -1589,6 +1611,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1597,6 +1619,8 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                                      this.lastYaw = to.getYaw();
                                      this.lastPitch = to.getPitch();
  
@@ -218,10 +218,10 @@ index 3b959f42d958bf0f426853aee56753d6c455fcdb..d17abb283ea818244df0379d6b57fc63
                  if (range < 0.0D || d < range * range) {
                      return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7188e31ade709b244d378a685a7188c5aa7dd279..5e5062648d0822f9364dbefddb3f496f39001e23 100644
+index 722ba7f34d4f6c0d470f6a933da61837442e1c68..10d52b858be9ab93bd934bf9ca35f272410c3c96 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -525,10 +525,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -528,10 +528,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setPlayerListName(String name) {
@@ -238,7 +238,7 @@ index 7188e31ade709b244d378a685a7188c5aa7dd279..5e5062648d0822f9364dbefddb3f496f
          for (ServerPlayer player : (List<ServerPlayer>) server.getHandle().players) {
              if (player.getBukkitEntity().canSee(this)) {
                  player.connection.send(new ClientboundPlayerInfoUpdatePacket(ClientboundPlayerInfoUpdatePacket.Action.UPDATE_DISPLAY_NAME, this.getHandle()));
-@@ -3164,5 +3169,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3167,5 +3172,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean usesPurpurClient() {
          return getHandle().purpurClient;
      }
@@ -310,7 +310,7 @@ index 46b6994812086405f20a4dd410c1d79621958cd5..21a33a7952ea9d70df45a99e82286713
      public boolean untamedTamablesAreRidable = true;
      public boolean useNightVisionWhenRiding = false;
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 63d3fcc45be732a4cd2dc8b5347d860fd6577bdd..f1abcd9c63d7bb9797f05e3764262e0080c60da2 100644
+index 07050c78a2eb6ce0c699101b38961b111d631a41..1f37695950e69fc9784a415a5ab9c6586ed32e61 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -203,6 +203,7 @@ public class ActivationRange

--- a/patches/server/0018-Player-invulnerabilities.patch
+++ b/patches/server/0018-Player-invulnerabilities.patch
@@ -82,10 +82,10 @@ index 71905201cd42094fa3f545f29ada0f7ebcd7c21d..f5c5ed6cfb963ad2b5612fd7623d5e0f
      public Scoreboard getScoreboard() {
          return this.getBukkitEntity().getScoreboard().getHandle();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index db1ff7b3a5d19171480d065ff827606efecbba0f..6568f3dac5a77ac0cbbaffe7bf499ca1b5f3ff81 100644
+index 951dfa2b71695d2cf3dd3c14a9f7c9165e5c5a4d..470f44cd4627ab48573a22714ccd088bd318dbd0 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2082,12 +2082,21 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2090,12 +2090,21 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      @Override
      public void handleResourcePackResponse(ServerboundResourcePackPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());
@@ -108,10 +108,10 @@ index db1ff7b3a5d19171480d065ff827606efecbba0f..6568f3dac5a77ac0cbbaffe7bf499ca1
          this.cserver.getPluginManager().callEvent(new PlayerResourcePackStatusEvent(this.getCraftPlayer(), packStatus)); // CraftBukkit
          // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 86a1f0733ed2aabe09fc748bdf9561d9b9a8286e..3ed1af31cf0beb945699480bca104e7a282e3651 100644
+index 3af2e1eabfa3e49f2aad676fe1516f749f289285..f50689f9a9e74856725f92817892c1af0edf340d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -962,6 +962,8 @@ public abstract class PlayerList {
+@@ -966,6 +966,8 @@ public abstract class PlayerList {
          }
          // Paper end
  
@@ -121,10 +121,10 @@ index 86a1f0733ed2aabe09fc748bdf9561d9b9a8286e..3ed1af31cf0beb945699480bca104e7a
          return entityplayer1;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5e5062648d0822f9364dbefddb3f496f39001e23..0ed68ef0152b36960d74e9d7f0466cf09eaacfac 100644
+index 10d52b858be9ab93bd934bf9ca35f272410c3c96..6ad913ee78570db794fd2953cc1320905fa557de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3184,5 +3184,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3187,5 +3187,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetIdleTimer() {
          getHandle().resetLastActionTime();
      }

--- a/patches/server/0020-Alternative-Keepalive-Handling.patch
+++ b/patches/server/0020-Alternative-Keepalive-Handling.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Alternative Keepalive Handling
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fce3de7864cbded18b4d5fb3dc37122efe9d38f4..9cfc42eb35c5a1f36b7f5976b67d62d063973e0b 100644
+index 470f44cd4627ab48573a22714ccd088bd318dbd0..427041d523ccabcf585994638903df571e7adefe 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -261,6 +261,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
@@ -16,7 +16,7 @@ index fce3de7864cbded18b4d5fb3dc37122efe9d38f4..9cfc42eb35c5a1f36b7f5976b67d62d0
      // CraftBukkit start - multithreaded fields
      private final AtomicInteger chatSpamTickCount = new AtomicInteger();
      private final java.util.concurrent.atomic.AtomicInteger tabSpamLimiter = new java.util.concurrent.atomic.AtomicInteger(); // Paper - configurable tab spam limits
-@@ -412,6 +413,21 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -413,6 +414,21 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          long currentTime = Util.getMillis();
          long elapsedTime = currentTime - this.keepAliveTime;
  
@@ -38,7 +38,7 @@ index fce3de7864cbded18b4d5fb3dc37122efe9d38f4..9cfc42eb35c5a1f36b7f5976b67d62d0
          if (this.keepAlivePending) {
              if (!this.processedDisconnect && elapsedTime >= KEEPALIVE_LIMIT) { // check keepalive limit, don't fire if already disconnected
                  ServerGamePacketListenerImpl.LOGGER.warn("{} was kicked due to keepalive timeout!", this.player.getScoreboardName()); // more info
-@@ -3511,6 +3527,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3519,6 +3535,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
      @Override
      public void handleKeepAlive(ServerboundKeepAlivePacket packet) {

--- a/patches/server/0048-Add-permission-for-F3-N-debug.patch
+++ b/patches/server/0048-Add-permission-for-F3-N-debug.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add permission for F3+N debug
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3ed1af31cf0beb945699480bca104e7a282e3651..dc500865eca561d465d5ff495ae65e7892b366ea 100644
+index f50689f9a9e74856725f92817892c1af0edf340d..f3a629d28506fc90e19db79fec1dc0ba67190835 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1141,6 +1141,7 @@ public abstract class PlayerList {
+@@ -1145,6 +1145,7 @@ public abstract class PlayerList {
              } else {
                  b0 = (byte) (24 + permissionLevel);
              }

--- a/patches/server/0062-Add-5-second-tps-average-in-tps.patch
+++ b/patches/server/0062-Add-5-second-tps-average-in-tps.patch
@@ -27,7 +27,7 @@ index fa56cd09102a89692b42f1d14257990508c5c720..f9251183df72ddc56662fd3f02acf216
          setListData(vector);
      }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ffc045d1bf40e620fb8364ac8694f39afdb9067b..585b5cd7361c01157ba279f21fea05e990738e34 100644
+index ffc045d1bf40e620fb8364ac8694f39afdb9067b..c0442a8fe5236c071d390a7b4b08cd11212150f9 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -305,7 +305,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -51,7 +51,7 @@ index ffc045d1bf40e620fb8364ac8694f39afdb9067b..585b5cd7361c01157ba279f21fea05e9
                  {
                      final long diff = curTime - tickSection;
                      java.math.BigDecimal currentTps = TPS_BASE.divide(new java.math.BigDecimal(diff), 30, java.math.RoundingMode.HALF_UP);
-+                        tps5s.add(currentTps, diff); // Purpur
++                    tps5s.add(currentTps, diff); // Purpur
                      tps1.add(currentTps, diff);
                      tps5.add(currentTps, diff);
                      tps15.add(currentTps, diff);
@@ -69,7 +69,7 @@ index ffc045d1bf40e620fb8364ac8694f39afdb9067b..585b5cd7361c01157ba279f21fea05e9
                          lagging = recentTps[0] < org.purpurmc.purpur.PurpurConfig.laggingThreshold; // Purpur
                      tickSection = curTime;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c6067c4446ee5c531bc2c855ebd0c9cb2e3dada8..6f4cb22b477042cb895572596797556e0f21a100 100644
+index aa23b90d46f538563c2e399c7b8b0f4f342b67a8..24a21e5a62334a92d2b57b60fc273d3c043bf568 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2706,6 +2706,7 @@ public final class CraftServer implements Server {
@@ -81,15 +81,15 @@ index c6067c4446ee5c531bc2c855ebd0c9cb2e3dada8..6f4cb22b477042cb895572596797556e
                  net.minecraft.server.MinecraftServer.getServer().tps5.getAverage(),
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
 diff --git a/src/main/java/org/spigotmc/TicksPerSecondCommand.java b/src/main/java/org/spigotmc/TicksPerSecondCommand.java
-index 9bede6a26c08ede063c7a38f1149c811df14b258..088239d17aa8178cf8af09ec23cfd4deaaf2bbb6 100644
+index b1a72aa3634405f3fce64c66677a75d8f77cb6f6..df158d5339000cbc3206e4e1e0603acb1d39c528 100644
 --- a/src/main/java/org/spigotmc/TicksPerSecondCommand.java
 +++ b/src/main/java/org/spigotmc/TicksPerSecondCommand.java
-@@ -31,7 +31,7 @@ public class TicksPerSecondCommand extends Command
+@@ -37,7 +37,7 @@ public class TicksPerSecondCommand extends Command
          for ( int i = 0; i < tps.length; i++) {
              tpsAvg[i] = TicksPerSecondCommand.format( tps[i] );
          }
--        sender.sendMessage(ChatColor.GOLD + "TPS from last 1m, 5m, 15m: " + org.apache.commons.lang.StringUtils.join(tpsAvg, ", "));
-+        sender.sendMessage(ChatColor.GOLD + "TPS from last 5s, 1m, 5m, 15m: " + org.apache.commons.lang.StringUtils.join(tpsAvg, ", ")); // Purpur
+-        sender.sendMessage(net.kyori.adventure.text.Component.text("TPS from last 1m, 5m, 15m: " + org.apache.commons.lang.StringUtils.join(tpsAvg, ", "), net.kyori.adventure.text.format.NamedTextColor.GOLD));
++        sender.sendMessage(net.kyori.adventure.text.Component.text("TPS from last 5s, 1m, 5m, 15m: " + org.apache.commons.lang.StringUtils.join(tpsAvg, ", "), net.kyori.adventure.text.format.NamedTextColor.GOLD));
          if (args.length > 0 && args[0].equals("mem") && sender.hasPermission("bukkit.command.tpsmemory")) {
-             sender.sendMessage(ChatColor.GOLD + "Current Memory Usage: " + ChatColor.GREEN + ((Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024 * 1024)) + "/" + (Runtime.getRuntime().totalMemory() / (1024 * 1024)) + " mb (Max: " + (Runtime.getRuntime().maxMemory() / (1024 * 1024)) + " mb)");
-             if (!hasShownMemoryWarning) {
+             sender.sendMessage(net.kyori.adventure.text.Component.text()
+                 .append(net.kyori.adventure.text.Component.text("Current Memory Usage: ", net.kyori.adventure.text.format.NamedTextColor.GOLD))

--- a/patches/server/0074-Allow-color-codes-in-books.patch
+++ b/patches/server/0074-Allow-color-codes-in-books.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow color codes in books
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4e23ff71e14be7b88abc0bbcb8523eeb87556310..ee1a16c9fa76685e43b47495cff95b2abe1c040b 100644
+index 427041d523ccabcf585994638903df571e7adefe..5ce2eebcd883bf18e59444c988a3d2ee4b3321ca 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1332,13 +1332,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1340,13 +1340,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                  itemstack1.setTag(nbttagcompound.copy());
              }
  
@@ -28,7 +28,7 @@ index 4e23ff71e14be7b88abc0bbcb8523eeb87556310..ee1a16c9fa76685e43b47495cff95b2a
  
              this.updateBookPages(pages, (s) -> {
                  return Component.Serializer.toJson(Component.literal(s));
-@@ -1350,10 +1353,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1358,10 +1361,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      private void updateBookPages(List<FilteredText> list, UnaryOperator<String> unaryoperator, ItemStack itemstack, int slot, ItemStack handItem) { // CraftBukkit
          ListTag nbttaglist = new ListTag();
  
@@ -44,7 +44,7 @@ index 4e23ff71e14be7b88abc0bbcb8523eeb87556310..ee1a16c9fa76685e43b47495cff95b2a
  
              Objects.requireNonNull(nbttaglist);
              stream.forEach(nbttaglist::add);
-@@ -1363,11 +1369,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1371,11 +1377,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
              for (int j = list.size(); i < j; ++i) {
                  FilteredText filteredtext = (FilteredText) list.get(i);
@@ -58,7 +58,7 @@ index 4e23ff71e14be7b88abc0bbcb8523eeb87556310..ee1a16c9fa76685e43b47495cff95b2a
                  }
              }
  
-@@ -1380,6 +1386,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1388,6 +1394,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          this.player.getInventory().setItem(slot, CraftEventFactory.handleEditBookEvent(player, slot, handItem, itemstack)); // CraftBukkit // Paper - Don't ignore result (see other callsite for handleEditBookEvent)
      }
  

--- a/patches/server/0075-Entity-lifespan.patch
+++ b/patches/server/0075-Entity-lifespan.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity lifespan
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d6c81951f702277fb4e78f0bee6a08e03f9884e6..b48014c6b7d08272be97ad76d6175e907b5018a2 100644
+index 5ce2eebcd883bf18e59444c988a3d2ee4b3321ca..f78fe22022d9b2718613ed8822b51449061fcdaa 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2845,6 +2845,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2853,6 +2853,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              AABB axisalignedbb = entity.getBoundingBox();
  
              if (axisalignedbb.distanceToSqr(this.player.getEyePosition()) < ServerGamePacketListenerImpl.MAX_INTERACTION_DISTANCE) {

--- a/patches/server/0077-Squid-EAR-immunity.patch
+++ b/patches/server/0077-Squid-EAR-immunity.patch
@@ -25,7 +25,7 @@ index 2cbab8dc920fff0d1573072b791f39debd61a710..6b2a2b898d8a4b75f7c9d1ec7112e4f7
  
      public boolean spiderRidable = false;
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index f1abcd9c63d7bb9797f05e3764262e0080c60da2..00744aceb25ddc689b8c5ed90ae27e1ea28057ad 100644
+index 1f37695950e69fc9784a415a5ab9c6586ed32e61..d9448a222bbe2cbd09debfb93f339b175ed44c92 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -15,6 +15,7 @@ import net.minecraft.world.entity.ambient.AmbientCreature;
@@ -36,7 +36,7 @@ index f1abcd9c63d7bb9797f05e3764262e0080c60da2..00744aceb25ddc689b8c5ed90ae27e1e
  import net.minecraft.world.entity.animal.WaterAnimal;
  import net.minecraft.world.entity.animal.horse.Llama;
  import net.minecraft.world.entity.boss.EnderDragonPart;
-@@ -396,6 +397,7 @@ public class ActivationRange
+@@ -397,6 +398,7 @@ public class ActivationRange
       */
      public static boolean checkIfActive(Entity entity)
      {

--- a/patches/server/0121-Implement-TPSBar.patch
+++ b/patches/server/0121-Implement-TPSBar.patch
@@ -17,7 +17,7 @@ index 277fb799d898ca726205519b1516861901be33c5..144e83bac0d8885c48d97d7fbb4b712d
  
          if (environment.includeIntegrated) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 371de53f342e6dba7da54a6d60c1907f06fa9191..40a52c16e4e9da8c846ff69e9d22066ff134caea 100644
+index a5e7147f8dd8085ed9a14086f5925596682ffee7..037b56aa1455b88065e0046a5c97f489a8af40a8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1026,6 +1026,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -84,10 +84,10 @@ index ead34927019224e76063ac1a040dea78022fb36a..adceeb21805e207b0bc0cfa0035eefcb
      // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index dc500865eca561d465d5ff495ae65e7892b366ea..5041ed85e1cbe8ffee8d4760b668fe32402ec0be 100644
+index f3a629d28506fc90e19db79fec1dc0ba67190835..531c7005165cfa959cc4b0a98509bdf833eb13a7 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -462,6 +462,7 @@ public abstract class PlayerList {
+@@ -466,6 +466,7 @@ public abstract class PlayerList {
              scoreboard.addPlayerToTeam(player.getScoreboardName(), collideRuleTeam);
          }
          // Paper end
@@ -95,7 +95,7 @@ index dc500865eca561d465d5ff495ae65e7892b366ea..5041ed85e1cbe8ffee8d4760b668fe32
          // CraftBukkit - Moved from above, added world
          PlayerList.LOGGER.info("{}[{}] logged in with entity id {} at ([{}]{}, {}, {})", player.getName().getString(), s1, player.getId(), worldserver1.serverLevelData.getLevelName(), player.getX(), player.getY(), player.getZ());
      }
-@@ -571,6 +572,8 @@ public abstract class PlayerList {
+@@ -575,6 +576,8 @@ public abstract class PlayerList {
      }
      public net.kyori.adventure.text.Component remove(ServerPlayer entityplayer, net.kyori.adventure.text.Component leaveMessage) {
          // Paper end

--- a/patches/server/0123-PlayerBookTooLargeEvent.patch
+++ b/patches/server/0123-PlayerBookTooLargeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerBookTooLargeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f82e2a6e3803645ec002afeb62ccb44c5ec15fde..fb9a1cacc6246a822931d6dd71c092a2f7048712 100644
+index f78fe22022d9b2718613ed8822b51449061fcdaa..9871c168cb9ac20127aa5bb61b5d46ffec1af753 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1252,10 +1252,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1260,10 +1260,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              int maxBookPageSize = io.papermc.paper.configuration.GlobalConfiguration.get().itemValidation.bookSize.pageMax;
              double multiplier = Math.max(0.3D, Math.min(1D, io.papermc.paper.configuration.GlobalConfiguration.get().itemValidation.bookSize.totalMultiplier));
              long byteAllowed = maxBookPageSize;
@@ -21,7 +21,7 @@ index f82e2a6e3803645ec002afeb62ccb44c5ec15fde..fb9a1cacc6246a822931d6dd71c092a2
                      server.scheduleOnMain(() -> this.disconnect("Book too large!", org.bukkit.event.player.PlayerKickEvent.Cause.ILLEGAL_ACTION)); // Paper - kick event cause
                      return;
                  }
-@@ -1279,6 +1281,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1287,6 +1289,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
              if (byteTotal > byteAllowed) {
                  ServerGamePacketListenerImpl.LOGGER.warn(this.player.getScoreboardName() + " tried to send too large of a book. Book Size: " + byteTotal + " - Allowed:  "+ byteAllowed + " - Pages: " + pageList.size());

--- a/patches/server/0128-Add-EntityTeleportHinderedEvent.patch
+++ b/patches/server/0128-Add-EntityTeleportHinderedEvent.patch
@@ -89,10 +89,10 @@ index fa6938626c64ed17a2f56739d5801494ea6f3be1..df33bd0c97faa3c7eb4ab6cbe7286f6a
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 254d91e2a06186d602f7edae7a46b0e4ee9be662..2aaebeb6dc44f5be176471816de29056ea4e1043 100644
+index 6ad913ee78570db794fd2953cc1320905fa557de..37865836db462b365c1fd5cb43f610295b80cf84 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1341,6 +1341,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1344,6 +1344,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          if (entity.isVehicle() && !ignorePassengers) { // Paper - Teleport API
@@ -104,7 +104,7 @@ index 254d91e2a06186d602f7edae7a46b0e4ee9be662..2aaebeb6dc44f5be176471816de29056
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 622a6226ac1ed4e97dc667fdc30679a97d4f44b0..444879c211a1298d59e6c38e769a5521241fa060 100644
+index 7b8eaac637ec1db255bb63d8b73d86c267642035..81428fd4d0de768eed12711eb1859989fa28b6e2 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -119,6 +119,7 @@ public class PurpurWorldConfig {

--- a/patches/server/0136-Dont-run-with-scissors.patch
+++ b/patches/server/0136-Dont-run-with-scissors.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Dont run with scissors!
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fb9a1cacc6246a822931d6dd71c092a2f7048712..a004ee039ed9129ffbcbba3d591e16de70c7eff1 100644
+index 9871c168cb9ac20127aa5bb61b5d46ffec1af753..ef10fa567b1f9d1b23f5679c65798511c2e53b37 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -1687,6 +1687,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1695,6 +1695,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                                      this.player.resetFallDistance();
                                  }
  
@@ -22,7 +22,7 @@ index fb9a1cacc6246a822931d6dd71c092a2f7048712..a004ee039ed9129ffbcbba3d591e16de
                                  this.player.checkMovementStatistics(this.player.getX() - d3, this.player.getY() - d4, this.player.getZ() - d5);
                                  this.lastGoodX = this.player.getX();
                                  this.lastGoodY = this.player.getY();
-@@ -1720,6 +1727,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1728,6 +1735,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      }
      // Paper end - optimise out extra getCubes
  
@@ -61,7 +61,7 @@ index 5b0625955e2a65f689c8a128d73170bc1f0c8025..c8097ec7887ac8e689b6843d9ff7744d
  
      public static String serverModName = "Purpur";
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e3d6108c58e4a6447eca536764cdf20507603ebf..afa4f88f0aae074a05d6a38547fb4a069a813964 100644
+index 09582ba26c93e260a1eb4aad5e71f059a7457cc2..940a5436d9ceec72a103ede707afd1cd2e0a71d0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -199,6 +199,10 @@ public class PurpurWorldConfig {

--- a/patches/server/0186-Allow-player-join-full-server-by-permission.patch
+++ b/patches/server/0186-Allow-player-join-full-server-by-permission.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow player join full server by permission
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 5041ed85e1cbe8ffee8d4760b668fe32402ec0be..bd3e2345929d1dc5c126e2506c6569e1a41ebf4d 100644
+index 531c7005165cfa959cc4b0a98509bdf833eb13a7..71d3a4c16e80bf16d8c5841a04c532c1f69c0c0b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -727,7 +727,7 @@ public abstract class PlayerList {
+@@ -731,7 +731,7 @@ public abstract class PlayerList {
              event.disallow(PlayerLoginEvent.Result.KICK_BANNED, PaperAdventure.asAdventure(ichatmutablecomponent)); // Paper - Adventure
          } else {
              // return this.players.size() >= this.maxPlayers && !this.canBypassPlayerLimit(gameprofile) ? IChatBaseComponent.translatable("multiplayer.disconnect.server_full") : null;

--- a/patches/server/0215-Extended-OfflinePlayer-API.patch
+++ b/patches/server/0215-Extended-OfflinePlayer-API.patch
@@ -223,10 +223,10 @@ index 714afc98b5150907b45a00060be4e41582333204..312a6d90c0a09570aef24c205dc2ff27
 +    // Purpur end - OfflinePlayer API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2813032e6cfe0a4f2258dc7246c5bde0426dfe0b..51be48d1ebfcceac087cf7f03ce332d8d402360c 100644
+index 37865836db462b365c1fd5cb43f610295b80cf84..85f89f26a65d659976eef400713541058f23de31 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2375,6 +2375,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2378,6 +2378,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return this.getHandle().getAbilities().walkingSpeed * 2f;
      }
  

--- a/patches/server/0219-Shift-right-click-to-use-exp-for-mending.patch
+++ b/patches/server/0219-Shift-right-click-to-use-exp-for-mending.patch
@@ -36,10 +36,10 @@ index 6b186a49957e97a60bb245912211d58eb7b84c0d..75f29f6dddf50ccf7ef43ecfa602ccad
 +    // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a004ee039ed9129ffbcbba3d591e16de70c7eff1..672fb9b917f994e9778a833ce722d6b5b3900e5a 100644
+index ef10fa567b1f9d1b23f5679c65798511c2e53b37..ce2872a137b06cb2e4bd4b8d8fff06f720260e10 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2077,6 +2077,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2085,6 +2085,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
  
              boolean cancelled;
              if (movingobjectposition == null || movingobjectposition.getType() != HitResult.Type.BLOCK) {

--- a/patches/server/0230-Signs-allow-color-codes.patch
+++ b/patches/server/0230-Signs-allow-color-codes.patch
@@ -17,10 +17,10 @@ index 44562c3ae8d0776b8834587b1d3fb628c97a7138..de504623d3b7aff451edbc9b87249c99
          this.connection.send(new ClientboundBlockUpdatePacket(this.level, sign.getBlockPos()));
          this.connection.send(new ClientboundOpenSignEditorPacket(sign.getBlockPos()));
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a38cc0c318cbf591d4eb1c6b540c94a459a7af45..3cf6dff82e76ad89dd783221c0c24c75b6899321 100644
+index ce2872a137b06cb2e4bd4b8d8fff06f720260e10..b8c2cbf0abbb81769c3887794656132a9f597b0b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3535,11 +3535,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3543,11 +3543,17 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              for (int i = 0; i < signText.size(); ++i) {
                  FilteredText filteredtext = (FilteredText) signText.get(i);
  

--- a/patches/server/0267-Option-to-disable-kick-for-out-of-order-chat.patch
+++ b/patches/server/0267-Option-to-disable-kick-for-out-of-order-chat.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to disable kick for out of order chat
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3cf6dff82e76ad89dd783221c0c24c75b6899321..82ecca48fdb1bffc87ec21b569725d87fbfb7325 100644
+index b8c2cbf0abbb81769c3887794656132a9f597b0b..ea3bfb5f639d5d3357111c82a974a8de1e9e178f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2436,7 +2436,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2444,7 +2444,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          do {
              instant1 = (Instant) this.lastChatTimeStamp.get();
              if (timestamp.isBefore(instant1)) {

--- a/patches/server/0276-Remove-Timings.patch
+++ b/patches/server/0276-Remove-Timings.patch
@@ -77,7 +77,7 @@ index d2f0a0755317f5fa9a1ccf7db346aa77fd287d80..03852e7d21d9470a4469676367463fef
                      } catch (Exception exception) {
                          if (listener.shouldPropagateHandlingExceptions()) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 64b4397a3d91d9c5a29498e738c317f362106fec..123c7f9730a999ea5ea11de817fa61cc455e6962 100644
+index 1b833662bba290a8fc031a8479a680b0ed96f809..4150b1d788ec23a1e0b33592c1d3d3600ebe2a36 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1408,15 +1408,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -471,7 +471,7 @@ index 8438354e482b6f892c3344eceff1abd23cfa128a..7dde0357d0c63469176a44d84631c52e
              // Paper end - use set of chunks requiring updates, rather than iterating every single one loaded
              // Paper start - controlled flush for entity tracker packets
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index e0951fd02868f04bb12afab15b73b6d41e814abd..74ab15db63acae728a55ad2cde40ae9bfa3003f3 100644
+index b3226f53559da2cdc2b74b02cd89921e6001556a..2d367377ac024b6ab3d9072813d03ad36db5a22d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -687,7 +687,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -650,10 +650,10 @@ index e0951fd02868f04bb12afab15b73b6d41e814abd..74ab15db63acae728a55ad2cde40ae9b
  
          } else if (close) { chunkproviderserver.close(false); } // Paper - rewrite chunk system
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 82ecca48fdb1bffc87ec21b569725d87fbfb7325..517b70c1c421d48de775d92c4383e40a48fd53a8 100644
+index ea3bfb5f639d5d3357111c82a974a8de1e9e178f..43a5eb13728bee99cdf87947d98c042689d1af53 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -2573,7 +2573,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2581,7 +2581,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              }
          }
          // Paper End
@@ -662,7 +662,7 @@ index 82ecca48fdb1bffc87ec21b569725d87fbfb7325..517b70c1c421d48de775d92c4383e40a
          if ( org.spigotmc.SpigotConfig.logCommands ) // Spigot
          this.LOGGER.info(this.player.getScoreboardName() + " issued server command: " + s);
  
-@@ -2583,7 +2583,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2591,7 +2591,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          this.cserver.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {
@@ -671,7 +671,7 @@ index 82ecca48fdb1bffc87ec21b569725d87fbfb7325..517b70c1c421d48de775d92c4383e40a
              return;
          }
  
-@@ -2596,7 +2596,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -2604,7 +2604,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              java.util.logging.Logger.getLogger(ServerGamePacketListenerImpl.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
              return;
          } finally {
@@ -681,10 +681,10 @@ index 82ecca48fdb1bffc87ec21b569725d87fbfb7325..517b70c1c421d48de775d92c4383e40a
      }
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index bd3e2345929d1dc5c126e2506c6569e1a41ebf4d..1a288ebcaade0cc44c7d09478f4f2f8eee7a4269 100644
+index 71d3a4c16e80bf16d8c5841a04c532c1f69c0c0b..b04e905534baf35e50d9d09921581e04edd19fc5 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1235,7 +1235,7 @@ public abstract class PlayerList {
+@@ -1239,7 +1239,7 @@ public abstract class PlayerList {
  
      public void saveAll(int interval) {
          io.papermc.paper.util.MCUtil.ensureMain("Save Players" , () -> { // Paper - Ensure main
@@ -693,7 +693,7 @@ index bd3e2345929d1dc5c126e2506c6569e1a41ebf4d..1a288ebcaade0cc44c7d09478f4f2f8e
          int numSaved = 0;
          long now = MinecraftServer.currentTick;
          for (int i = 0; i < this.players.size(); ++i) {
-@@ -1246,7 +1246,7 @@ public abstract class PlayerList {
+@@ -1250,7 +1250,7 @@ public abstract class PlayerList {
              }
              // Paper end
          }
@@ -923,7 +923,7 @@ index 138407c2d4b0bc55ddb9aac5d2aa3edadda090fb..a6e9e503a496c18e2501b03ec84f4600
          // Paper end - add timings for scoreboard search
      }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 00744aceb25ddc689b8c5ed90ae27e1ea28057ad..665625c69b93a2568b1f2218a0db39da435d8c99 100644
+index d9448a222bbe2cbd09debfb93f339b175ed44c92..ee64ddb0da23ea1e54d0295324aca5b46a438111 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -170,7 +170,7 @@ public class ActivationRange
@@ -935,7 +935,7 @@ index 00744aceb25ddc689b8c5ed90ae27e1ea28057ad..665625c69b93a2568b1f2218a0db39da
          final int miscActivationRange = world.spigotConfig.miscActivationRange;
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
-@@ -244,7 +244,7 @@ public class ActivationRange
+@@ -245,7 +245,7 @@ public class ActivationRange
              }
              // Paper end
          }

--- a/patches/server/0277-Remove-Mojang-Profiler.patch
+++ b/patches/server/0277-Remove-Mojang-Profiler.patch
@@ -39,7 +39,7 @@ index 314ab6183e31b4bac6a40c1f8007d48e9cab1760..6b05907bfec377e72a8858534d001bda
  
          return b0;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 123c7f9730a999ea5ea11de817fa61cc455e6962..ee0a1f4be8a30f90e4c64deb31c06a78690aa09e 100644
+index 4150b1d788ec23a1e0b33592c1d3d3600ebe2a36..41b03fdb34d58630ef30308004c9652e1a830f68 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -343,13 +343,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -556,7 +556,7 @@ index 7dde0357d0c63469176a44d84631c52efdd83d41..30d364b385da21544a810a76f436f068
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 74ab15db63acae728a55ad2cde40ae9bfa3003f3..43bf3285729ec5cedb3de84f2b60673928b079db 100644
+index 2d367377ac024b6ab3d9072813d03ad36db5a22d..06b0b78d16804b4bf8f6b5bb29b21b0eda57f0fc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -654,12 +654,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -801,10 +801,10 @@ index de504623d3b7aff451edbc9b87249c99efbcbed4..9081d891ddb61df628009232efdb31d6
                  this.connection.send(new ClientboundPlayerAbilitiesPacket(this.getAbilities()));
                  playerlist.sendLevelInfo(this, worldserver);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9cfe9f137a20a15af87d48fef0f7ee48400026ac..c7f8f15f8982b8514ee0ca0871a6934cdccd8d29 100644
+index 43a5eb13728bee99cdf87947d98c042689d1af53..d37bbff4375724fe85d1ed5cc0fa0696736736ac 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -407,7 +407,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -408,7 +408,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
              this.aboveGroundVehicleTickCount = 0;
          }
  
@@ -813,7 +813,7 @@ index 9cfe9f137a20a15af87d48fef0f7ee48400026ac..c7f8f15f8982b8514ee0ca0871a6934c
          // Paper Start - give clients a longer time to respond to pings as per pre 1.12.2 timings
          // This should effectively place the keepalive handling back to "as it was" before 1.12.2
          long currentTime = Util.getMillis();
-@@ -443,7 +443,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -444,7 +444,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          }
          // Paper end
  
@@ -1590,10 +1590,10 @@ index cb55b8479f8874ff2fa0941e277c4891cf3fe8d9..8129ad2ca6e0b4c6ca586dc221dcce1e
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java b/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
-index 595c23fee0f1ab313f64769c6cac33acaf9b9dcd..6e7c0e95b27c41bf12da1beb3458830ce27c6029 100644
+index a34f41878bffa7bbe01310be95bf4bc6711cc0ef..adae992ade60e0fce7ca0cc10192720025a574fe 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/sniffer/Sniffer.java
-@@ -469,11 +469,11 @@ public class Sniffer extends Animal {
+@@ -470,11 +470,11 @@ public class Sniffer extends Animal {
  
      @Override
      protected void customServerAiStep() {

--- a/patches/server/0278-Add-more-logger-output-for-invalid-movement-kicks.patch
+++ b/patches/server/0278-Add-more-logger-output-for-invalid-movement-kicks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more logger output for invalid movement kicks
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c7f8f15f8982b8514ee0ca0871a6934cdccd8d29..88cd723ecb0fe646db4225d036b8aeafba849b22 100644
+index d37bbff4375724fe85d1ed5cc0fa0696736736ac..9bfdd8970c3e48790795ab83b45146d133f5c673 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -848,6 +848,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -856,6 +856,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
          if (packet.getId() == this.awaitingTeleport) {
              if (this.awaitingPositionFromClient == null) {
                  this.disconnect(Component.translatable("multiplayer.disconnect.invalid_player_movement"), org.bukkit.event.player.PlayerKickEvent.Cause.INVALID_PLAYER_MOVEMENT); // Paper - kick event cause
@@ -16,7 +16,7 @@ index c7f8f15f8982b8514ee0ca0871a6934cdccd8d29..88cd723ecb0fe646db4225d036b8aeaf
                  return;
              }
  
-@@ -1428,8 +1429,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -1436,8 +1437,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
      @Override
      public void handleMovePlayer(ServerboundMovePlayerPacket packet) {
          PacketUtils.ensureRunningOnSameThread(packet, this, this.player.getLevel());

--- a/patches/server/0280-Debug-Marker-API.patch
+++ b/patches/server/0280-Debug-Marker-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Debug Marker API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 86e40bf7cf90c33f914c38f2edb3bd8c5bb00f1c..37f0618747e0615ff1ef583e12b434b0cfacdaba 100644
+index 9b06d1fbad26abb2daf9d9034239ffa28bd42952..b16437c40a5e9b329efc1c41cb5e1c348b35aae8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1446,6 +1446,42 @@ public final class CraftServer implements Server {
@@ -99,10 +99,10 @@ index 24b390702d6abc256aee4a282cca64a654b95bd8..c6a3b59c65466f9f2b16cefe0059a6e5
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 51be48d1ebfcceac087cf7f03ce332d8d402360c..bcd457d2344a6a3b76021bebce564233152454d0 100644
+index 85f89f26a65d659976eef400713541058f23de31..e45dc7306bfbc0516995104005e6564ec4b1a797 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3225,5 +3225,48 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3228,5 +3228,48 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setSpawnInvulnerableTicks(int spawnInvulnerableTime) {
          getHandle().spawnInvulnerableTime = spawnInvulnerableTime;
      }

--- a/patches/server/0284-Add-death-screen-API.patch
+++ b/patches/server/0284-Add-death-screen-API.patch
@@ -30,10 +30,10 @@ index 53b75f5737a910ffc5448cd9a85eae57f9c1488f..ea95873dd034779e56a8b924cd27f937
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bcd457d2344a6a3b76021bebce564233152454d0..f81b320ef330d03b68cf8b4af04b7c991ce9636b 100644
+index e45dc7306bfbc0516995104005e6564ec4b1a797..b7f1382d48a66f78c4492b0f8b90c16116a90220 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -3268,5 +3268,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -3271,5 +3271,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (this.getHandle().connection == null) return;
          this.getHandle().connection.send(new net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket(ClientboundCustomPayloadPacket.DEBUG_GAME_TEST_CLEAR, new FriendlyByteBuf(io.netty.buffer.Unpooled.buffer())));
      }

--- a/patches/server/0287-Add-item-packet-serialize-event.patch
+++ b/patches/server/0287-Add-item-packet-serialize-event.patch
@@ -36,7 +36,7 @@ index 9938bb90bef84cf784f9a1ceb02a1a45aa8b48a1..1f4b64a5f812376c499c98cb4be62469
  
              this.writeId(BuiltInRegistries.ITEM, item);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ee0a1f4be8a30f90e4c64deb31c06a78690aa09e..46b9aed8ab46bd4bfdcf44a392ffc34e26da0f5f 100644
+index 41b03fdb34d58630ef30308004c9652e1a830f68..612c383a83d5d8c8faab15b66874897b95916799 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1548,6 +1548,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -48,10 +48,10 @@ index ee0a1f4be8a30f90e4c64deb31c06a78690aa09e..46b9aed8ab46bd4bfdcf44a392ffc34e
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 0439be2715445a0517217275119a79422abbe94a..dd53bc05595c6ea7afff23f11e0f54e90078684f 100644
+index 9bfdd8970c3e48790795ab83b45146d133f5c673..21211e2790cd667ec389353fb90fb700f33421cc 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -3438,6 +3438,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
+@@ -3446,6 +3446,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Tic
                      }
                  }
              }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly

Paper Changes:
PaperMC/Paper@7a96bf2 Make debug dump file names consistent (#9075) 
PaperMC/Paper@1704bf7 [ci skip] Edit Paper download link in README (#9077) 
PaperMC/Paper@5fb3ab0 Allow non player entities in scoreboards by default (#9082) 
PaperMC/Paper@dc08c74 Remove duplicate animate packet for records (#8600) 
PaperMC/Paper@50e683d Added a config option for ticking markers (#9034) 
PaperMC/Paper@1d2fe64 fix: null SpawnReason for new player (#9015) 
PaperMC/Paper@9893e2b Deprecate ChatColor (#9069)
PaperMC/Paper@0849144 Do not send expired keys to players on login (#9090) 
PaperMC/Paper@641dafd Cleanup some patches (#9093)