### PR TITLE
Add configurable "sleep.not_possible" actionbar message

### DIFF
--- a/patches/server/0193-Customizable-sleeping-actionbar-messages.patch
+++ b/patches/server/0193-Customizable-sleeping-actionbar-messages.patch
@@ -37,25 +37,52 @@ index fea5481c98e4cbcaecb9f4adef35b7340ad0c9b8..df8efd93ad6ab30974e3025187cd234b
                      ichatmutablecomponent = Component.translatable("sleep.players_sleeping", this.sleepStatus.amountSleeping(), this.sleepStatus.sleepersNeeded(i));
                  }
  
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 784634596696521cfbd58e85392183dd96b843b0..b724a6fd90e6774db1f64090dc4854b6de4a9f44 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -1472,7 +1472,19 @@ public class ServerPlayer extends Player {
+                     });
+ 
+                     if (!this.serverLevel().canSleepThroughNights()) {
+-                        this.displayClientMessage(Component.translatable("sleep.not_possible"), true);
++                        // Purpur start
++                        Component clientMessage;
++                        if (org.purpurmc.purpur.PurpurConfig.sleepNotPossible.isBlank()) {
++                            clientMessage = null;
++                        } else if (!org.purpurmc.purpur.PurpurConfig.sleepNotPossible.equalsIgnoreCase("default")) {
++                            clientMessage = io.papermc.paper.adventure.PaperAdventure.asVanilla(net.kyori.adventure.text.minimessage.MiniMessage.miniMessage().deserialize(org.purpurmc.purpur.PurpurConfig.sleepNotPossible));
++                        } else {
++                            clientMessage = Component.translatable("sleep.not_possible");
++                        }
++                        if (clientMessage != null) {
++                            this.displayClientMessage(clientMessage, true);
++                        }
++                        // Purpur end
+                     }
+ 
+                     ((ServerLevel) this.level()).updateSleepingPlayerList();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index f5a5cc0f954f33f75b542c33d8385076a8aad163..34eae29ed89a32bed6777b514e6beed2cb3cd177 100644
+index f5a5cc0f954f33f75b542c33d8385076a8aad163..fe0f582291d61b1fd6f1916a39d62bfaf5abfa49 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -186,6 +186,8 @@ public class PurpurConfig {
+@@ -186,6 +186,9 @@ public class PurpurConfig {
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
      public static String uptimeCommandOutput = "<green>Server uptime is <uptime>";
      public static String unverifiedUsername = "default";
 +    public static String sleepSkippingNight = "default";
 +    public static String sleepingPlayersPercent = "default";
++    public static String sleepNotPossible = "default";
      private static void messages() {
          cannotRideMob = getString("settings.messages.cannot-ride-mob", cannotRideMob);
          afkBroadcastAway = getString("settings.messages.afk-broadcast-away", afkBroadcastAway);
-@@ -200,6 +202,8 @@ public class PurpurConfig {
+@@ -200,6 +203,9 @@ public class PurpurConfig {
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);
          uptimeCommandOutput = getString("settings.messages.uptime-command-output", uptimeCommandOutput);
          unverifiedUsername = getString("settings.messages.unverified-username", unverifiedUsername);
 +        sleepSkippingNight = getString("settings.messages.sleep-skipping-night", sleepSkippingNight);
 +        sleepingPlayersPercent = getString("settings.messages.sleeping-players-percent", sleepingPlayersPercent);
++        sleepNotPossible = getString("settings.messages.sleep-not-possible", sleepNotPossible);
      }
  
      public static String deathMsgRunWithScissors = "<player> slipped and fell on their shears";

--- a/patches/server/0198-Add-compass-command.patch
+++ b/patches/server/0198-Add-compass-command.patch
@@ -17,7 +17,7 @@ index 7aae9e3c60ba15b8dcd8174a4d70866edebb6cca..5f6cc8b16af6dce3b74f0c2c662b0ecf
  
          if (environment.includeIntegrated) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 784634596696521cfbd58e85392183dd96b843b0..597a85ec28382410efb255bebb326ad16841ded1 100644
+index b724a6fd90e6774db1f64090dc4854b6de4a9f44..6045da26c79bbb1c96319b6582bacef836024dec 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -281,6 +281,7 @@ public class ServerPlayer extends Player {
@@ -44,7 +44,7 @@ index 784634596696521cfbd58e85392183dd96b843b0..597a85ec28382410efb255bebb326ad1
      }
  
      // CraftBukkit start - World fallback code, either respawn location or global spawn
-@@ -2806,5 +2809,13 @@ public class ServerPlayer extends Player {
+@@ -2818,5 +2821,13 @@ public class ServerPlayer extends Player {
      public void tpsBar(boolean tpsBar) {
          this.tpsBar = tpsBar;
      }
@@ -59,10 +59,10 @@ index 784634596696521cfbd58e85392183dd96b843b0..597a85ec28382410efb255bebb326ad1
      // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 34eae29ed89a32bed6777b514e6beed2cb3cd177..90a72821a61dc00fbac9efac3d1cc3fb3ed72f22 100644
+index fe0f582291d61b1fd6f1916a39d62bfaf5abfa49..853cf54077d760f1118ce494b401d286d789e5fc 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -253,6 +253,11 @@ public class PurpurConfig {
+@@ -255,6 +255,11 @@ public class PurpurConfig {
      public static String commandTPSBarTextColorMedium = "<gradient:#ffff55:#ffaa00><text></gradient>";
      public static String commandTPSBarTextColorLow = "<gradient:#ff5555:#aa0000><text></gradient>";
      public static int commandTPSBarTickInterval = 20;
@@ -74,7 +74,7 @@ index 34eae29ed89a32bed6777b514e6beed2cb3cd177..90a72821a61dc00fbac9efac3d1cc3fb
      public static boolean commandGamemodeRequiresPermission = false;
      public static boolean hideHiddenPlayersFromEntitySelector = false;
      public static String uptimeFormat = "<days><hours><minutes><seconds>";
-@@ -275,6 +280,13 @@ public class PurpurConfig {
+@@ -277,6 +282,13 @@ public class PurpurConfig {
          commandTPSBarTextColorMedium = getString("settings.command.tpsbar.text-color.medium", commandTPSBarTextColorMedium);
          commandTPSBarTextColorLow = getString("settings.command.tpsbar.text-color.low", commandTPSBarTextColorLow);
          commandTPSBarTickInterval = getInt("settings.command.tpsbar.tick-interval", commandTPSBarTickInterval);

--- a/patches/server/0219-Config-for-grindstones.patch
+++ b/patches/server/0219-Config-for-grindstones.patch
@@ -57,10 +57,10 @@ index b56766ff0e61691294b40ea8c2370940c0e8b640..6860e3467bf785e9d017fc98fce1e3cf
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 90a72821a61dc00fbac9efac3d1cc3fb3ed72f22..5b77759fc6cf17462bc3e6d4db34ec7d480176ab 100644
+index 853cf54077d760f1118ce494b401d286d789e5fc..19313ea70f105e71019947e34669384472b0aaab 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -307,6 +307,9 @@ public class PurpurConfig {
+@@ -309,6 +309,9 @@ public class PurpurConfig {
      public static int beeInsideBeeHive = 3;
      public static boolean anvilCumulativeCost = true;
      public static int lightningRodRange = 128;
@@ -70,7 +70,7 @@ index 90a72821a61dc00fbac9efac3d1cc3fb3ed72f22..5b77759fc6cf17462bc3e6d4db34ec7d
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -341,6 +344,19 @@ public class PurpurConfig {
+@@ -343,6 +346,19 @@ public class PurpurConfig {
          beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
          anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);
          lightningRodRange = getInt("settings.blocks.lightning_rod.range", lightningRodRange);

--- a/patches/server/0220-UPnP-Port-Forwarding.patch
+++ b/patches/server/0220-UPnP-Port-Forwarding.patch
@@ -67,10 +67,10 @@ index 012c990efb2647b0a3e983b23fed98c6e3f2224b..62c437f5618032b78d1b68c5c2490d4d
          // CraftBukkit start
          // this.setPlayerList(new DedicatedPlayerList(this, this.registries(), this.playerDataStorage)); // Spigot - moved up
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 5b77759fc6cf17462bc3e6d4db34ec7d480176ab..124a237112000c73ac973f00934a34b7eb495642 100644
+index 19313ea70f105e71019947e34669384472b0aaab..37764d22804fecf704963d3208039834f1525b0d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -415,4 +415,9 @@ public class PurpurConfig {
+@@ -417,4 +417,9 @@ public class PurpurConfig {
      private static void tpsCatchup() {
          tpsCatchup = getBoolean("settings.tps-catchup", tpsCatchup);
      }

--- a/patches/server/0225-Signs-allow-color-codes.patch
+++ b/patches/server/0225-Signs-allow-color-codes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Signs allow color codes
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 597a85ec28382410efb255bebb326ad16841ded1..3a51e711eb66fa1ac48a0c0d4f237e24af5f5e69 100644
+index 6045da26c79bbb1c96319b6582bacef836024dec..81f6cbff68fb1c0be0a702ac09004275316256dc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1572,6 +1572,7 @@ public class ServerPlayer extends Player {
+@@ -1584,6 +1584,7 @@ public class ServerPlayer extends Player {
  
      @Override
      public void openTextEdit(SignBlockEntity sign, boolean front) {

--- a/patches/server/0226-Kelp-cave-weeping-and-twisting-vines-configurable-ma.patch
+++ b/patches/server/0226-Kelp-cave-weeping-and-twisting-vines-configurable-ma.patch
@@ -135,10 +135,10 @@ index e5c135ec059746b75fe58516809584221285cdbe..713c7e6e31a3e1097b612c77a4fce147
 +    // Purpur end
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 124a237112000c73ac973f00934a34b7eb495642..0357cc9225c835b50b6160af0b8bbdb0d32bdf16 100644
+index 37764d22804fecf704963d3208039834f1525b0d..b359b106f51e68d8a1e59d40dff75d656cd3b6e4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -310,6 +310,10 @@ public class PurpurConfig {
+@@ -312,6 +312,10 @@ public class PurpurConfig {
      public static Set<Enchantment> grindstoneIgnoredEnchants = new HashSet<>();
      public static boolean grindstoneRemoveAttributes = false;
      public static boolean grindstoneRemoveDisplay = false;
@@ -149,7 +149,7 @@ index 124a237112000c73ac973f00934a34b7eb495642..0357cc9225c835b50b6160af0b8bbdb0
      private static void blockSettings() {
          if (version < 3) {
              boolean oldValue = getBoolean("settings.barrel.packed-barrels", true);
-@@ -357,6 +361,30 @@ public class PurpurConfig {
+@@ -359,6 +363,30 @@ public class PurpurConfig {
          });
          grindstoneRemoveAttributes = getBoolean("settings.blocks.grindstone.remove-attributes", grindstoneRemoveAttributes);
          grindstoneRemoveDisplay = getBoolean("settings.blocks.grindstone.remove-name-and-lore", grindstoneRemoveDisplay);

--- a/patches/server/0234-Configurable-valid-characters-for-usernames.patch
+++ b/patches/server/0234-Configurable-valid-characters-for-usernames.patch
@@ -18,10 +18,10 @@ index b4b88a3d4dc66c44ca8f3bad1025c17a9993ac1d..01d5fa265fb2818465b5a71a2e2efeec
              char c = in.charAt(i);
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 0357cc9225c835b50b6160af0b8bbdb0d32bdf16..d76949c995bf8ecbabb87a87d4084b59a19d99f7 100644
+index b359b106f51e68d8a1e59d40dff75d656cd3b6e4..d22ffa006e5c39ebe5f94c41b62aebf11d07b80f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -448,4 +448,11 @@ public class PurpurConfig {
+@@ -450,4 +450,11 @@ public class PurpurConfig {
      private static void networkSettings() {
          useUPnP = getBoolean("settings.network.upnp-port-forwarding", useUPnP);
      }

--- a/patches/server/0235-Shears-can-have-looting-enchantment.patch
+++ b/patches/server/0235-Shears-can-have-looting-enchantment.patch
@@ -158,10 +158,10 @@ index 4007c16550683e23b396dfdff29530a82523fe05..8fe09c13643d99639fb242da4367c42e
      public int getMinCost(int level) {
          return 15 + (level - 1) * 9;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index d76949c995bf8ecbabb87a87d4084b59a19d99f7..bb5da073f0839a624ae4c86dfed20e56233ff5a3 100644
+index d22ffa006e5c39ebe5f94c41b62aebf11d07b80f..9a9e223aea463050f81ea7eadef778ea6b8401c7 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -389,6 +389,7 @@ public class PurpurConfig {
+@@ -391,6 +391,7 @@ public class PurpurConfig {
  
      public static boolean allowInfinityMending = false;
      public static boolean allowCrossbowInfinity = false;
@@ -169,7 +169,7 @@ index d76949c995bf8ecbabb87a87d4084b59a19d99f7..bb5da073f0839a624ae4c86dfed20e56
      public static boolean allowUnsafeEnchants = false;
      public static boolean allowInapplicableEnchants = true;
      public static boolean allowIncompatibleEnchants = true;
-@@ -410,6 +411,7 @@ public class PurpurConfig {
+@@ -412,6 +413,7 @@ public class PurpurConfig {
          }
          allowInfinityMending = getBoolean("settings.enchantment.allow-infinity-and-mending-together", allowInfinityMending);
          allowCrossbowInfinity = getBoolean("settings.enchantment.allow-infinity-on-crossbow", allowCrossbowInfinity);

--- a/patches/server/0242-Configurable-food-attributes.patch
+++ b/patches/server/0242-Configurable-food-attributes.patch
@@ -69,10 +69,10 @@ index 31f5ed9dd1727eee24804a384817d2b76a45676b..5fbb13ebef0ca66419f3e5006d19e4a5
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index bb5da073f0839a624ae4c86dfed20e56233ff5a3..51080c334f78796c75c906bdd79f5e2df94995a4 100644
+index 9a9e223aea463050f81ea7eadef778ea6b8401c7..07f5c71baefedce1237003a1bee193240a5b9af5 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -457,4 +457,75 @@ public class PurpurConfig {
+@@ -459,4 +459,75 @@ public class PurpurConfig {
          String setPattern = getString("settings.username-valid-characters", defaultPattern);
          usernameValidCharactersPattern = java.util.regex.Pattern.compile(setPattern == null || setPattern.isBlank() ? defaultPattern : setPattern);
      }

--- a/patches/server/0243-Max-joins-per-second.patch
+++ b/patches/server/0243-Max-joins-per-second.patch
@@ -31,10 +31,10 @@ index cf20f0983fc25b26cf92b9d3a28746b1909fc56b..89c1b69ddeb420c2fbda5f588e7c9a46
          }
          // Paper end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 51080c334f78796c75c906bdd79f5e2df94995a4..430a289ae9780083ef4cfef88b4c210c60a61471 100644
+index 07f5c71baefedce1237003a1bee193240a5b9af5..abea0905cc8a1ce6bffd4f2e581faea38ddd5b13 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -447,8 +447,10 @@ public class PurpurConfig {
+@@ -449,8 +449,10 @@ public class PurpurConfig {
      }
  
      public static boolean useUPnP = false;

--- a/patches/server/0251-Add-toggle-for-enchant-level-clamping.patch
+++ b/patches/server/0251-Add-toggle-for-enchant-level-clamping.patch
@@ -31,10 +31,10 @@ index 2048899f8e4c8211e8dde0d11148d647678009fa..1eec84e217f6dc929091fa7451cd235e
  
      @Nullable
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 430a289ae9780083ef4cfef88b4c210c60a61471..aeb104f4311b5affd0207eb1ec28dff11f537b39 100644
+index abea0905cc8a1ce6bffd4f2e581faea38ddd5b13..33a67078ba6ecc11d2929a164354702664d6a480 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -395,6 +395,7 @@ public class PurpurConfig {
+@@ -397,6 +397,7 @@ public class PurpurConfig {
      public static boolean allowIncompatibleEnchants = true;
      public static boolean allowHigherEnchantsLevels = true;
      public static boolean allowUnsafeEnchantCommand = false;
@@ -42,7 +42,7 @@ index 430a289ae9780083ef4cfef88b4c210c60a61471..aeb104f4311b5affd0207eb1ec28dff1
      private static void enchantmentSettings() {
          if (version < 5) {
              boolean oldValue = getBoolean("settings.enchantment.allow-infinite-and-mending-together", false);
-@@ -417,6 +418,7 @@ public class PurpurConfig {
+@@ -419,6 +420,7 @@ public class PurpurConfig {
          allowIncompatibleEnchants = getBoolean("settings.enchantment.anvil.allow-incompatible-enchants", allowIncompatibleEnchants);
          allowHigherEnchantsLevels = getBoolean("settings.enchantment.anvil.allow-higher-enchants-levels", allowHigherEnchantsLevels);
          allowUnsafeEnchantCommand = getBoolean("settings.enchantment.allow-unsafe-enchant-command", allowUnsafeEnchants); // allowUnsafeEnchants as default for backwards compatability

--- a/patches/server/0254-Stonecutter-damage.patch
+++ b/patches/server/0254-Stonecutter-damage.patch
@@ -90,10 +90,10 @@ index d976a6df54c1e817def2d588692abe25a03ee0fa..ba57accc272958da4714896baeadb52c
                      return BlockPathTypes.STICKY_HONEY;
                  } else if (blockState.is(Blocks.COCOA)) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index aeb104f4311b5affd0207eb1ec28dff11f537b39..4a789da3b4f4220084c17b70e308660d73df5e75 100644
+index 33a67078ba6ecc11d2929a164354702664d6a480..15eb4403deefca5f16052a74bbd9059091ed4c3f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -207,8 +207,10 @@ public class PurpurConfig {
+@@ -209,8 +209,10 @@ public class PurpurConfig {
      }
  
      public static String deathMsgRunWithScissors = "<player> slipped and fell on their shears";

--- a/patches/server/0260-Option-to-disable-kick-for-out-of-order-chat.patch
+++ b/patches/server/0260-Option-to-disable-kick-for-out-of-order-chat.patch
@@ -18,10 +18,10 @@ index cb1851fca9290edb502662c100bb2ac6fa4d70d1..b1050654cca5ce8a834c9e913b8e8046
          } while (!this.lastChatTimeStamp.compareAndSet(instant1, timestamp));
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 4a789da3b4f4220084c17b70e308660d73df5e75..bb3a1562a67c69fd120afa4fa44d6b075beec820 100644
+index 15eb4403deefca5f16052a74bbd9059091ed4c3f..6191efac8add7d45747036e07c7e895a70f6ff7b 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -452,9 +452,11 @@ public class PurpurConfig {
+@@ -454,9 +454,11 @@ public class PurpurConfig {
  
      public static boolean useUPnP = false;
      public static boolean maxJoinsPerSecond = false;

--- a/patches/server/0278-Implement-ram-and-rambar-commands.patch
+++ b/patches/server/0278-Implement-ram-and-rambar-commands.patch
@@ -18,7 +18,7 @@ index 52b06c34d9d3ffb8844556e7b0eaed5a7f03da0c..5c0085589b08f199c75ceeab8d0cf25e
  
          if (environment.includeIntegrated) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3d128b69ab5cc2ec75819ca8c88c5551d07e78f6..09db5ff64fb0df753d80dea5d14ad32d9be671ef 100644
+index 4942f4b1a54f6583a9d627a0b0513d36c6f81a7a..9c729910a39b010bf2123517c0bffc5a8993e6d1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -280,6 +280,7 @@ public class ServerPlayer extends Player {
@@ -45,7 +45,7 @@ index 3d128b69ab5cc2ec75819ca8c88c5551d07e78f6..09db5ff64fb0df753d80dea5d14ad32d
          nbt.putBoolean("Purpur.TPSBar", this.tpsBar); // Purpur
          nbt.putBoolean("Purpur.CompassBar", this.compassBar); // Purpur
      }
-@@ -2803,6 +2806,14 @@ public class ServerPlayer extends Player {
+@@ -2815,6 +2818,14 @@ public class ServerPlayer extends Player {
          }
      }
  
@@ -61,7 +61,7 @@ index 3d128b69ab5cc2ec75819ca8c88c5551d07e78f6..09db5ff64fb0df753d80dea5d14ad32d
          return this.tpsBar;
      }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index bb3a1562a67c69fd120afa4fa44d6b075beec820..fb3212e696bbb0450dbb92844380cb02f736cfde 100644
+index 6191efac8add7d45747036e07c7e895a70f6ff7b..77d927a28eb01aae3a49be3e7b7a5fe219b7739d 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 @@ -182,6 +182,8 @@ public class PurpurConfig {
@@ -73,7 +73,7 @@ index bb3a1562a67c69fd120afa4fa44d6b075beec820..fb3212e696bbb0450dbb92844380cb02
      public static String tpsbarCommandOutput = "<green>Tpsbar toggled <onoff> for <target>";
      public static String dontRunWithScissors = "<red><italic>Don't run with scissors!";
      public static String uptimeCommandOutput = "<green>Server uptime is <uptime>";
-@@ -198,6 +200,8 @@ public class PurpurConfig {
+@@ -199,6 +201,8 @@ public class PurpurConfig {
          creditsCommandOutput = getString("settings.messages.credits-command-output", creditsCommandOutput);
          demoCommandOutput = getString("settings.messages.demo-command-output", demoCommandOutput);
          pingCommandOutput = getString("settings.messages.ping-command-output", pingCommandOutput);
@@ -82,7 +82,7 @@ index bb3a1562a67c69fd120afa4fa44d6b075beec820..fb3212e696bbb0450dbb92844380cb02
          tpsbarCommandOutput = getString("settings.messages.tpsbar-command-output", tpsbarCommandOutput);
          dontRunWithScissors = getString("settings.messages.dont-run-with-scissors", dontRunWithScissors);
          uptimeCommandOutput = getString("settings.messages.uptime-command-output", uptimeCommandOutput);
-@@ -245,6 +249,15 @@ public class PurpurConfig {
+@@ -247,6 +251,15 @@ public class PurpurConfig {
          disableGiveCommandDrops = getBoolean("settings.disable-give-dropping", disableGiveCommandDrops);
      }
  
@@ -98,7 +98,7 @@ index bb3a1562a67c69fd120afa4fa44d6b075beec820..fb3212e696bbb0450dbb92844380cb02
      public static String commandTPSBarTitle = "<gray>TPS<yellow>:</yellow> <tps> MSPT<yellow>:</yellow> <mspt> Ping<yellow>:</yellow> <ping>ms";
      public static BossBar.Overlay commandTPSBarProgressOverlay = BossBar.Overlay.NOTCHED_20;
      public static TPSBarTask.FillMode commandTPSBarProgressFillMode = TPSBarTask.FillMode.MSPT;
-@@ -272,6 +285,16 @@ public class PurpurConfig {
+@@ -274,6 +287,16 @@ public class PurpurConfig {
      public static String uptimeSecond = "%02d second";
      public static String uptimeSeconds = "%02d seconds";
      private static void commandSettings() {

--- a/patches/server/0279-Add-item-packet-serialize-event.patch
+++ b/patches/server/0279-Add-item-packet-serialize-event.patch
@@ -65,10 +65,10 @@ index 9b488a98fdf06515ff267040dd6d654004665207..9cc3ab8cd3f7ab7f8fbf4d9d14f25ea0
              boolean flag1 = packet.getSlotNum() >= 1 && packet.getSlotNum() <= 45;
              boolean flag2 = itemstack.isEmpty() || itemstack.getDamageValue() >= 0 && itemstack.getCount() <= 64 && !itemstack.isEmpty();
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index fb3212e696bbb0450dbb92844380cb02f736cfde..b2cb7bf966ac1d52070d2d3c0b2b99e4aa2fd895 100644
+index 77d927a28eb01aae3a49be3e7b7a5fe219b7739d..7fc62c524f2df054ce7fa9399cda155a134477d1 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -559,4 +559,9 @@ public class PurpurConfig {
+@@ -561,4 +561,9 @@ public class PurpurConfig {
              }
          });
      }

--- a/patches/server/0280-Add-an-option-to-fix-MC-3304-projectile-looting.patch
+++ b/patches/server/0280-Add-an-option-to-fix-MC-3304-projectile-looting.patch
@@ -104,10 +104,10 @@ index 31918fa2eb38e42a5ea5366e559f25ea9d7d59ae..15d8e9261a89da30529ac347462c5209
              if (context.hasParam(LootContextParams.LOOTING_MOD)) {
                  i = context.getParamOrNull(LootContextParams.LOOTING_MOD);
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index b2cb7bf966ac1d52070d2d3c0b2b99e4aa2fd895..1be0f2fe80d5b47e763a636c0bf6290a3c701496 100644
+index 7fc62c524f2df054ce7fa9399cda155a134477d1..3a6eac678f1ab96ce1501a9951592faabed1e288 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -564,4 +564,9 @@ public class PurpurConfig {
+@@ -566,4 +566,9 @@ public class PurpurConfig {
      private static void fixNetworkSerializedCreativeItems() {
          fixNetworkSerializedItemsInCreative = getBoolean("settings.fix-network-serialized-items-in-creative", fixNetworkSerializedItemsInCreative);
      }

--- a/patches/server/0281-Configurable-block-blast-resistance.patch
+++ b/patches/server/0281-Configurable-block-blast-resistance.patch
@@ -18,10 +18,10 @@ index 5ac102afde62c08f36886b466010ccfedabfa05e..942ce713afe27ec75d849877a88721ef
      protected final SoundType soundType;
      protected final float friction;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 1be0f2fe80d5b47e763a636c0bf6290a3c701496..9a61c6e8ce684a5b656812de665abb6aff6c38dd 100644
+index 3a6eac678f1ab96ce1501a9951592faabed1e288..f52d82e3d16a0b94ece4530a4f0ca3196a1c09b0 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -569,4 +569,19 @@ public class PurpurConfig {
+@@ -571,4 +571,19 @@ public class PurpurConfig {
      private static void fixProjectileLootingTransfer() {
          fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
      }

--- a/patches/server/0282-Configurable-block-fall-damage-modifiers.patch
+++ b/patches/server/0282-Configurable-block-fall-damage-modifiers.patch
@@ -54,10 +54,10 @@ index cfbe1dae76db76cf54a4f5d72aca72d5e893859e..74cb10230d459ac9f300a9d59af504d2
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 9a61c6e8ce684a5b656812de665abb6aff6c38dd..1ec6cd330a3a59b38b14f53335387397801a3296 100644
+index f52d82e3d16a0b94ece4530a4f0ca3196a1c09b0..057a43a157d976526fc515d10f8b62fd69a41385 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -584,4 +584,50 @@ public class PurpurConfig {
+@@ -586,4 +586,50 @@ public class PurpurConfig {
              block.explosionResistance = blastResistance.floatValue();
          });
      }

--- a/patches/server/0286-Add-log-suppression-for-LibraryLoader.patch
+++ b/patches/server/0286-Add-log-suppression-for-LibraryLoader.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add log suppression for LibraryLoader
 
 
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 1ec6cd330a3a59b38b14f53335387397801a3296..38523f516adeee6ccd99f2b97bca60e0b499e01c 100644
+index 057a43a157d976526fc515d10f8b62fd69a41385..e6aab22248b463e088f50acf6275e364ea4b0809 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -461,11 +461,14 @@ public class PurpurConfig {
+@@ -463,11 +463,14 @@ public class PurpurConfig {
      public static boolean loggerSuppressIgnoredAdvancementWarnings = false;
      public static boolean loggerSuppressUnrecognizedRecipeErrors = false;
      public static boolean loggerSuppressSetBlockFarChunk = false;

--- a/patches/server/0294-Add-attribute-clamping-and-armor-limit-config.patch
+++ b/patches/server/0294-Add-attribute-clamping-and-armor-limit-config.patch
@@ -36,10 +36,10 @@ index f0703302e7dbbda88de8c648d20d87c55ed9b1e0..a913ebabaa5f443afa987b972355a8f8
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-index 38523f516adeee6ccd99f2b97bca60e0b499e01c..39ad05c21caaaee6860ceb3a310e2aeaeda7ad5b 100644
+index e6aab22248b463e088f50acf6275e364ea4b0809..87834a0d2bde9588abb89525ad8ac8fc6afd1a2f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
-@@ -573,6 +573,16 @@ public class PurpurConfig {
+@@ -575,6 +575,16 @@ public class PurpurConfig {
          fixProjectileLootingTransfer = getBoolean("settings.fix-projectile-looting-transfer", fixProjectileLootingTransfer);
      }
  


### PR DESCRIPTION
Customizable sleeping actionbar messages do not currently allow configuration of the "sleeping not possible" message. In en-US, the message is "No amount of rest can pass this night". As far as I know, this message only appears when `/gamerule playersSleepingPercentage` is greater than 100.

This PR amends the existing patch to add this third sleeping-related actionbar message.