### PR TITLE
Disable suffocation optimization for withers

### DIFF
--- a/patches/server/0001-Pufferfish-Server-Changes.patch
+++ b/patches/server/0001-Pufferfish-Server-Changes.patch
@@ -2145,20 +2145,21 @@ diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/ma
 index e11d7283662834047b2ff81a2fd25a4263792deb..e9a31314424d9db911cd9806741222397c3072d7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -142,7 +142,6 @@ import org.bukkit.event.entity.EntityTeleportEvent;
+@@ -142,7 +142,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
  import org.bukkit.event.player.PlayerItemConsumeEvent;
  // CraftBukkit end
  
 -import co.aikar.timings.MinecraftTimings; // Paper
++import net.minecraft.entity.boss.WitherEntity;
  
  public abstract class LivingEntity extends Entity implements Attackable {
  
-@@ -414,7 +413,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -414,7 +414,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              boolean flag = this instanceof net.minecraft.world.entity.player.Player;
  
              if (!this.level().isClientSide) {
 -                if (this.isInWall()) {
-+                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
++                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || this instanceof WitherEntity || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
                      this.hurt(this.damageSources().inWall(), 1.0F);
                  } else if (flag && !this.level().getWorldBorder().isWithinBounds(this.getBoundingBox())) {
                      double d0 = this.level().getWorldBorder().getDistanceToBorder(this) + this.level().getWorldBorder().getDamageSafeZone();

--- a/patches/server/0001-Pufferfish-Server-Changes.patch
+++ b/patches/server/0001-Pufferfish-Server-Changes.patch
@@ -2158,7 +2158,7 @@ index e11d7283662834047b2ff81a2fd25a4263792deb..e9a31314424d9db911cd980674122239
  
              if (!this.level().isClientSide) {
 -                if (this.isInWall()) {
-+                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || this instanceof net.minecraft.entity.boss.WitherEntity || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
++                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || this instanceof net.minecraft.world.entity.boss.wither.WitherBoss || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
                      this.hurt(this.damageSources().inWall(), 1.0F);
                  } else if (flag && !this.level().getWorldBorder().isWithinBounds(this.getBoundingBox())) {
                      double d0 = this.level().getWorldBorder().getDistanceToBorder(this) + this.level().getWorldBorder().getDamageSafeZone();

--- a/patches/server/0001-Pufferfish-Server-Changes.patch
+++ b/patches/server/0001-Pufferfish-Server-Changes.patch
@@ -2145,21 +2145,20 @@ diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/ma
 index e11d7283662834047b2ff81a2fd25a4263792deb..e9a31314424d9db911cd9806741222397c3072d7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -142,7 +142,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
+@@ -142,7 +142,6 @@ import org.bukkit.event.entity.EntityTeleportEvent;
  import org.bukkit.event.player.PlayerItemConsumeEvent;
  // CraftBukkit end
  
 -import co.aikar.timings.MinecraftTimings; // Paper
-+import net.minecraft.entity.boss.WitherEntity;
  
  public abstract class LivingEntity extends Entity implements Attackable {
  
-@@ -414,7 +414,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
+@@ -414,7 +413,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
              boolean flag = this instanceof net.minecraft.world.entity.player.Player;
  
              if (!this.level().isClientSide) {
 -                if (this.isInWall()) {
-+                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || this instanceof WitherEntity || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
++                if ((!gg.pufferfish.pufferfish.PufferfishConfig.enableSuffocationOptimization || this instanceof net.minecraft.entity.boss.WitherEntity || (tickCount % 10 == 0 && couldPossiblyBeHurt(1.0F))) && this.isInWall()) { // Pufferfish - optimize suffocation
                      this.hurt(this.damageSources().inWall(), 1.0F);
                  } else if (flag && !this.level().getWorldBorder().isWithinBounds(this.getBoundingBox())) {
                      double d0 = this.level().getWorldBorder().getDistanceToBorder(this) + this.level().getWorldBorder().getDamageSafeZone();


### PR DESCRIPTION
The `enableSuffocationOptimization` from pufferfish usually does a great job reducing entity lag on huge servers.
It reduces the rate of checking for suffocation 10 times (which is collision box calculation and getBlock)

However, it also breaks suffocation based wither cages. 
I feel like purpur goes mostly against tnt duping, so wither cages seem like the vanilla way to go around block farms.

This simple change would fix suffocation based wither cages on purpur with the optimization enabled, while still removing most of the lag from the suffocation check.

Given that there are usually only a few withers and thousands of other entities on the server, this option should be the best of both worlds on most of the servers.

Also from a practical standpoint, wither cages are the only useful contraptions that are broken by this patch.