### PR TITLE
Delete cache on build failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 name: Build
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,8 @@ jobs:
         run: ./gradlew applyPatches --no-daemon --stacktrace
       - name: Build
         run: ./gradlew build --no-daemon --stacktrace
+      - name: Delete cache on Failure
+        if: ${{ failure() }}
+        uses: mokmok-dev/delete-actions-cache@main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,6 @@ jobs:
         run: ./gradlew build --no-daemon --stacktrace
       - name: Delete cache on Failure
         if: ${{ failure() }}
-        uses: mokmok-dev/delete-actions-cache@main
+        uses: TheRealRyGuy/clear-cache-action@master
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,9 @@ jobs:
         run: ./gradlew applyPatches --no-daemon --stacktrace
       - name: Build
         run: ./gradlew build --no-daemon --stacktrace
-      - name: Delete cache on Failure
+      - name: Rebuild on Failure
         if: ${{ failure() }}
-        uses: TheRealRyGuy/clear-cache-action@master
-        env:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./gradlew clean cleanCache
+          ./gradlew applyPatches --no-daemon --stacktrace 
+          ./gradlew build --no-daemon --stacktrace


### PR DESCRIPTION
cc granny
This deletes cache on build fail, still requires a rerun though 
If you wanted to combine the rerun, just needs a check (label?) to ensure it only runs once
`POST /repos/:owner/:repo/actions/runs/:run_id/rerun` 
https://docs.github.com/en/rest/actions/cache?apiVersion=2022-11-28 - cache API