### PR TITLE
Shears can defuse TNT

### DIFF
--- a/patches/server/0306-Shears-can-defuse-TNT.patch
+++ b/patches/server/0306-Shears-can-defuse-TNT.patch
@@ -44,26 +44,10 @@ index bf3301eb1341ba9d482e10873447c42bd670f5ed..3c46956efec714a2286ad8bc058f43a3
 +    // Purpur end - Shears can defuse TNT
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 64527770986fb44cb2b569924b2f98c9570b25b2..ec39dc4bbbde346ba404c46c15c75d2d8fa88db3 100644
+index 64527770986fb44cb2b569924b2f98c9570b25b2..59c413b5d6681da2636d7cfa0d452a4643e9f84b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-@@ -8,7 +8,6 @@ import net.minecraft.world.entity.EntityType;
- import net.minecraft.world.item.DyeColor;
- import net.minecraft.world.item.Item;
- import net.minecraft.world.item.Items;
--import net.minecraft.world.level.Explosion;
- import net.minecraft.world.level.block.Block;
- import net.minecraft.world.level.block.Blocks;
- import net.minecraft.world.level.block.state.properties.Tilt;
-@@ -23,7 +22,6 @@ import org.bukkit.configuration.ConfigurationSection;
- import java.util.ArrayList;
- import java.util.HashMap;
- import java.util.List;
--import java.util.Locale;
- import java.util.Map;
- import java.util.function.Predicate;
- import java.util.logging.Level;
-@@ -3198,4 +3196,11 @@ public class PurpurWorldConfig {
+@@ -3198,4 +3198,11 @@ public class PurpurWorldConfig {
          cauldronDripstoneWaterFillChance = (float) getDouble("blocks.cauldron.fill-chances.dripstone-water", cauldronDripstoneWaterFillChance);
          cauldronDripstoneLavaFillChance = (float) getDouble("blocks.cauldron.fill-chances.dripstone-lava", cauldronDripstoneLavaFillChance);
      }

--- a/patches/server/0306-Shears-can-defuse-TNT.patch
+++ b/patches/server/0306-Shears-can-defuse-TNT.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrFishCakes <FinlayOxby@outlook.com>
+Date: Sun, 2 Jul 2023 00:50:14 +0100
+Subject: [PATCH] Shears can defuse TNT
+
+Shears can now defuse TNT. Each world can have a configured chance for the TNT to be defused when right clicking with a set of shears and damage dealt to the shears accordingly. If the TNT is defused then it will drop the TNT item instead and the entity removed from the world no longer existing. All the interaction is handled within the net.minecraft.world.entity.item.PrimedTnt class similar to how it is handled for when sheep are sheared.
+
+By default the option is disabled to avoid breaking any possible vanilla mechanics.
+
+diff --git a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
+index bf3301eb1341ba9d482e10873447c42bd670f5ed..3c46956efec714a2286ad8bc058f43a3e41424a3 100644
+--- a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
++++ b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
+@@ -174,4 +174,31 @@ public class PrimedTnt extends Entity implements TraceableEntity {
+         return !level().paperConfig().fixes.preventTntFromMovingInWater && super.isPushedByFluid();
+     }
+     // Paper end
++    // Purpur start - Shears can defuse TNT
++    @Override
++    public net.minecraft.world.InteractionResult interact(net.minecraft.world.entity.player.Player player, net.minecraft.world.InteractionHand hand) {
++        if (hand != net.minecraft.world.InteractionHand.MAIN_HAND) return net.minecraft.world.InteractionResult.PASS;
++        if (!level().purpurConfig.shearsCanDefuseTnt) return net.minecraft.world.InteractionResult.PASS;
++
++        final net.minecraft.world.item.ItemStack inHand = player.getItemInHand(hand);
++
++        if (!inHand.is(net.minecraft.world.item.Items.SHEARS)) return net.minecraft.world.InteractionResult.PASS;
++
++        if (level().random.nextFloat() > level().purpurConfig.shearsCanDefuseTntChance) return net.minecraft.world.InteractionResult.PASS;
++
++        net.minecraft.world.entity.item.ItemEntity tntItem = new net.minecraft.world.entity.item.ItemEntity(level(), getX(), getY(), getZ(),
++                new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.TNT));
++        tntItem.setPickUpDelay(10);
++
++        if (!player.isCreative()) {
++            inHand.hurt(1, level().random, player);
++            level().addFreshEntity(tntItem, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.CUSTOM);
++        }
++
++        this.playSound(net.minecraft.sounds.SoundEvents.SHEEP_SHEAR);
++
++        this.kill();
++        return net.minecraft.world.InteractionResult.SUCCESS;
++    }
++    // Purpur end - Shears can defuse TNT
+ }
+diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+index 64527770986fb44cb2b569924b2f98c9570b25b2..ec39dc4bbbde346ba404c46c15c75d2d8fa88db3 100644
+--- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
++++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+@@ -8,7 +8,6 @@ import net.minecraft.world.entity.EntityType;
+ import net.minecraft.world.item.DyeColor;
+ import net.minecraft.world.item.Item;
+ import net.minecraft.world.item.Items;
+-import net.minecraft.world.level.Explosion;
+ import net.minecraft.world.level.block.Block;
+ import net.minecraft.world.level.block.Blocks;
+ import net.minecraft.world.level.block.state.properties.Tilt;
+@@ -23,7 +22,6 @@ import org.bukkit.configuration.ConfigurationSection;
+ import java.util.ArrayList;
+ import java.util.HashMap;
+ import java.util.List;
+-import java.util.Locale;
+ import java.util.Map;
+ import java.util.function.Predicate;
+ import java.util.logging.Level;
+@@ -3198,4 +3196,11 @@ public class PurpurWorldConfig {
+         cauldronDripstoneWaterFillChance = (float) getDouble("blocks.cauldron.fill-chances.dripstone-water", cauldronDripstoneWaterFillChance);
+         cauldronDripstoneLavaFillChance = (float) getDouble("blocks.cauldron.fill-chances.dripstone-lava", cauldronDripstoneLavaFillChance);
+     }
++
++    public float shearsCanDefuseTntChance = 0.00F;
++    public boolean shearsCanDefuseTnt = false;
++    private void shearsCanDefuseTntSettings() {
++        shearsCanDefuseTntChance = (float) getDouble("gameplay-mechanics.item.shears.defuse-tnt-chance", 0.00D);
++        shearsCanDefuseTnt = shearsCanDefuseTntChance > 0.00F;
++    }
+ }

--- a/patches/server/0306-Shears-can-defuse-TNT.patch
+++ b/patches/server/0306-Shears-can-defuse-TNT.patch
@@ -8,38 +8,36 @@ Shears can now defuse TNT. Each world can have a configured chance for the TNT t
 By default the option is disabled to avoid breaking any possible vanilla mechanics.
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
-index bf3301eb1341ba9d482e10873447c42bd670f5ed..3c46956efec714a2286ad8bc058f43a3e41424a3 100644
+index bf3301eb1341ba9d482e10873447c42bd670f5ed..98c12ca547685c189e11c79a6fd3e6d1448539b8 100644
 --- a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
 +++ b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
-@@ -174,4 +174,31 @@ public class PrimedTnt extends Entity implements TraceableEntity {
+@@ -174,4 +174,29 @@ public class PrimedTnt extends Entity implements TraceableEntity {
          return !level().paperConfig().fixes.preventTntFromMovingInWater && super.isPushedByFluid();
      }
      // Paper end
 +    // Purpur start - Shears can defuse TNT
 +    @Override
 +    public net.minecraft.world.InteractionResult interact(net.minecraft.world.entity.player.Player player, net.minecraft.world.InteractionHand hand) {
-+        if (hand != net.minecraft.world.InteractionHand.MAIN_HAND) return net.minecraft.world.InteractionResult.PASS;
-+        if (!level().purpurConfig.shearsCanDefuseTnt) return net.minecraft.world.InteractionResult.PASS;
++        if (!level().isClientSide && level().purpurConfig.shearsCanDefuseTnt) {
++            final net.minecraft.world.item.ItemStack inHand = player.getItemInHand(hand);
 +
-+        final net.minecraft.world.item.ItemStack inHand = player.getItemInHand(hand);
++            if (!inHand.is(net.minecraft.world.item.Items.SHEARS) || !player.getBukkitEntity().hasPermission("purpur.tnt.defuse") ||
++                    level().random.nextFloat() > level().purpurConfig.shearsCanDefuseTntChance) return net.minecraft.world.InteractionResult.PASS;
 +
-+        if (!inHand.is(net.minecraft.world.item.Items.SHEARS)) return net.minecraft.world.InteractionResult.PASS;
++            net.minecraft.world.entity.item.ItemEntity tntItem = new net.minecraft.world.entity.item.ItemEntity(level(), getX(), getY(), getZ(),
++                    new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.TNT));
++            tntItem.setPickUpDelay(10);
 +
-+        if (level().random.nextFloat() > level().purpurConfig.shearsCanDefuseTntChance) return net.minecraft.world.InteractionResult.PASS;
-+
-+        net.minecraft.world.entity.item.ItemEntity tntItem = new net.minecraft.world.entity.item.ItemEntity(level(), getX(), getY(), getZ(),
-+                new net.minecraft.world.item.ItemStack(net.minecraft.world.item.Items.TNT));
-+        tntItem.setPickUpDelay(10);
-+
-+        if (!player.isCreative()) {
-+            inHand.hurt(1, level().random, player);
++            inHand.hurtAndBreak(1, player, entity -> entity.broadcastBreakEvent(hand));
 +            level().addFreshEntity(tntItem, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.CUSTOM);
++
++            this.playSound(net.minecraft.sounds.SoundEvents.SHEEP_SHEAR);
++
++            this.kill();
++            return net.minecraft.world.InteractionResult.SUCCESS;
 +        }
 +
-+        this.playSound(net.minecraft.sounds.SoundEvents.SHEEP_SHEAR);
-+
-+        this.kill();
-+        return net.minecraft.world.InteractionResult.SUCCESS;
++        return super.interact(player, hand);
 +    }
 +    // Purpur end - Shears can defuse TNT
  }


### PR DESCRIPTION
TNT can now be defused when right clicking with shears, nothing more to it than an additional gameplay mechanic. 

Option is per-world and a value of 0.00 disables the function. See patch commit for a few more details