### PR TITLE
AnvilMenu createResult() set itemName to "" if name is null

### DIFF
--- a/patches/server/0081-Allow-anvil-colors.patch
+++ b/patches/server/0081-Allow-anvil-colors.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow anvil colors
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index b500a04b8135604f0159a741b3d228c9e87b2a46..6fc5699ad90127dc48fa9ff5cb6ba5367031ce83 100644
+index b500a04b8135604f0159a741b3d228c9e87b2a46..5a051332f72c9446dd54d4f97a8f852d4b57e365 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-@@ -299,6 +299,54 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -299,6 +299,57 @@ public class AnvilMenu extends ItemCombinerMenu {
              } else if (itemstack.hasCustomHoverName()) {
                  b1 = 1;
                  i += b1;
@@ -16,6 +16,9 @@ index b500a04b8135604f0159a741b3d228c9e87b2a46..6fc5699ad90127dc48fa9ff5cb6ba536
 +                if (this.player != null) {
 +                    org.bukkit.craftbukkit.entity.CraftHumanEntity player = this.player.getBukkitEntity();
 +                    String name = this.itemName;
++                    if (name == null) {
++                        name = "";
++                    }
 +                    boolean removeItalics = false;
 +                    if (player.hasPermission("purpur.anvil.remove_italics")) {
 +                        if (name.startsWith("&r")) {
@@ -64,7 +67,7 @@ index b500a04b8135604f0159a741b3d228c9e87b2a46..6fc5699ad90127dc48fa9ff5cb6ba536
              }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index b52a5b3cee95528be6edfcc488ab043225c81f67..63d27e2ee263fdc8b165526f04781a1cf3e60894 100644
+index 4c37ded57929b79936edd3446bd4c92acf21790c..035a18d131fab9892a85b41663fc3dbe2f8bafe2 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -299,6 +299,13 @@ public class PurpurWorldConfig {

--- a/patches/server/0152-Config-to-allow-for-unsafe-enchants.patch
+++ b/patches/server/0152-Config-to-allow-for-unsafe-enchants.patch
@@ -27,7 +27,7 @@ index 664cbce2e06fcb95d3d3d6c5302fc9119f938925..bc9778c705d23acd84fa1cdeff6b403b
                              ++i;
                          } else if (targets.size() == 1) {
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 6fc5699ad90127dc48fa9ff5cb6ba5367031ce83..c179fd1ee55116e1bbdd8f8fadd18825c6ba2cde 100644
+index 5a051332f72c9446dd54d4f97a8f852d4b57e365..361fa3e58b7629a7d9b9d9cc81dc1496a1b925ec 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 @@ -228,7 +228,8 @@ public class AnvilMenu extends ItemCombinerMenu {
@@ -60,7 +60,7 @@ index 6fc5699ad90127dc48fa9ff5cb6ba5367031ce83..c179fd1ee55116e1bbdd8f8fadd18825
                                      i2 = enchantment.getMaxLevel();
                                  }
  
-@@ -389,7 +390,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -392,7 +393,7 @@ public class AnvilMenu extends ItemCombinerMenu {
              sendAllDataToRemote(); // CraftBukkit - SPIGOT-6686: Always send completed inventory to stay in sync with client
              this.broadcastChanges();
              // Purpur start
@@ -70,7 +70,7 @@ index 6fc5699ad90127dc48fa9ff5cb6ba5367031ce83..c179fd1ee55116e1bbdd8f8fadd18825
                  ((ServerPlayer) player).connection.send(new ClientboundContainerSetDataPacket(containerId, 0, cost.get()));
              }
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 0addb98459b9de0fc954531f8c09b0af73abcc45..5a6a80b544ff5a0259da9bd49baf8ef43c220480 100644
+index 190a446ba6c41a8da7e11b953c8fb2cb8119c412..43ed450fbd7472495b1965dcbdc7ad107ba91dcc 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -1202,6 +1202,12 @@ public final class ItemStack {

--- a/patches/server/0172-Make-anvil-cumulative-cost-configurable.patch
+++ b/patches/server/0172-Make-anvil-cumulative-cost-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make anvil cumulative cost configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index c179fd1ee55116e1bbdd8f8fadd18825c6ba2cde..d5ac94043f833355dbd84252c490c06a691d9aa6 100644
+index 361fa3e58b7629a7d9b9d9cc81dc1496a1b925ec..61b3be1ed7552770e70240f3016702b75b5c908b 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-@@ -399,7 +399,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+@@ -402,7 +402,7 @@ public class AnvilMenu extends ItemCombinerMenu {
      }
  
      public static int calculateIncreasedRepairCost(int cost) {


### PR DESCRIPTION
The LegacyComponentSerializer threw an NullPointerException because the name was null(This could be expected because the itemName have an @Nullable annotation).  Now it is an empty string.
The PR is a fix for my issue https://github.com/PurpurMC/Purpur/issues/1344 .