### PR TITLE
Adds option for display name in afk message

### DIFF
--- a/patches/server/0012-AFK-API.patch
+++ b/patches/server/0012-AFK-API.patch
@@ -3,12 +3,13 @@ From: William Blake Galbreath <blake.galbreath@gmail.com>
 Date: Thu, 8 Aug 2019 15:29:15 -0500
 Subject: [PATCH] AFK API
 
+Adds the option for display names to be used in the afk broadcast
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 055915f609d1181bbcfa2ce72e1282ace71cb45c..4e68585de7601f87297977c426a8f4621c8c0860 100644
+index 055915f609d1181bbcfa2ce72e1282ace71cb45c..58d7daf06352713ad6dee2412dc0b9d5e900ddd0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2071,8 +2071,63 @@ public class ServerPlayer extends Player {
+@@ -2071,8 +2071,68 @@ public class ServerPlayer extends Player {
  
      public void resetLastActionTime() {
          this.lastActionTime = Util.getMillis();
@@ -39,7 +40,12 @@ index 055915f609d1181bbcfa2ce72e1282ace71cb45c..4e68585de7601f87297977c426a8f462
 +
 +        msg = event.getBroadcastMsg();
 +        if (msg != null && !msg.isEmpty()) {
-+            server.getPlayerList().broadcastMiniMessage(String.format(msg, this.getGameProfile().getName()), false);
++            String playerName = this.getGameProfile().getName();
++            if (org.purpurmc.purpur.PurpurConfig.afkBroadcastUseDisplayName) {
++                net.kyori.adventure.text.Component playerDisplayNameComponent = net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(this.getBukkitEntity().getDisplayName());
++                playerName = net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText().serialize(playerDisplayNameComponent);
++            }
++            server.getPlayerList().broadcastMiniMessage(String.format(msg, playerName), false);
 +        }
 +
 +        if (this.level.purpurConfig.idleTimeoutUpdateTabList) {
@@ -260,21 +266,23 @@ index 39ab19be66530c4792719d2d86b6979cffedcf83..2fd1eb97d70890efe431af32f47db29b
      // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index e6a720f25266d793bec5f644dadacbf45aef23f5..594d041c63f86dbafca756f6f7012b9ab5e385ef 100644
+index e6a720f25266d793bec5f644dadacbf45aef23f5..6b768cff1318b4bcebeed95345f3cfdce05a2c16 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -174,8 +174,16 @@ public class PurpurConfig {
+@@ -174,8 +174,18 @@ public class PurpurConfig {
      }
  
      public static String cannotRideMob = "<red>You cannot mount that mob";
 +    public static String afkBroadcastAway = "<yellow><italic>%s is now AFK";
 +    public static String afkBroadcastBack = "<yellow><italic>%s is no longer AFK";
++    public static boolean afkBroadcastUseDisplayName = false;
 +    public static String afkTabListPrefix = "[AFK] ";
 +    public static String afkTabListSuffix = "";
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
 +        afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
 +        afkBroadcastBack = getString("settings.messages.afk-broadcast-back", afkBroadcastBack);
++        afkBroadcastUseDisplayName = getBoolean("settings.messages.afk-broadcast-use-display-name", afkBroadcastUseDisplayName);
 +        afkTabListPrefix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-prefix", afkTabListPrefix)));
 +        afkTabListSuffix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-suffix", afkTabListSuffix)));
      }

--- a/patches/server/0014-Configurable-server-mod-name.patch
+++ b/patches/server/0014-Configurable-server-mod-name.patch
@@ -18,10 +18,10 @@ index 7f37231b33d6cfbd3d10c6c5d0b3e0b96ba0ceb3..57f6de7872bfa80cf7668524975946cb
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 594d041c63f86dbafca756f6f7012b9ab5e385ef..c01dd22d131a0048ff1d4dd86bb48fec6965494e 100644
+index 6b768cff1318b4bcebeed95345f3cfdce05a2c16..3d72f71c851e2d46e9cbeab9cdbadc532cb90eb2 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -186,6 +186,11 @@ public class PurpurConfig {
+@@ -188,6 +188,11 @@ public class PurpurConfig {
          afkTabListSuffix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-suffix", afkTabListSuffix)));
      }
  

--- a/patches/server/0016-Lagging-threshold.patch
+++ b/patches/server/0016-Lagging-threshold.patch
@@ -40,10 +40,10 @@ index c4c0cfa2530bab3d898603f2335ffe92460431b6..5805da6b1322d6be5067aeab91be90c0
      // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index c01dd22d131a0048ff1d4dd86bb48fec6965494e..96ceda25ed790d2cbc75488c46f05e44b4a876dc 100644
+index 3d72f71c851e2d46e9cbeab9cdbadc532cb90eb2..16ba03a9df0c3709c4794df7cb46249bda0bbac6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -191,6 +191,11 @@ public class PurpurConfig {
+@@ -193,6 +193,11 @@ public class PurpurConfig {
          serverModName = getString("settings.server-mod-name", serverModName);
      }
  

--- a/patches/server/0018-Player-invulnerabilities.patch
+++ b/patches/server/0018-Player-invulnerabilities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player invulnerabilities
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 4e68585de7601f87297977c426a8f4621c8c0860..600b003551757af0a6032fa114ca26e3bbd5f461 100644
+index 58d7daf06352713ad6dee2412dc0b9d5e900ddd0..c69d3d7a1970f7cec7a3e12b8633b9328c8d5d67 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -278,6 +278,7 @@ public class ServerPlayer extends Player {
@@ -62,7 +62,7 @@ index 4e68585de7601f87297977c426a8f4621c8c0860..600b003551757af0a6032fa114ca26e3
          this.connection.send(new ClientboundResourcePackPacket(url, hash, required, resourcePackPrompt));
      }
  
-@@ -2599,9 +2609,17 @@ public class ServerPlayer extends Player {
+@@ -2604,9 +2614,17 @@ public class ServerPlayer extends Player {
  
      @Override
      public boolean isImmobile() {

--- a/patches/server/0020-Alternative-Keepalive-Handling.patch
+++ b/patches/server/0020-Alternative-Keepalive-Handling.patch
@@ -56,10 +56,10 @@ index db737258db16ec9f61d0d601a6ea5f6b14638033..f7b3110cf30124fc4054bfcda6d5ad28
          if (this.keepAlivePending && packet.getId() == this.keepAliveChallenge) {
              int i = (int) (Util.getMillis() - this.keepAliveTime);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 1c09a68b4cdc275ed85859eef678e1e6e98ae993..b086bd679b74583d358f15ed017f56108fa85941 100644
+index 16ba03a9df0c3709c4794df7cb46249bda0bbac6..fa27bb42697cd5741b7308b34cd768232604a20f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -196,6 +196,11 @@ public class PurpurConfig {
+@@ -198,6 +198,11 @@ public class PurpurConfig {
          laggingThreshold = getDouble("settings.lagging-threshold", laggingThreshold);
      }
  

--- a/patches/server/0023-Logger-settings-suppressing-pointless-logs.patch
+++ b/patches/server/0023-Logger-settings-suppressing-pointless-logs.patch
@@ -53,10 +53,10 @@ index 110503062b3043cffa082a1cda6b8d57152869aa..3e7e06bd5e9e4ed45c9e3452eb04e946
          if (MinecraftServer.getServer() != null && MinecraftServer.getServer().isDebugging()) {
              new Exception().printStackTrace();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 70d128ed8d19d47056d2f3ba3f75efb12bcb0347..39cb606bdac144952d0e73055db3c3b38ee828f5 100644
+index fa27bb42697cd5741b7308b34cd768232604a20f..9db231480f0763c2b6514a956ec9398b98b7d1bc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -235,4 +235,15 @@ public class PurpurConfig {
+@@ -237,4 +237,15 @@ public class PurpurConfig {
          org.bukkit.event.inventory.InventoryType.ENDER_CHEST.setDefaultSize(enderChestSixRows ? 54 : 27);
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
      }

--- a/patches/server/0048-Configurable-TPS-Catchup.patch
+++ b/patches/server/0048-Configurable-TPS-Catchup.patch
@@ -24,10 +24,10 @@ index 6cdcd4f105b15f10d60499572f6f4f830565513e..ceaafede643bac0b6714df3d5475b4cb
                  this.profiler.pop();
                  this.endMetricsRecordingTick();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 39cb606bdac144952d0e73055db3c3b38ee828f5..01ac09bda83703c16aed64133096377d7113693e 100644
+index 9db231480f0763c2b6514a956ec9398b98b7d1bc..4905358e2a1939bfba963bda3fcf914721dfac45 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -246,4 +246,9 @@ public class PurpurConfig {
+@@ -248,4 +248,9 @@ public class PurpurConfig {
          loggerSuppressUnrecognizedRecipeErrors = getBoolean("settings.logger.suppress-unrecognized-recipe-errors", loggerSuppressUnrecognizedRecipeErrors);
          loggerSuppressSetBlockFarChunk = getBoolean("settings.logger.suppress-setblock-in-far-chunk-errors", loggerSuppressSetBlockFarChunk);
      }

--- a/patches/server/0064-Add-ping-command.patch
+++ b/patches/server/0064-Add-ping-command.patch
@@ -17,18 +17,19 @@ index 34d1fad0ad4adfcb0372ab16ecd7af0b92b5bedc..dc34d1a2fe967d94eb6ea16b51f1b8da
  
          if (environment.includeIntegrated) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 22b9e1b944bf5d771c3d60d460134b3274dac108..28c525a387d6636670a594c7fdf75a6c2d5466a9 100644
+index 4905358e2a1939bfba963bda3fcf914721dfac45..a74932163207506e779c941c819eb663b98bd18c 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -178,12 +178,14 @@ public class PurpurConfig {
-     public static String afkBroadcastBack = "<yellow><italic>%s is no longer AFK";
+@@ -179,6 +179,7 @@ public class PurpurConfig {
+     public static boolean afkBroadcastUseDisplayName = false;
      public static String afkTabListPrefix = "[AFK] ";
      public static String afkTabListSuffix = "";
 +    public static String pingCommandOutput = "<green>%s's ping is %sms";
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-         afkBroadcastBack = getString("settings.messages.afk-broadcast-back", afkBroadcastBack);
+@@ -186,6 +187,7 @@ public class PurpurConfig {
+         afkBroadcastUseDisplayName = getBoolean("settings.messages.afk-broadcast-use-display-name", afkBroadcastUseDisplayName);
          afkTabListPrefix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-prefix", afkTabListPrefix)));
          afkTabListSuffix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-suffix", afkTabListSuffix)));
 +        pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);

--- a/patches/server/0065-Add-demo-command.patch
+++ b/patches/server/0065-Add-demo-command.patch
@@ -17,19 +17,19 @@ index dc34d1a2fe967d94eb6ea16b51f1b8da205f95b5..a7c26527eb282d2f80fa14d265b748f7
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 28c525a387d6636670a594c7fdf75a6c2d5466a9..63095ddc7ea342a985b528441fdc658332e77f87 100644
+index a74932163207506e779c941c819eb663b98bd18c..235db276a07017bf89e6311a0b84291e8a0af06b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -178,6 +178,7 @@ public class PurpurConfig {
-     public static String afkBroadcastBack = "<yellow><italic>%s is no longer AFK";
+@@ -179,6 +179,7 @@ public class PurpurConfig {
+     public static boolean afkBroadcastUseDisplayName = false;
      public static String afkTabListPrefix = "[AFK] ";
      public static String afkTabListSuffix = "";
 +    public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
-@@ -185,6 +186,7 @@ public class PurpurConfig {
-         afkBroadcastBack = getString("settings.messages.afk-broadcast-back", afkBroadcastBack);
+@@ -187,6 +188,7 @@ public class PurpurConfig {
+         afkBroadcastUseDisplayName = getBoolean("settings.messages.afk-broadcast-use-display-name", afkBroadcastUseDisplayName);
          afkTabListPrefix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-prefix", afkTabListPrefix)));
          afkTabListSuffix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-suffix", afkTabListSuffix)));
 +        demoCommandOutput = getString("settings.messages.demo-command-output", demoCommandOutput);

--- a/patches/server/0066-Add-credits-command.patch
+++ b/patches/server/0066-Add-credits-command.patch
@@ -17,19 +17,19 @@ index a7c26527eb282d2f80fa14d265b748f7a41a7ebe..277fb799d898ca726205519b15168619
              org.purpurmc.purpur.command.PingCommand.register(this.dispatcher); // Purpur
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 63095ddc7ea342a985b528441fdc658332e77f87..92a489d2a7e1f9001f7a66fbf1104280aa1af67b 100644
+index 235db276a07017bf89e6311a0b84291e8a0af06b..8e99128759e555cdef0efe9cea1b3b36f2c3fda9 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -178,6 +178,7 @@ public class PurpurConfig {
-     public static String afkBroadcastBack = "<yellow><italic>%s is no longer AFK";
+@@ -179,6 +179,7 @@ public class PurpurConfig {
+     public static boolean afkBroadcastUseDisplayName = false;
      public static String afkTabListPrefix = "[AFK] ";
      public static String afkTabListSuffix = "";
 +    public static String creditsCommandOutput = "<green>%s has been shown the end credits";
      public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      private static void messages() {
-@@ -186,6 +187,7 @@ public class PurpurConfig {
-         afkBroadcastBack = getString("settings.messages.afk-broadcast-back", afkBroadcastBack);
+@@ -188,6 +189,7 @@ public class PurpurConfig {
+         afkBroadcastUseDisplayName = getBoolean("settings.messages.afk-broadcast-use-display-name", afkBroadcastUseDisplayName);
          afkTabListPrefix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-prefix", afkTabListPrefix)));
          afkTabListSuffix = MiniMessage.miniMessage().serialize(MiniMessage.miniMessage().deserialize(getString("settings.messages.afk-tab-list-suffix", afkTabListSuffix)));
 +        creditsCommandOutput = getString("settings.messages.credits-command-output", creditsCommandOutput);

--- a/patches/server/0072-Add-allow-water-in-end-world-option.patch
+++ b/patches/server/0072-Add-allow-water-in-end-world-option.patch
@@ -68,10 +68,10 @@ index 5ecf02ce83b7496c977adfeb203b8eadb05f9da5..bf7f1ac5c691c0c4c30c124970f4b08a
          } else {
              world.setBlockAndUpdate(pos, Blocks.WATER.defaultBlockState());
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 28711abdabec6894faefb3a5bcff503ce5125e2f..005f9146aac12d342e5b679a24e9a0ab4a10d9a5 100644
+index 8e99128759e555cdef0efe9cea1b3b36f2c3fda9..8575753af39d19e485f915e3e12e377c325b4751 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -242,6 +242,11 @@ public class PurpurConfig {
+@@ -244,6 +244,11 @@ public class PurpurConfig {
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
      }
  

--- a/patches/server/0075-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
+++ b/patches/server/0075-Add-option-to-teleport-to-spawn-if-outside-world-bor.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to teleport to spawn if outside world border
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1224e5f2b34d32ffeb92300a1763dd6f52b3d1ce..581685e53fc9b63d291ba4904e47e8afc1119c9a 100644
+index c481110ae2d2c792856a4140d63747bb5afc65c6..7ccc2faa622082e2c06ce3906b22e3079a486711 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2668,4 +2668,26 @@ public class ServerPlayer extends Player {
+@@ -2673,4 +2673,26 @@ public class ServerPlayer extends Player {
          return (CraftPlayer) super.getBukkitEntity();
      }
      // CraftBukkit end

--- a/patches/server/0082-Add-option-to-disable-certain-block-updates.patch
+++ b/patches/server/0082-Add-option-to-disable-certain-block-updates.patch
@@ -99,7 +99,7 @@ index 3c6d97b51c6fec130b80e5965afa2c49d48843c9..b456cb8efd8f0be8a6860c82462ce9bd
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/block/NoteBlock.java b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
-index 50ead76879398222a76f26c36e98800d2d1af167..42e8e2d9d673947ecbfb55e0f31fc22afe3223b6 100644
+index a9c2d254bda5686a35ad2393534b85030dd8b136..58deb2a688833151fa96941e81ae81046cf3c18a 100644
 --- a/src/main/java/net/minecraft/world/level/block/NoteBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
 @@ -62,11 +62,13 @@ public class NoteBlock extends Block {
@@ -125,10 +125,10 @@ index 50ead76879398222a76f26c36e98800d2d1af167..42e8e2d9d673947ecbfb55e0f31fc22a
          }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 005f9146aac12d342e5b679a24e9a0ab4a10d9a5..d646e0f7661436814ea59ab6054094f454d97aa4 100644
+index 8575753af39d19e485f915e3e12e377c325b4751..e829e215d1fe80cdaf9162268011912081f4c5ee 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -247,6 +247,15 @@ public class PurpurConfig {
+@@ -249,6 +249,15 @@ public class PurpurConfig {
          allowWaterPlacementInTheEnd = getBoolean("settings.allow-water-placement-in-the-end", allowWaterPlacementInTheEnd);
      }
  

--- a/patches/server/0086-Short-enderman-height.patch
+++ b/patches/server/0086-Short-enderman-height.patch
@@ -31,10 +31,10 @@ index b24d890fb9a85434d612c57b4a8763652565d017..d8123aa5585cb4c0cc1210ced04fdf08
              boolean flag = source.getDirectEntity() instanceof ThrownPotion;
              boolean flag1;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index d646e0f7661436814ea59ab6054094f454d97aa4..453557507925a3eaa2d6057e2f776a25ebbae18a 100644
+index e829e215d1fe80cdaf9162268011912081f4c5ee..db4c85cae58805cfa2a460e33a13e85abc8e593d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -242,6 +242,12 @@ public class PurpurConfig {
+@@ -244,6 +244,12 @@ public class PurpurConfig {
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
      }
  

--- a/patches/server/0088-Crying-obsidian-valid-for-portal-frames.patch
+++ b/patches/server/0088-Crying-obsidian-valid-for-portal-frames.patch
@@ -18,10 +18,10 @@ index c461e0d04047db9c0c5ecc04063cebd38bf96ec2..e7554ec800f321e4e34c926c53f2375a
      private static final float SAFE_TRAVEL_MAX_ENTITY_XY = 4.0F;
      private static final double SAFE_TRAVEL_MAX_VERTICAL_DELTA = 1.0D;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 453557507925a3eaa2d6057e2f776a25ebbae18a..876ac29d5f6cbf539c9756c7ffbbd82fe24ead00 100644
+index db4c85cae58805cfa2a460e33a13e85abc8e593d..ba4dc732327e7661d39929dfa330a5b29cce9269 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -210,6 +210,7 @@ public class PurpurConfig {
+@@ -212,6 +212,7 @@ public class PurpurConfig {
      public static int barrelRows = 3;
      public static boolean enderChestSixRows = false;
      public static boolean enderChestPermissionRows = false;
@@ -29,7 +29,7 @@ index 453557507925a3eaa2d6057e2f776a25ebbae18a..876ac29d5f6cbf539c9756c7ffbbd82f
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -240,6 +241,7 @@ public class PurpurConfig {
+@@ -242,6 +243,7 @@ public class PurpurConfig {
          enderChestSixRows = getBoolean("settings.blocks.ender_chest.six-rows", enderChestSixRows);
          org.bukkit.event.inventory.InventoryType.ENDER_CHEST.setDefaultSize(enderChestSixRows ? 54 : 27);
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);

--- a/patches/server/0100-Allow-infinite-and-mending-enchantments-together.patch
+++ b/patches/server/0100-Allow-infinite-and-mending-enchantments-together.patch
@@ -17,10 +17,10 @@ index 518d85a13c37a2f7d32ca0718323181048559986..2c4ce164ab3011f372ff1719c8d4a333
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 876ac29d5f6cbf539c9756c7ffbbd82fe24ead00..35da12023f9d314a0861680c11be259f46353ddd 100644
+index ba4dc732327e7661d39929dfa330a5b29cce9269..4e303fc793bef67426308204d704b02960fc75b8 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -244,6 +244,16 @@ public class PurpurConfig {
+@@ -246,6 +246,16 @@ public class PurpurConfig {
          cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
      }
  

--- a/patches/server/0113-EMC-Configurable-disable-give-dropping.patch
+++ b/patches/server/0113-EMC-Configurable-disable-give-dropping.patch
@@ -20,10 +20,10 @@ index ee7d29d85c8b024c9b23cba8ecd4192aa7e8aa7b..7a44bac6e66bc5f5fe14a45a5e7c78c9
                          itemstack.setCount(1);
                          entityitem = entityplayer.drop(itemstack, false, false, false); // SPIGOT-2942: Add boolean to call event
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 35da12023f9d314a0861680c11be259f46353ddd..126eb32d182b78b07add872aad6a821334639662 100644
+index 4e303fc793bef67426308204d704b02960fc75b8..b1757cd2f828304ca7376eed6eea01f816b26550 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -207,6 +207,11 @@ public class PurpurConfig {
+@@ -209,6 +209,11 @@ public class PurpurConfig {
          useAlternateKeepAlive = getBoolean("settings.use-alternate-keepalive", useAlternateKeepAlive);
      }
  

--- a/patches/server/0120-Implement-TPSBar.patch
+++ b/patches/server/0120-Implement-TPSBar.patch
@@ -42,7 +42,7 @@ index ca6a2fee12ac8a89dae57aa2787462f190463cd0..e0b2819d6c73a9ca1fa60ff71d29e201
          }
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 02078f459eb7230a5ac9b4499d961c8b37e5b196..06c225972d5a92296042ff612634f81298b32107 100644
+index 91a2081acf514b61033b669dc331b223c84adfbd..d526d2374008bdaac4b03437e24da25a7915cbeb 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -279,6 +279,7 @@ public class ServerPlayer extends Player {
@@ -69,7 +69,7 @@ index 02078f459eb7230a5ac9b4499d961c8b37e5b196..06c225972d5a92296042ff612634f812
      }
  
      // CraftBukkit start - World fallback code, either respawn location or global spawn
-@@ -2698,5 +2701,13 @@ public class ServerPlayer extends Player {
+@@ -2703,5 +2706,13 @@ public class ServerPlayer extends Player {
              this.server.getPlayerList().respawn(this, toLevel, true, to, !toLevel.paperConfig().environment.disableTeleportationSuffocationCheck, org.bukkit.event.player.PlayerRespawnEvent.RespawnReason.DEATH);
          }
      }
@@ -84,7 +84,7 @@ index 02078f459eb7230a5ac9b4499d961c8b37e5b196..06c225972d5a92296042ff612634f812
      // Purpur end
  }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 68905d5121eb05b825602d2bf24612283481c205..cfe70ad065f7c5919faad67b171b9dbbabaea51c 100644
+index 91166ac140e14a4300ecbec8d80716b175fd2889..37943331eecee6263041b64d274a8be682a1039d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -469,6 +469,7 @@ public abstract class PlayerList {
@@ -105,10 +105,10 @@ index 68905d5121eb05b825602d2bf24612283481c205..cfe70ad065f7c5919faad67b171b9dbb
  
          entityplayer.awardStat(Stats.LEAVE_GAME);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index ce59c8dbbf6cdc684befe9302107645795576e48..74882c48068d01d59adbfc0c51bd7f2b7f756e6a 100644
+index b1757cd2f828304ca7376eed6eea01f816b26550..70db296b80b98b378917f68037420ae150e14adb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -181,6 +181,7 @@ public class PurpurConfig {
+@@ -182,6 +182,7 @@ public class PurpurConfig {
      public static String creditsCommandOutput = "<green>%s has been shown the end credits";
      public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
@@ -116,7 +116,7 @@ index ce59c8dbbf6cdc684befe9302107645795576e48..74882c48068d01d59adbfc0c51bd7f2b
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -190,6 +191,7 @@ public class PurpurConfig {
+@@ -192,6 +193,7 @@ public class PurpurConfig {
          creditsCommandOutput = getString("settings.messages.credits-command-output", creditsCommandOutput);
          demoCommandOutput = getString("settings.messages.demo-command-output", demoCommandOutput);
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
@@ -124,7 +124,7 @@ index ce59c8dbbf6cdc684befe9302107645795576e48..74882c48068d01d59adbfc0c51bd7f2b
      }
  
      public static String serverModName = "Purpur";
-@@ -212,6 +214,29 @@ public class PurpurConfig {
+@@ -214,6 +216,29 @@ public class PurpurConfig {
          disableGiveCommandDrops = getBoolean("settings.disable-give-dropping", disableGiveCommandDrops);
      }
  

--- a/patches/server/0135-Dont-run-with-scissors.patch
+++ b/patches/server/0135-Dont-run-with-scissors.patch
@@ -36,10 +36,10 @@ index d9a6a5ef1cd419d2111e49d42df8b866e90d9c6b..4345b10d2aad2d82155fe50f31139917
          Iterable<VoxelShape> iterable = world.getCollisions(this.player, this.player.getBoundingBox().deflate(9.999999747378752E-6D));
          VoxelShape voxelshape = Shapes.create(box.deflate(9.999999747378752E-6D));
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 74882c48068d01d59adbfc0c51bd7f2b7f756e6a..dcd2d690d36eb51e3e7217f0ddef5fc32d1fc0c6 100644
+index 70db296b80b98b378917f68037420ae150e14adb..3fc967279daaf6eb2b2d80fcad57b5b6a11cec43 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -182,6 +182,7 @@ public class PurpurConfig {
+@@ -183,6 +183,7 @@ public class PurpurConfig {
      public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
@@ -47,7 +47,7 @@ index 74882c48068d01d59adbfc0c51bd7f2b7f756e6a..dcd2d690d36eb51e3e7217f0ddef5fc3
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -192,6 +193,12 @@ public class PurpurConfig {
+@@ -194,6 +195,12 @@ public class PurpurConfig {
          demoCommandOutput = getString("settings.messages.demo-command-output", demoCommandOutput);
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);

--- a/patches/server/0149-Allow-infinity-on-crossbows.patch
+++ b/patches/server/0149-Allow-infinity-on-crossbows.patch
@@ -77,10 +77,10 @@ index 3d0ce0803e1da8a2681a3cb41096ac942ece54a1..bcd075a771c7f43c6d1549aeec2ccb20
              return null;
          }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index c8097ec7887ac8e689b6843d9ff7744d6a453478..5717f09d31dbc89b0c3aba8330e593bf5a53b6a4 100644
+index 3fc967279daaf6eb2b2d80fcad57b5b6a11cec43..a191d631e4c5401e1fafc0d9a4a4d5eed4f300af 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -282,6 +282,7 @@ public class PurpurConfig {
+@@ -284,6 +284,7 @@ public class PurpurConfig {
      }
  
      public static boolean allowInfinityMending = false;
@@ -88,7 +88,7 @@ index c8097ec7887ac8e689b6843d9ff7744d6a453478..5717f09d31dbc89b0c3aba8330e593bf
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -289,6 +290,7 @@ public class PurpurConfig {
+@@ -291,6 +292,7 @@ public class PurpurConfig {
              set("settings.enchantment.allow-infinite-and-mending-together", null);
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);

--- a/patches/server/0155-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0155-Config-to-allow-for-unsafe-enchants.patch
@@ -70,7 +70,7 @@ index 2281dba58d32b6314a7abcdb103c03c7056c24e9..37c79c0e13e6d7b6b03ebdf57bebf124
                  ((ServerPlayer) player).connection.send(new ClientboundContainerSetDataPacket(containerId, 0, cost.get()));
              }
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 6d3d68faba89cf388d52d9a526a3d14ab9e21a22..71acec715d65737d0b13392b5b42b607937c2d15 100644
+index a29ceeb798619bbda730ce154dfe03dae214c737..729b470e19e83730132e419bd40741018b4ff72e 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -1196,6 +1196,12 @@ public final class ItemStack {
@@ -87,10 +87,10 @@ index 6d3d68faba89cf388d52d9a526a3d14ab9e21a22..71acec715d65737d0b13392b5b42b607
          this.getOrCreateTag().put(key, element);
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 5717f09d31dbc89b0c3aba8330e593bf5a53b6a4..e61e4c53c15a65ef5135e657e6f5882cb35a574a 100644
+index a191d631e4c5401e1fafc0d9a4a4d5eed4f300af..80f47a113b48670695a5ffe67dd6e0f800970e1e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -283,14 +283,32 @@ public class PurpurConfig {
+@@ -285,14 +285,32 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;

--- a/patches/server/0160-Config-to-change-max-number-of-bees.patch
+++ b/patches/server/0160-Config-to-change-max-number-of-bees.patch
@@ -18,10 +18,10 @@ index 41c9f074203915c31c1ae7a160ce509c13383f84..a16a1df28258d605cf5908dbe19bda5d
      public BeehiveBlockEntity(BlockPos pos, BlockState state) {
          super(BlockEntityType.BEEHIVE, pos, state);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index e61e4c53c15a65ef5135e657e6f5882cb35a574a..368d7842621892183ab0305272bf27707ca2d5af 100644
+index 80f47a113b48670695a5ffe67dd6e0f800970e1e..606b5842888a0089103a36367664533fbfedd8f9 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -248,6 +248,7 @@ public class PurpurConfig {
+@@ -250,6 +250,7 @@ public class PurpurConfig {
      public static boolean enderChestSixRows = false;
      public static boolean enderChestPermissionRows = false;
      public static boolean cryingObsidianValidForPortalFrame = false;
@@ -29,7 +29,7 @@ index e61e4c53c15a65ef5135e657e6f5882cb35a574a..368d7842621892183ab0305272bf2770
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -279,6 +280,7 @@ public class PurpurConfig {
+@@ -281,6 +282,7 @@ public class PurpurConfig {
          org.bukkit.event.inventory.InventoryType.ENDER_CHEST.setDefaultSize(enderChestSixRows ? 54 : 27);
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
          cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);

--- a/patches/server/0162-Gamemode-extra-permissions.patch
+++ b/patches/server/0162-Gamemode-extra-permissions.patch
@@ -75,10 +75,10 @@ index ec771c480156db393c326fa2fbdc2d432fb76f53..71940bf3a4162d12a422a5b3100ad8de
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "defaultgamemode", "Allows the user to change the default gamemode of the server", PermissionDefault.OP, commands);
          DefaultPermissions.registerPermission(CommandPermissions.PREFIX + "seed", "Allows the user to view the seed of the world", PermissionDefault.OP, commands);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 368d7842621892183ab0305272bf27707ca2d5af..d4d58ae8dc114a26129cbe88e0025a0593ae13b9 100644
+index 606b5842888a0089103a36367664533fbfedd8f9..dd741a961e3cfdbe81aa087ef983d1fb4dc94cc2 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -231,6 +231,7 @@ public class PurpurConfig {
+@@ -233,6 +233,7 @@ public class PurpurConfig {
      public static String commandTPSBarTextColorMedium = "<gradient:#ffff55:#ffaa00><text></gradient>";
      public static String commandTPSBarTextColorLow = "<gradient:#ff5555:#aa0000><text></gradient>";
      public static int commandTPSBarTickInterval = 20;
@@ -86,7 +86,7 @@ index 368d7842621892183ab0305272bf27707ca2d5af..d4d58ae8dc114a26129cbe88e0025a05
      private static void commandSettings() {
          commandTPSBarTitle = getString("settings.command.tpsbar.title", commandTPSBarTitle);
          commandTPSBarProgressOverlay = BossBar.Overlay.valueOf(getString("settings.command.tpsbar.overlay", commandTPSBarProgressOverlay.name()));
-@@ -242,6 +243,7 @@ public class PurpurConfig {
+@@ -244,6 +245,7 @@ public class PurpurConfig {
          commandTPSBarTextColorMedium = getString("settings.command.tpsbar.text-color.medium", commandTPSBarTextColorMedium);
          commandTPSBarTextColorLow = getString("settings.command.tpsbar.text-color.low", commandTPSBarTextColorLow);
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);

--- a/patches/server/0165-Configurable-broadcast-settings.patch
+++ b/patches/server/0165-Configurable-broadcast-settings.patch
@@ -17,7 +17,7 @@ index 25b832fe30c3837d02b10017e58ad0fa9d097092..3919d9c193abcfd8b97dfb0ceb386384
                      // Paper end
                  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 272e7cc5fc33ec7148a47328d2ba9d88b11092d3..244ca77d8d50c4e30b90fc2df46bc7c291f94744 100644
+index 285f6b72800fa7f5003fb4de7eb092a2310e4d5a..d1f569a7813717552c20a0392b9bc9b2862ecc00 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -962,6 +962,7 @@ public class ServerPlayer extends Player {
@@ -29,10 +29,10 @@ index 272e7cc5fc33ec7148a47328d2ba9d88b11092d3..244ca77d8d50c4e30b90fc2df46bc7c2
                  if (scoreboardteambase.getDeathMessageVisibility() == Team.Visibility.HIDE_FOR_OTHER_TEAMS) {
                      this.server.getPlayerList().broadcastSystemToTeam(this, ichatbasecomponent);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 43c2572dc1c091703b3d2fb6bc26e685383675df..6b29c1d551d647c0ff82434a466f92c20403ea73 100644
+index dd741a961e3cfdbe81aa087ef983d1fb4dc94cc2..0139da5fcac438530f023a32a75ef454879fe6c1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -201,6 +201,18 @@ public class PurpurConfig {
+@@ -203,6 +203,18 @@ public class PurpurConfig {
          deathMsgRunWithScissors = getString("settings.messages.death-message.run-with-scissors", deathMsgRunWithScissors);
      }
  

--- a/patches/server/0167-Hide-hidden-players-from-entity-selector.patch
+++ b/patches/server/0167-Hide-hidden-players-from-entity-selector.patch
@@ -59,10 +59,10 @@ index f25b9330e068c7d9e12cb57a7761cfef9ebaf7bc..7e66aaa960ce7b6dda7c064d4c6856cc
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 8eddfbc2c702d877f5efbc69b9d55635e6561c55..d4adc9fab1711438013c1a4c852c20834ecb8249 100644
+index 0139da5fcac438530f023a32a75ef454879fe6c1..f3ddb65684a2cf7776c6e0137cb7acc7f36eb493 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -244,6 +244,7 @@ public class PurpurConfig {
+@@ -246,6 +246,7 @@ public class PurpurConfig {
      public static String commandTPSBarTextColorLow = "<gradient:#ff5555:#aa0000><text></gradient>";
      public static int commandTPSBarTickInterval = 20;
      public static boolean commandGamemodeRequiresPermission = false;
@@ -70,7 +70,7 @@ index 8eddfbc2c702d877f5efbc69b9d55635e6561c55..d4adc9fab1711438013c1a4c852c2083
      private static void commandSettings() {
          commandTPSBarTitle = getString("settings.command.tpsbar.title", commandTPSBarTitle);
          commandTPSBarProgressOverlay = BossBar.Overlay.valueOf(getString("settings.command.tpsbar.overlay", commandTPSBarProgressOverlay.name()));
-@@ -256,6 +257,7 @@ public class PurpurConfig {
+@@ -258,6 +259,7 @@ public class PurpurConfig {
          commandTPSBarTextColorLow = getString("settings.command.tpsbar.text-color.low", commandTPSBarTextColorLow);
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);
          commandGamemodeRequiresPermission = getBoolean("settings.command.gamemode.requires-specific-permission", commandGamemodeRequiresPermission);

--- a/patches/server/0174-Config-for-unverified-username-message.patch
+++ b/patches/server/0174-Config-for-unverified-username-message.patch
@@ -18,10 +18,10 @@ index 2ff578e4a953ffcf5176815ba8e3f06f73499989..af3ef12851cbfca13ad3316214bd53f2
                      }
                  } catch (AuthenticationUnavailableException authenticationunavailableexception) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index d4adc9fab1711438013c1a4c852c20834ecb8249..7b5f6a258939d0dca30df758f7b13b562d35a6e2 100644
+index f3ddb65684a2cf7776c6e0137cb7acc7f36eb493..3e3a1e859e78d295388706d175dded5dbc41336e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -183,6 +183,7 @@ public class PurpurConfig {
+@@ -184,6 +184,7 @@ public class PurpurConfig {
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
@@ -29,7 +29,7 @@ index d4adc9fab1711438013c1a4c852c20834ecb8249..7b5f6a258939d0dca30df758f7b13b56
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -194,6 +195,7 @@ public class PurpurConfig {
+@@ -196,6 +197,7 @@ public class PurpurConfig {
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);

--- a/patches/server/0175-Make-anvil-cumulative-cost-configurable.patch
+++ b/patches/server/0175-Make-anvil-cumulative-cost-configurable.patch
@@ -18,10 +18,10 @@ index 37c79c0e13e6d7b6b03ebdf57bebf124cb98bcb6..7ade5cd93b3d7b7259bf3246a8b74b0b
  
      public void setItemName(String newItemName) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 7b5f6a258939d0dca30df758f7b13b562d35a6e2..cbd5d395ab37a893340b5dbab866b6d2db1d0f01 100644
+index 3e3a1e859e78d295388706d175dded5dbc41336e..14f2b23248f23804a85b522e9e46ffa170162335 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -267,6 +267,7 @@ public class PurpurConfig {
+@@ -269,6 +269,7 @@ public class PurpurConfig {
      public static boolean enderChestPermissionRows = false;
      public static boolean cryingObsidianValidForPortalFrame = false;
      public static int beeInsideBeeHive = 3;
@@ -29,7 +29,7 @@ index 7b5f6a258939d0dca30df758f7b13b562d35a6e2..cbd5d395ab37a893340b5dbab866b6d2
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -299,6 +300,7 @@ public class PurpurConfig {
+@@ -301,6 +302,7 @@ public class PurpurConfig {
          enderChestPermissionRows = getBoolean("settings.blocks.ender_chest.use-permissions-for-rows", enderChestPermissionRows);
          cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);

--- a/patches/server/0183-Make-lightning-rod-range-configurable.patch
+++ b/patches/server/0183-Make-lightning-rod-range-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make lightning rod range configurable
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 43cc17bf7d93cdb5a171007e8341c583ec6eab53..2625f92d3bb61f89207941adbba59cb99d99eeb6 100644
+index cd7ca682b569c3633e412704534a9425c007f09b..da0ee556419074c8f1af6fd09e713a8898e0c8c4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -994,7 +994,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -18,10 +18,10 @@ index 43cc17bf7d93cdb5a171007e8341c583ec6eab53..2625f92d3bb61f89207941adbba59cb9
          return optional.map((blockposition1) -> {
              return blockposition1.above(1);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index cbd5d395ab37a893340b5dbab866b6d2db1d0f01..43b3ccf9d6991cf72ab44da83b43f5807be5c4f7 100644
+index 14f2b23248f23804a85b522e9e46ffa170162335..90354c009041e38143464f082ee8b6b54a5ec8cb 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -268,6 +268,7 @@ public class PurpurConfig {
+@@ -270,6 +270,7 @@ public class PurpurConfig {
      public static boolean cryingObsidianValidForPortalFrame = false;
      public static int beeInsideBeeHive = 3;
      public static boolean anvilCumulativeCost = true;
@@ -29,7 +29,7 @@ index cbd5d395ab37a893340b5dbab866b6d2db1d0f01..43b3ccf9d6991cf72ab44da83b43f580
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -301,6 +302,7 @@ public class PurpurConfig {
+@@ -303,6 +304,7 @@ public class PurpurConfig {
          cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
          anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);

--- a/patches/server/0192-Add-uptime-command.patch
+++ b/patches/server/0192-Add-uptime-command.patch
@@ -29,10 +29,10 @@ index de9e19d9979ad6981fcda881d22b18a613c4138d..83cfdbd54d5eb9fb614ab0828b052735
      public int autosavePeriod;
      public Commands vanillaCommandDispatcher;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 43b3ccf9d6991cf72ab44da83b43f5807be5c4f7..32dcd6db3c3c06d34bb4303bbaef8db648b1843d 100644
+index 90354c009041e38143464f082ee8b6b54a5ec8cb..669174925e7dcca0e5a8b5c5d5feb241b58e8719 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -183,6 +183,7 @@ public class PurpurConfig {
+@@ -184,6 +184,7 @@ public class PurpurConfig {
      public static String pingCommandOutput = "<green>%s's ping is %sms";
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
@@ -40,7 +40,7 @@ index 43b3ccf9d6991cf72ab44da83b43f5807be5c4f7..32dcd6db3c3c06d34bb4303bbaef8db6
      public static String unverifiedUsername = "default";
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
-@@ -195,6 +196,7 @@ public class PurpurConfig {
+@@ -197,6 +198,7 @@ public class PurpurConfig {
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);
@@ -48,7 +48,7 @@ index 43b3ccf9d6991cf72ab44da83b43f5807be5c4f7..32dcd6db3c3c06d34bb4303bbaef8db6
          unverifiedUsername = getString("settings.messages.unverified-username", unverifiedUsername);
      }
  
-@@ -247,6 +249,15 @@ public class PurpurConfig {
+@@ -249,6 +251,15 @@ public class PurpurConfig {
      public static int commandTPSBarTickInterval = 20;
      public static boolean commandGamemodeRequiresPermission = false;
      public static boolean hideHiddenPlayersFromEntitySelector = false;
@@ -64,7 +64,7 @@ index 43b3ccf9d6991cf72ab44da83b43f5807be5c4f7..32dcd6db3c3c06d34bb4303bbaef8db6
      private static void commandSettings() {
          commandTPSBarTitle = getString("settings.command.tpsbar.title", commandTPSBarTitle);
          commandTPSBarProgressOverlay = BossBar.Overlay.valueOf(getString("settings.command.tpsbar.overlay", commandTPSBarProgressOverlay.name()));
-@@ -260,6 +271,15 @@ public class PurpurConfig {
+@@ -262,6 +273,15 @@ public class PurpurConfig {
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);
          commandGamemodeRequiresPermission = getBoolean("settings.command.gamemode.requires-specific-permission", commandGamemodeRequiresPermission);
          hideHiddenPlayersFromEntitySelector = getBoolean("settings.command.hide-hidden-players-from-entity-selector", hideHiddenPlayersFromEntitySelector);

--- a/patches/server/0196-Customizable-sleeping-actionbar-messages.patch
+++ b/patches/server/0196-Customizable-sleeping-actionbar-messages.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Customizable sleeping actionbar messages
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2625f92d3bb61f89207941adbba59cb99d99eeb6..63deec6d22c18ca43c34b7f2dc961ce84a10bdaa 100644
+index da0ee556419074c8f1af6fd09e713a8898e0c8c4..a6bdef67b3bdc7b149c443fb1e4341f0379e0501 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1043,11 +1043,27 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -38,10 +38,10 @@ index 2625f92d3bb61f89207941adbba59cb99d99eeb6..63deec6d22c18ca43c34b7f2dc961ce8
                  }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 32dcd6db3c3c06d34bb4303bbaef8db648b1843d..31f5d9bcc11dc78b0d04c55560d5a2fa18bf3896 100644
+index 669174925e7dcca0e5a8b5c5d5feb241b58e8719..714acff3f53ef463d1de1d5f301b9a2f89711acc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -185,6 +185,8 @@ public class PurpurConfig {
+@@ -186,6 +186,8 @@ public class PurpurConfig {
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
      public static String uptimeCommandOutput = "<green>Server uptime is <uptime>";
      public static String unverifiedUsername = "default";
@@ -50,7 +50,7 @@ index 32dcd6db3c3c06d34bb4303bbaef8db648b1843d..31f5d9bcc11dc78b0d04c55560d5a2fa
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -198,6 +200,8 @@ public class PurpurConfig {
+@@ -200,6 +202,8 @@ public class PurpurConfig {
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);
          uptimeCommandOutput = getString("settings.messages.uptime-command-output", uptimeCommandOutput);
          unverifiedUsername = getString("settings.messages.unverified-username", unverifiedUsername);

--- a/patches/server/0202-Add-compass-command.patch
+++ b/patches/server/0202-Add-compass-command.patch
@@ -17,7 +17,7 @@ index 23e19bfbc41c5982a746ad0b5ba8c5834c2494a5..314ab6183e31b4bac6a40c1f8007d48e
  
          if (environment.includeIntegrated) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 244ca77d8d50c4e30b90fc2df46bc7c291f94744..0ac5a879c9098ea37f23cf4a23046e82c27231f4 100644
+index d1f569a7813717552c20a0392b9bc9b2862ecc00..086c49137da6f29abbfd11a17f50128c106a42e7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -280,6 +280,7 @@ public class ServerPlayer extends Player {
@@ -44,7 +44,7 @@ index 244ca77d8d50c4e30b90fc2df46bc7c291f94744..0ac5a879c9098ea37f23cf4a23046e82
      }
  
      // CraftBukkit start - World fallback code, either respawn location or global spawn
-@@ -2711,5 +2714,13 @@ public class ServerPlayer extends Player {
+@@ -2716,5 +2719,13 @@ public class ServerPlayer extends Player {
      public void tpsBar(boolean tpsBar) {
          this.tpsBar = tpsBar;
      }
@@ -59,10 +59,10 @@ index 244ca77d8d50c4e30b90fc2df46bc7c291f94744..0ac5a879c9098ea37f23cf4a23046e82
      // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 2c470ffdd3137e185e224de864d4248a4a290b41..7fe9d7939f6263878209724f38418006d680ba7b 100644
+index 714acff3f53ef463d1de1d5f301b9a2f89711acc..351fc72f0d1450114285b0577e8d5e533ad62901 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -251,6 +251,11 @@ public class PurpurConfig {
+@@ -253,6 +253,11 @@ public class PurpurConfig {
      public static String commandTPSBarTextColorMedium = "<gradient:#ffff55:#ffaa00><text></gradient>";
      public static String commandTPSBarTextColorLow = "<gradient:#ff5555:#aa0000><text></gradient>";
      public static int commandTPSBarTickInterval = 20;
@@ -74,7 +74,7 @@ index 2c470ffdd3137e185e224de864d4248a4a290b41..7fe9d7939f6263878209724f38418006
      public static boolean commandGamemodeRequiresPermission = false;
      public static boolean hideHiddenPlayersFromEntitySelector = false;
      public static String uptimeFormat = "<days><hours><minutes><seconds>";
-@@ -273,6 +278,13 @@ public class PurpurConfig {
+@@ -275,6 +280,13 @@ public class PurpurConfig {
          commandTPSBarTextColorMedium = getString("settings.command.tpsbar.text-color.medium", commandTPSBarTextColorMedium);
          commandTPSBarTextColorLow = getString("settings.command.tpsbar.text-color.low", commandTPSBarTextColorLow);
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);
@@ -89,7 +89,7 @@ index 2c470ffdd3137e185e224de864d4248a4a290b41..7fe9d7939f6263878209724f38418006
          hideHiddenPlayersFromEntitySelector = getBoolean("settings.command.hide-hidden-players-from-entity-selector", hideHiddenPlayersFromEntitySelector);
          uptimeFormat = getString("settings.command.uptime.format", uptimeFormat);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 6ea932028d3d429b23f3ed9e5f7fe852a0534ad4..95b44570978d036107b4b282d39289fed550cefe 100644
+index 3523fed89e2f42ef3e92c91a5f12c9aa92e3d32d..c346ebfa1df94dd523ef2a11778f42e0266e22c7 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -224,6 +224,7 @@ public class PurpurWorldConfig {

--- a/patches/server/0223-Config-for-grindstones.patch
+++ b/patches/server/0223-Config-for-grindstones.patch
@@ -57,10 +57,10 @@ index 89838076f3231ff4318ebb2718c9406399b4e4f5..155f601ce39b109fa04b4de176dec8e2
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 42532975d8c5558a7598e759838e75f2f1cc485e..11c0c8d9a294330eb2f4147420f2bde3068a2786 100644
+index 351fc72f0d1450114285b0577e8d5e533ad62901..ec519c0e6388eac27f9eb6fcd85713763206d71e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -305,6 +305,9 @@ public class PurpurConfig {
+@@ -307,6 +307,9 @@ public class PurpurConfig {
      public static int beeInsideBeeHive = 3;
      public static boolean anvilCumulativeCost = true;
      public static int lightningRodRange = 128;
@@ -70,7 +70,7 @@ index 42532975d8c5558a7598e759838e75f2f1cc485e..11c0c8d9a294330eb2f4147420f2bde3
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -339,6 +342,19 @@ public class PurpurConfig {
+@@ -341,6 +344,19 @@ public class PurpurConfig {
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
          anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);
          lightningRodRange = getInt("settings.blocks.lightning_rod.range", lightningRodRange);

--- a/patches/server/0224-UPnP-Port-Forwarding.patch
+++ b/patches/server/0224-UPnP-Port-Forwarding.patch
@@ -67,10 +67,10 @@ index e0b2819d6c73a9ca1fa60ff71d29e201360370a8..283b05dccb828f3e19739c0434ad6b31
          // CraftBukkit start
          // this.setPlayerList(new DedicatedPlayerList(this, this.registries(), this.playerDataStorage)); // Spigot - moved up
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 11c0c8d9a294330eb2f4147420f2bde3068a2786..303d647ceeec29a9133b7588156eb2c9941c7db6 100644
+index ec519c0e6388eac27f9eb6fcd85713763206d71e..1c277fca191df2ed3cc397ec247a7d785d97a894 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -422,4 +422,9 @@ public class PurpurConfig {
+@@ -424,4 +424,9 @@ public class PurpurConfig {
      private static void tpsCatchup() {
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }

--- a/patches/server/0230-Kelp-cave-weeping-and-twisting-vines-configurable-ma.patch
+++ b/patches/server/0230-Kelp-cave-weeping-and-twisting-vines-configurable-ma.patch
@@ -135,10 +135,10 @@ index e5c135ec059746b75fe58516809584221285cdbe..713c7e6e31a3e1097b612c77a4fce147
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 303d647ceeec29a9133b7588156eb2c9941c7db6..32769f726d3200478e13b5b31756d2139aac40b7 100644
+index 1c277fca191df2ed3cc397ec247a7d785d97a894..7467d3738b1159323606f08e7086dba653063211 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -308,6 +308,10 @@ public class PurpurConfig {
+@@ -310,6 +310,10 @@ public class PurpurConfig {
      public static Set<Enchantment> grindstoneIgnoredEnchants = new HashSet<>();
      public static boolean grindstoneRemoveAttributes = false;
      public static boolean grindstoneRemoveDisplay = false;
@@ -149,7 +149,7 @@ index 303d647ceeec29a9133b7588156eb2c9941c7db6..32769f726d3200478e13b5b31756d213
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -355,6 +359,30 @@ public class PurpurConfig {
+@@ -357,6 +361,30 @@ public class PurpurConfig {
          });
          grindstoneRemoveAttributes = getBoolean("settings.blocks.grindstone.remove-attributes", grindstoneRemoveAttributes);
          grindstoneRemoveDisplay = getBoolean("settings.blocks.grindstone.remove-name-and-lore", grindstoneRemoveDisplay);

--- a/patches/server/0238-Configurable-valid-characters-for-usernames.patch
+++ b/patches/server/0238-Configurable-valid-characters-for-usernames.patch
@@ -18,10 +18,10 @@ index af3ef12851cbfca13ad3316214bd53f2359e2078..f719f8aafe7c75e2ef8fcb05f556a8d6
              char c = in.charAt(i);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 32769f726d3200478e13b5b31756d2139aac40b7..0394e3150daebc8e63165faafb8362ce7a0d8641 100644
+index 7467d3738b1159323606f08e7086dba653063211..1429ff6e89efd58a618c1b1bbeea567466f5f397 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -455,4 +455,11 @@ public class PurpurConfig {
+@@ -457,4 +457,11 @@ public class PurpurConfig {
      private static void networkSettings() {
          useUPnP = getBoolean("settings.network.upnp-port-forwarding", useUPnP);
      }

--- a/patches/server/0239-Shears-can-have-looting-enchantment.patch
+++ b/patches/server/0239-Shears-can-have-looting-enchantment.patch
@@ -158,10 +158,10 @@ index 4007c16550683e23b396dfdff29530a82523fe05..8fe09c13643d99639fb242da4367c42e
      public int getMinCost(int level) {
          return 15 + (level - 1) * 9;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 0394e3150daebc8e63165faafb8362ce7a0d8641..aebd8ac1a50d88d08447b9cbc0dbed0676abfb8e 100644
+index 1429ff6e89efd58a618c1b1bbeea567466f5f397..eb5747485a43bc5c5574cfc539bdc98bee045e9f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -387,6 +387,7 @@ public class PurpurConfig {
+@@ -389,6 +389,7 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
@@ -169,7 +169,7 @@ index 0394e3150daebc8e63165faafb8362ce7a0d8641..aebd8ac1a50d88d08447b9cbc0dbed06
      public static boolean allowUnsafeEnchants = false;
      public static boolean allowInapplicableEnchants = true;
      public static boolean allowIncompatibleEnchants = true;
-@@ -408,6 +409,7 @@ public class PurpurConfig {
+@@ -410,6 +411,7 @@ public class PurpurConfig {
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);

--- a/patches/server/0247-Configurable-food-attributes.patch
+++ b/patches/server/0247-Configurable-food-attributes.patch
@@ -69,10 +69,10 @@ index 1f2e467272dddf3e91b7ab7037a0367b809725ca..bc0915913d3d8fbe145ee7e19133c7de
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index aebd8ac1a50d88d08447b9cbc0dbed0676abfb8e..0a22351506d1fc088ab9912c3e820b2bb2ecbfed 100644
+index eb5747485a43bc5c5574cfc539bdc98bee045e9f..a64cd03bd7b7855330eedfd37f7528e0b61107bc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -464,4 +464,56 @@ public class PurpurConfig {
+@@ -466,4 +466,56 @@ public class PurpurConfig {
          String setPattern = getString("settings.username-valid-characters", defaultPattern);
          usernameValidCharactersPattern = java.util.regex.Pattern.compile(setPattern == null || setPattern.isBlank() ? defaultPattern : setPattern);
      }

--- a/patches/server/0248-Max-joins-per-second.patch
+++ b/patches/server/0248-Max-joins-per-second.patch
@@ -31,10 +31,10 @@ index f9e10bf048929886db3c414038d2c7e9f84226a6..323416311f14f5ad887f05183ad3b492
          }
          // Paper end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 0a22351506d1fc088ab9912c3e820b2bb2ecbfed..4c702a1a5b555d2fc68a80231d73018cf7e6fec6 100644
+index a64cd03bd7b7855330eedfd37f7528e0b61107bc..3db04bc9611a76b939758ebaac8596e05860f365 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -454,8 +454,10 @@ public class PurpurConfig {
+@@ -456,8 +456,10 @@ public class PurpurConfig {
      }
  
      public static boolean useUPnP = false;

--- a/patches/server/0257-Add-toggle-for-enchant-level-clamping.patch
+++ b/patches/server/0257-Add-toggle-for-enchant-level-clamping.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add toggle for enchant level clamping
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index d5c667a9ca5562c2df38e191748f081ef9ffbd68..c318f0b6d956c19d16b13c1aa99beda704d52027 100644
+index dfca70fd75dc2d6c169a35a25aba2262680f6ca9..f671a4475ead763d2202ff2208b8ff3490d6b5e3 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -1190,7 +1190,7 @@ public final class ItemStack {
@@ -31,10 +31,10 @@ index 2048899f8e4c8211e8dde0d11148d647678009fa..1eec84e217f6dc929091fa7451cd235e
  
      @Nullable
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 4c702a1a5b555d2fc68a80231d73018cf7e6fec6..636c032127c2026509764745f805ae0693e4a983 100644
+index 3db04bc9611a76b939758ebaac8596e05860f365..3de2e7a17e1234367e4ec6d944b1145781aefeba 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -393,6 +393,7 @@ public class PurpurConfig {
+@@ -395,6 +395,7 @@ public class PurpurConfig {
      public static boolean allowIncompatibleEnchants = true;
      public static boolean allowHigherEnchantsLevels = true;
      public static boolean allowUnsafeEnchantCommand = false;
@@ -42,7 +42,7 @@ index 4c702a1a5b555d2fc68a80231d73018cf7e6fec6..636c032127c2026509764745f805ae06
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -415,6 +416,7 @@ public class PurpurConfig {
+@@ -417,6 +418,7 @@ public class PurpurConfig {
          allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);
          allowHigherEnchantsLevels = getBoolean("settings.enchantment.anvil.allow-higher-enchants-levels", allowHigherEnchantsLevels);
          allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability

--- a/patches/server/0260-Stonecutter-damage.patch
+++ b/patches/server/0260-Stonecutter-damage.patch
@@ -48,10 +48,10 @@ index 17a7fab20b4174273354fdc2fc700b7f2d669a98..a7578e112e80ed2585a7eb4fff9542f6
                      return BlockPathTypes.STICKY_HONEY;
                  } else if (blockState.is(Blocks.COCOA)) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 6160699f5d680b65a85bace844bd694153688b3c..431e81c64219412a5a0dca1ac0a6a1b1751567f7 100644
+index 3de2e7a17e1234367e4ec6d944b1145781aefeba..15ed564a579237dd1f5d6ce56ccb473f038a8c13 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -205,8 +205,10 @@ public class PurpurConfig {
+@@ -207,8 +207,10 @@ public class PurpurConfig {
      }
  
      public static String deathMsgRunWithScissors = "<player> slipped and fell on their shears";

--- a/patches/server/0266-Option-to-disable-kick-for-out-of-order-chat.patch
+++ b/patches/server/0266-Option-to-disable-kick-for-out-of-order-chat.patch
@@ -18,10 +18,10 @@ index 565ae94ff218e18e38a5502c06d0caca407293e3..b5ff4750b669ffd60d7f3c926691fdce
          } while (!this.lastChatTimeStamp.compareAndSet(instant1, timestamp));
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index bab204904dd8e7bc949d83c59d075cc6f90ce60c..3bfa8021a7da677fd15d3f2827b271fe17f514a1 100644
+index 15ed564a579237dd1f5d6ce56ccb473f038a8c13..9e87afb01e569e6d5c2846b931440c4ce395adae 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -459,9 +459,11 @@ public class PurpurConfig {
+@@ -461,9 +461,11 @@ public class PurpurConfig {
  
      public static boolean useUPnP = false;
      public static boolean maxJoinsPerSecond = false;

--- a/patches/server/0285-Implement-ram-and-rambar-commands.patch
+++ b/patches/server/0285-Implement-ram-and-rambar-commands.patch
@@ -18,7 +18,7 @@ index 6b05907bfec377e72a8858534d001bda10a1c88a..08bed4f01a27162902aa63bb8d35a915
  
          if (environment.includeIntegrated) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 15ec63fab5468bbfbfeefdf5475305fdf64b2b33..116cd0204177c313a4e15765340da2c97913bd77 100644
+index a9158f9572a4c787247721a36465e362ad975c20..852266234cf3d63e3b23a71639e40defca91c1b8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -279,6 +279,7 @@ public class ServerPlayer extends Player {
@@ -45,7 +45,7 @@ index 15ec63fab5468bbfbfeefdf5475305fdf64b2b33..116cd0204177c313a4e15765340da2c9
          nbt.putBoolean("Purpur.TPSBar", this.tpsBar); // Purpur
          nbt.putBoolean("Purpur.CompassBar", this.compassBar); // Purpur
      }
-@@ -2708,6 +2711,14 @@ public class ServerPlayer extends Player {
+@@ -2713,6 +2716,14 @@ public class ServerPlayer extends Player {
          }
      }
  
@@ -61,10 +61,10 @@ index 15ec63fab5468bbfbfeefdf5475305fdf64b2b33..116cd0204177c313a4e15765340da2c9
          return this.tpsBar;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 3bfa8021a7da677fd15d3f2827b271fe17f514a1..82cf79cffbc961dc1db43a4afc6eb1efb5bfe297 100644
+index 9e87afb01e569e6d5c2846b931440c4ce395adae..4142820c3053d77d4ae7186fec968d624f893056 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -181,6 +181,8 @@ public class PurpurConfig {
+@@ -182,6 +182,8 @@ public class PurpurConfig {
      public static String creditsCommandOutput = "<green>%s has been shown the end credits";
      public static String demoCommandOutput = "<green>%s has been shown the demo screen";
      public static String pingCommandOutput = "<green>%s's ping is %sms";
@@ -73,7 +73,7 @@ index 3bfa8021a7da677fd15d3f2827b271fe17f514a1..82cf79cffbc961dc1db43a4afc6eb1ef
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
      public static String uptimeCommandOutput = "<green>Server uptime is <uptime>";
-@@ -196,6 +198,8 @@ public class PurpurConfig {
+@@ -198,6 +200,8 @@ public class PurpurConfig {
          creditsCommandOutput = getString("settings.messages.credits-command-output", creditsCommandOutput);
          demoCommandOutput = getString("settings.messages.demo-command-output", demoCommandOutput);
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
@@ -82,7 +82,7 @@ index 3bfa8021a7da677fd15d3f2827b271fe17f514a1..82cf79cffbc961dc1db43a4afc6eb1ef
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);
          uptimeCommandOutput = getString("settings.messages.uptime-command-output", uptimeCommandOutput);
-@@ -243,6 +247,15 @@ public class PurpurConfig {
+@@ -245,6 +249,15 @@ public class PurpurConfig {
          disableGiveCommandDrops = getBoolean("settings.disable-give-dropping", disableGiveCommandDrops);
      }
  
@@ -98,7 +98,7 @@ index 3bfa8021a7da677fd15d3f2827b271fe17f514a1..82cf79cffbc961dc1db43a4afc6eb1ef
      public static String commandTPSBarTitle = "<gray>TPS<yellow>:</yellow> <tps> MSPT<yellow>:</yellow> <mspt> Ping<yellow>:</yellow> <ping>ms";
      public static BossBar.Overlay commandTPSBarProgressOverlay = BossBar.Overlay.NOTCHED_20;
      public static TPSBarTask.FillMode commandTPSBarProgressFillMode = TPSBarTask.FillMode.MSPT;
-@@ -270,6 +283,16 @@ public class PurpurConfig {
+@@ -272,6 +285,16 @@ public class PurpurConfig {
      public static String uptimeSecond = "%02d second";
      public static String uptimeSeconds = "%02d seconds";
      private static void commandSettings() {

--- a/patches/server/0286-Add-item-packet-serialize-event.patch
+++ b/patches/server/0286-Add-item-packet-serialize-event.patch
@@ -65,10 +65,10 @@ index 11560dc4ab6eb33fcb1ffcfbd49ea663d754fd8a..af8cb1f1f0c128923495f51e48280031
              boolean flag1 = packet.getSlotNum() >= 1 && packet.getSlotNum() <= 45;
              boolean flag2 = itemstack.isEmpty() || itemstack.getDamageValue() >= 0 && itemstack.getCount() <= 64 && !itemstack.isEmpty();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 82cf79cffbc961dc1db43a4afc6eb1efb5bfe297..e6f058019f7ebbc900fab35b576685c586abe408 100644
+index 4142820c3053d77d4ae7186fec968d624f893056..7a02cecaaef511c0db4708a1ce9eb885c1cfe028 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -547,4 +547,9 @@ public class PurpurConfig {
+@@ -549,4 +549,9 @@ public class PurpurConfig {
              }
          });
      }

--- a/patches/server/0289-Add-an-option-to-fix-MC-3304-projectile-looting.patch
+++ b/patches/server/0289-Add-an-option-to-fix-MC-3304-projectile-looting.patch
@@ -104,10 +104,10 @@ index 31918fa2eb38e42a5ea5366e559f25ea9d7d59ae..15d8e9261a89da30529ac347462c5209
              if (context.hasParam(LootContextParams.LOOTING_MOD)) {
                  i = context.getParamOrNull(LootContextParams.LOOTING_MOD);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 797afa6e73992fc3dad1720494c089730e5deaba..21669bf5b2dcf46efd7fec751e161394abce320a 100644
+index 7a02cecaaef511c0db4708a1ce9eb885c1cfe028..af875d966081b6e9f0d6a2680cff7f843c8dea05 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -552,4 +552,9 @@ public class PurpurConfig {
+@@ -554,4 +554,9 @@ public class PurpurConfig {
      private static void fixNetworkSerializedCreativeItems() {
          fixNetworkSerializedItemsInCreative = getBoolean("settings.fix-network-serialized-items-in-creative", fixNetworkSerializedItemsInCreative);
      }

--- a/patches/server/0290-Configurable-block-blast-resistance.patch
+++ b/patches/server/0290-Configurable-block-blast-resistance.patch
@@ -44,10 +44,10 @@ index ec6c63075306f9e5389e83641d2c8a82369ddc6b..0f16deddd8cbb506ef7886f57ae640a4
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 21669bf5b2dcf46efd7fec751e161394abce320a..5fd3802976457e976e27ff05e028c7e71f9835e8 100644
+index af875d966081b6e9f0d6a2680cff7f843c8dea05..8972bbbaca23f771fb5e10ee4099a420a0ec3ccd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -557,4 +557,19 @@ public class PurpurConfig {
+@@ -559,4 +559,19 @@ public class PurpurConfig {
      private static void fixProjectileLootingTransfer() {
          fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
      }

--- a/patches/server/0291-Configurable-block-fall-damage-modifiers.patch
+++ b/patches/server/0291-Configurable-block-fall-damage-modifiers.patch
@@ -54,10 +54,10 @@ index cfbe1dae76db76cf54a4f5d72aca72d5e893859e..74cb10230d459ac9f300a9d59af504d2
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 5fd3802976457e976e27ff05e028c7e71f9835e8..17e40a07d659a6b562fa9734a8b0729fc02fcdc4 100644
+index 8972bbbaca23f771fb5e10ee4099a420a0ec3ccd..290a66b51dc6b86b006b577754d1030def288cf7 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -572,4 +572,50 @@ public class PurpurConfig {
+@@ -574,4 +574,50 @@ public class PurpurConfig {
              block.explosionResistance = blastResistance.floatValue();
          });
      }

--- a/patches/server/0295-Add-log-suppression-for-LibraryLoader.patch
+++ b/patches/server/0295-Add-log-suppression-for-LibraryLoader.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add log suppression for LibraryLoader
 
 
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 17e40a07d659a6b562fa9734a8b0729fc02fcdc4..ca7cbcf9820ac0b34ebcc8f6b423d7b95fd7ce3a 100644
+index 290a66b51dc6b86b006b577754d1030def288cf7..c3878aed434bdf490cbaf45064fa5a6c5814476f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -468,11 +468,14 @@ public class PurpurConfig {
+@@ -470,11 +470,14 @@ public class PurpurConfig {
      public static boolean loggerSuppressIgnoredAdvancementWarnings = false;
      public static boolean loggerSuppressUnrecognizedRecipeErrors = false;
      public static boolean loggerSuppressSetBlockFarChunk = false;

--- a/patches/server/0296-Allow-Transparent-Blocks-In-Enchanting-Box.patch
+++ b/patches/server/0296-Allow-Transparent-Blocks-In-Enchanting-Box.patch
@@ -20,10 +20,10 @@ index 37a888e5db65b927094b43775ae9d4098244f809..c4a91d7f1320027ee6a2b364303c01eb
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index ca7cbcf9820ac0b34ebcc8f6b423d7b95fd7ce3a..b2bd04a5cef4443700dc0d4d0e6b3a31a10fc0cd 100644
+index c3878aed434bdf490cbaf45064fa5a6c5814476f..81409df1af15b68971b1efd203b9ad8d87ca7b6e 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -413,6 +413,7 @@ public class PurpurConfig {
+@@ -415,6 +415,7 @@ public class PurpurConfig {
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
      public static boolean allowShearsLooting = false;
@@ -31,7 +31,7 @@ index ca7cbcf9820ac0b34ebcc8f6b423d7b95fd7ce3a..b2bd04a5cef4443700dc0d4d0e6b3a31
      public static boolean allowUnsafeEnchants = false;
      public static boolean allowInapplicableEnchants = true;
      public static boolean allowIncompatibleEnchants = true;
-@@ -436,6 +437,7 @@ public class PurpurConfig {
+@@ -438,6 +439,7 @@ public class PurpurConfig {
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);
          allowShearsLooting = getBoolean("settings.enchantment.allow-looting-on-shears", allowShearsLooting);

--- a/patches/server/0304-Add-attribute-clamping-and-armor-limit-config.patch
+++ b/patches/server/0304-Add-attribute-clamping-and-armor-limit-config.patch
@@ -36,10 +36,10 @@ index f0703302e7dbbda88de8c648d20d87c55ed9b1e0..a913ebabaa5f443afa987b972355a8f8
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index b2bd04a5cef4443700dc0d4d0e6b3a31a10fc0cd..0bcbe1f07ff8e552d2abd6e432af5710005acc04 100644
+index 81409df1af15b68971b1efd203b9ad8d87ca7b6e..be8b44daa0141151c973917a774aa07721647ed1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -563,6 +563,16 @@ public class PurpurConfig {
+@@ -565,6 +565,16 @@ public class PurpurConfig {
          fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
      }
  


### PR DESCRIPTION
Adds a config option for the plain text of a player's display name to be used in the AFK broadcast message

This does not show their display name in the TAB screen, as I believe that would be better handled by a plugin
![image](https://github.com/PurpurMC/Purpur/assets/45906780/3031f3b7-3a6f-41c9-a208-b1130d650e15)
