### PR TITLE
Add option to always show item in player death messages

### DIFF
--- a/patches/server/0306-Add-option-for-always-showing-item-in-player-death-m.patch
+++ b/patches/server/0306-Add-option-for-always-showing-item-in-player-death-m.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add option for always showing item in player death messages
 
 
 diff --git a/src/main/java/net/minecraft/world/damagesource/CombatTracker.java b/src/main/java/net/minecraft/world/damagesource/CombatTracker.java
-index 45e4717ba832edceeafdba575323c2527c350193..0c9d6724f51be6fe9cafaecd642df54f964766d3 100644
+index 45e4717ba832edceeafdba575323c2527c350193..45a1cbe958c1a626df97022afe22484f2b387233 100644
 --- a/src/main/java/net/minecraft/world/damagesource/CombatTracker.java
 +++ b/src/main/java/net/minecraft/world/damagesource/CombatTracker.java
 @@ -59,7 +59,7 @@ public class CombatTracker {
@@ -13,12 +13,12 @@ index 45e4717ba832edceeafdba575323c2527c350193..0c9d6724f51be6fe9cafaecd642df54f
  
          ItemStack itemStack = var10000;
 -        return !itemStack.isEmpty() && itemStack.hasCustomHoverName() ? Component.translatable(itemDeathTranslationKey, this.mob.getDisplayName(), attackerDisplayName, itemStack.getDisplayName()) : Component.translatable(deathTranslationKey, this.mob.getDisplayName(), attackerDisplayName);
-+        return !itemStack.isEmpty() && (itemStack.hasCustomHoverName() || org.purpurmc.purpur.PurpurConfig.playerDeathsAlwaysShowItem) ? Component.translatable(itemDeathTranslationKey, this.mob.getDisplayName(), attackerDisplayName, itemStack.getDisplayName()) : Component.translatable(deathTranslationKey, this.mob.getDisplayName(), attackerDisplayName);
++        return !itemStack.isEmpty() && (org.purpurmc.purpur.PurpurConfig.playerDeathsAlwaysShowItem || itemStack.hasCustomHoverName()) ? Component.translatable(itemDeathTranslationKey, this.mob.getDisplayName(), attackerDisplayName, itemStack.getDisplayName()) : Component.translatable(deathTranslationKey, this.mob.getDisplayName(), attackerDisplayName);
      }
  
      private Component getFallMessage(CombatEntry damageRecord, @Nullable Entity attacker) {
 diff --git a/src/main/java/net/minecraft/world/damagesource/DamageSource.java b/src/main/java/net/minecraft/world/damagesource/DamageSource.java
-index fc1fb63ee0e28b8d1f065bfad716b465cde5a69f..48094458691d41275b75edb5f8cd9557ede8a763 100644
+index fc1fb63ee0e28b8d1f065bfad716b465cde5a69f..c8860f20956a2819da001e93938249452bf7cb49 100644
 --- a/src/main/java/net/minecraft/world/damagesource/DamageSource.java
 +++ b/src/main/java/net/minecraft/world/damagesource/DamageSource.java
 @@ -126,7 +126,7 @@ public class DamageSource {
@@ -26,7 +26,7 @@ index fc1fb63ee0e28b8d1f065bfad716b465cde5a69f..48094458691d41275b75edb5f8cd9557
              ItemStack itemstack1 = itemstack;
  
 -            return !itemstack1.isEmpty() && itemstack1.hasCustomHoverName() ? Component.translatable(s + ".item", killed.getDisplayName(), ichatbasecomponent, itemstack1.getDisplayName()) : Component.translatable(s, killed.getDisplayName(), ichatbasecomponent);
-+            return !itemstack1.isEmpty() && (itemstack1.hasCustomHoverName() || org.purpurmc.purpur.PurpurConfig.playerDeathsAlwaysShowItem) ? Component.translatable(s + ".item", killed.getDisplayName(), ichatbasecomponent, itemstack1.getDisplayName()) : Component.translatable(s, killed.getDisplayName(), ichatbasecomponent);
++            return !itemstack1.isEmpty() && (org.purpurmc.purpur.PurpurConfig.playerDeathsAlwaysShowItem || itemstack1.hasCustomHoverName()) ? Component.translatable(s + ".item", killed.getDisplayName(), ichatbasecomponent, itemstack1.getDisplayName()) : Component.translatable(s, killed.getDisplayName(), ichatbasecomponent);
          }
      }
  

--- a/patches/server/0306-Add-option-for-always-showing-item-in-player-death-m.patch
+++ b/patches/server/0306-Add-option-for-always-showing-item-in-player-death-m.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MelnCat <melncatuwu@gmail.com>
+Date: Tue, 22 Aug 2023 22:18:26 -0700
+Subject: [PATCH] Add option for always showing item in player death messages
+
+
+diff --git a/src/main/java/net/minecraft/world/damagesource/CombatTracker.java b/src/main/java/net/minecraft/world/damagesource/CombatTracker.java
+index 45e4717ba832edceeafdba575323c2527c350193..0c9d6724f51be6fe9cafaecd642df54f964766d3 100644
+--- a/src/main/java/net/minecraft/world/damagesource/CombatTracker.java
++++ b/src/main/java/net/minecraft/world/damagesource/CombatTracker.java
+@@ -59,7 +59,7 @@ public class CombatTracker {
+         }
+ 
+         ItemStack itemStack = var10000;
+-        return !itemStack.isEmpty() && itemStack.hasCustomHoverName() ? Component.translatable(itemDeathTranslationKey, this.mob.getDisplayName(), attackerDisplayName, itemStack.getDisplayName()) : Component.translatable(deathTranslationKey, this.mob.getDisplayName(), attackerDisplayName);
++        return !itemStack.isEmpty() && (itemStack.hasCustomHoverName() || org.purpurmc.purpur.PurpurConfig.playerDeathsAlwaysShowItem) ? Component.translatable(itemDeathTranslationKey, this.mob.getDisplayName(), attackerDisplayName, itemStack.getDisplayName()) : Component.translatable(deathTranslationKey, this.mob.getDisplayName(), attackerDisplayName);
+     }
+ 
+     private Component getFallMessage(CombatEntry damageRecord, @Nullable Entity attacker) {
+diff --git a/src/main/java/net/minecraft/world/damagesource/DamageSource.java b/src/main/java/net/minecraft/world/damagesource/DamageSource.java
+index fc1fb63ee0e28b8d1f065bfad716b465cde5a69f..48094458691d41275b75edb5f8cd9557ede8a763 100644
+--- a/src/main/java/net/minecraft/world/damagesource/DamageSource.java
++++ b/src/main/java/net/minecraft/world/damagesource/DamageSource.java
+@@ -126,7 +126,7 @@ public class DamageSource {
+ 
+             ItemStack itemstack1 = itemstack;
+ 
+-            return !itemstack1.isEmpty() && itemstack1.hasCustomHoverName() ? Component.translatable(s + ".item", killed.getDisplayName(), ichatbasecomponent, itemstack1.getDisplayName()) : Component.translatable(s, killed.getDisplayName(), ichatbasecomponent);
++            return !itemstack1.isEmpty() && (itemstack1.hasCustomHoverName() || org.purpurmc.purpur.PurpurConfig.playerDeathsAlwaysShowItem) ? Component.translatable(s + ".item", killed.getDisplayName(), ichatbasecomponent, itemstack1.getDisplayName()) : Component.translatable(s, killed.getDisplayName(), ichatbasecomponent);
+         }
+     }
+ 
+diff --git a/src/main/java/org/purpurmc/purpur/PurpurConfig.java b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+index 39ad05c21caaaee6860ceb3a310e2aeaeda7ad5b..0299b99674d345ac55116fc9098aaaed1bd4daaf 100644
+--- a/src/main/java/org/purpurmc/purpur/PurpurConfig.java
++++ b/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+@@ -643,4 +643,9 @@ public class PurpurConfig {
+             block.fallDistanceMultiplier = fallDistanceMultiplier.floatValue();
+         });
+     }
++
++    public static boolean playerDeathsAlwaysShowItem = false;
++    private static void playerDeathsAlwaysShowItem() {
++        playerDeathsAlwaysShowItem = getBoolean("settings.player-deaths-always-show-item", playerDeathsAlwaysShowItem);
++    }
+ }


### PR DESCRIPTION
Currently, the item in player death messages is only shown if it is renamed, i.e. Player was killed by Player2 using [cool sword].
This patch adds a config option to allow always having the item show up, so if a player is killed with a non-renamed diamond sword, the death message will note that the killing weapon was a diamond sword.