### PR TITLE
Add hover lines API

### DIFF
--- a/patches/api/0054-Add-hover-lines-API.patch
+++ b/patches/api/0054-Add-hover-lines-API.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Meln Cat <melncatuwu@gmail.com>
+Date: Mon, 2 Oct 2023 17:42:19 -0700
+Subject: [PATCH] Add hover lines API
+
+
+diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
+index ab73893656932f54009340df59293df2a732be51..9448709716e0b91dd9e2c7ff4060ec0d33d77d24 100644
+--- a/src/main/java/org/bukkit/inventory/ItemFactory.java
++++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
+@@ -298,4 +298,14 @@ public interface ItemFactory {
+     @Deprecated
+     net.md_5.bungee.api.chat.hover.content.Content hoverContentOf(@NotNull org.bukkit.entity.Entity entity, @NotNull net.md_5.bungee.api.chat.BaseComponent[] customName);
+     // Paper end - bungee hover events
++
++    // Purpur start
++    /**
++     * Returns the lines of text shown when hovering over an item
++     * @param itemStack The ItemStack
++     * @param advanced Whether advanced tooltips are shown
++     * @return the list of Components
++     */
++    @NotNull java.util.List<net.kyori.adventure.text.@NotNull Component> getHoverLines(@NotNull ItemStack itemStack, boolean advanced);
++    // Purpur end
+ }
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index c733206b769d7a55076d863757fcac1a129033b7..ed168cba3692f55ac976c6ef31525e83ae36f5f9 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -1638,5 +1638,14 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, Translat
+         }
+         return random.nextInt(unbreaking + 1) > 0;
+     }
++
++    /**
++     * Returns the lines of text shown when hovering over the item
++     * @param advanced Whether advanced tooltips are shown
++     * @return the list of Components
++     */
++    public @NotNull List<net.kyori.adventure.text.@NotNull Component> getHoverLines(boolean advanced) {
++        return Bukkit.getItemFactory().getHoverLines(this, advanced);
++    }
+     // Purpur end
+ }

--- a/patches/server/0304-Add-hover-lines-API.patch
+++ b/patches/server/0304-Add-hover-lines-API.patch
@@ -5,25 +5,17 @@ Subject: [PATCH] Add hover lines API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 57f4cf40359fe9bb427eb0134660d00839a63c86..b5f5ec6724607b93c574db0ed331202ab0931bb8 100644
+index 57f4cf40359fe9bb427eb0134660d00839a63c86..ab510e5917081bd8750a2cd7465e7823687e94bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -18,6 +18,7 @@ import org.bukkit.entity.EntityType;
- import org.bukkit.inventory.ItemFactory;
- import org.bukkit.inventory.ItemStack;
- import org.bukkit.inventory.meta.ItemMeta;
-+import org.jetbrains.annotations.NotNull;
- 
- public final class CraftItemFactory implements ItemFactory {
-     static final Color DEFAULT_LEATHER_COLOR = Color.fromRGB(0xA06540);
-@@ -559,4 +560,17 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -559,4 +559,17 @@ public final class CraftItemFactory implements ItemFactory {
          return eggItem == null ? null : new net.minecraft.world.item.ItemStack(eggItem).asBukkitMirror();
      }
      // Paper end
 +
 +    // Purpur start
 +    @Override
-+    public @NotNull java.util.List<net.kyori.adventure.text.@NotNull Component> getHoverLines(@NotNull ItemStack itemStack, boolean advanced) {
++    public @org.jetbrains.annotations.NotNull java.util.List<net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component> getHoverLines(@org.jetbrains.annotations.NotNull ItemStack itemStack, boolean advanced) {
 +        return io.papermc.paper.adventure.PaperAdventure.asAdventure(
 +            CraftItemStack.asNMSCopy(itemStack).getTooltipLines(
 +            null,

--- a/patches/server/0304-Add-hover-lines-API.patch
+++ b/patches/server/0304-Add-hover-lines-API.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Meln Cat <melncatuwu@gmail.com>
+Date: Mon, 2 Oct 2023 17:42:26 -0700
+Subject: [PATCH] Add hover lines API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+index 57f4cf40359fe9bb427eb0134660d00839a63c86..b5f5ec6724607b93c574db0ed331202ab0931bb8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+@@ -18,6 +18,7 @@ import org.bukkit.entity.EntityType;
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.ItemStack;
+ import org.bukkit.inventory.meta.ItemMeta;
++import org.jetbrains.annotations.NotNull;
+ 
+ public final class CraftItemFactory implements ItemFactory {
+     static final Color DEFAULT_LEATHER_COLOR = Color.fromRGB(0xA06540);
+@@ -559,4 +560,17 @@ public final class CraftItemFactory implements ItemFactory {
+         return eggItem == null ? null : new net.minecraft.world.item.ItemStack(eggItem).asBukkitMirror();
+     }
+     // Paper end
++
++    // Purpur start
++    @Override
++    public @NotNull java.util.List<net.kyori.adventure.text.@NotNull Component> getHoverLines(@NotNull ItemStack itemStack, boolean advanced) {
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(
++            CraftItemStack.asNMSCopy(itemStack).getTooltipLines(
++            null,
++            advanced ? net.minecraft.world.item.TooltipFlag.ADVANCED
++                : net.minecraft.world.item.TooltipFlag.NORMAL
++            )
++        );
++    }
++    // Purpur end
+ }


### PR DESCRIPTION
This pull request adds a method on ItemStack to get the hover lines. This is the text shown when hovering over the item, which includes the item name, enchantments, and other information shown on hover. There is also an argument for showing the advanced tooltips, which functions like viewing the item on a client with F3 + H on.