### PR TITLE
Disable extra entities trampling turtle eggs by default

### DIFF
--- a/patches/server/0021-Add-turtle-egg-block-options.patch
+++ b/patches/server/0021-Add-turtle-egg-block-options.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add turtle egg block options
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java b/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
-index b0199e071cba4c7ad51799132d00b22b616953fc..f5eb45df4f2c9914e1780bb10fb085713c411a4d 100644
+index b4646e26965e0f1f26c5019e7c6a13fdf22bdb47..a98f04c892d6e11e311b16af36e824857dd3bc76 100644
 --- a/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
 @@ -202,6 +202,25 @@ public class TurtleEggBlock extends Block {
@@ -36,16 +36,16 @@ index b0199e071cba4c7ad51799132d00b22b616953fc..f5eb45df4f2c9914e1780bb10fb08571
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index d4bca5b5f3d10c3a04befd8c365f46433491f299..8142559d9d4eccd9d105acb1ff3aa131d8ea67b0 100644
+index d4bca5b5f3d10c3a04befd8c365f46433491f299..ac44ee7789b96e60e6d1d964d64ca33a3d3c2c62 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -140,6 +140,15 @@ public class PurpurWorldConfig {
          });
      }
  
-+    public boolean turtleEggsBreakFromExpOrbs = true;
-+    public boolean turtleEggsBreakFromItems = true;
-+    public boolean turtleEggsBreakFromMinecarts = true;
++    public boolean turtleEggsBreakFromExpOrbs = false;
++    public boolean turtleEggsBreakFromItems = false;
++    public boolean turtleEggsBreakFromMinecarts = false;
 +    private void turtleEggSettings() {
 +        turtleEggsBreakFromExpOrbs = getBoolean("blocks.turtle_egg.break-from-exp-orbs", turtleEggsBreakFromExpOrbs);
 +        turtleEggsBreakFromItems = getBoolean("blocks.turtle_egg.break-from-items", turtleEggsBreakFromItems);

--- a/patches/server/0039-Allow-soil-to-moisten-from-water-directly-under-it.patch
+++ b/patches/server/0039-Allow-soil-to-moisten-from-water-directly-under-it.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow soil to moisten from water directly under it
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/FarmBlock.java b/src/main/java/net/minecraft/world/level/block/FarmBlock.java
-index 47eb8bf604a63259c0200cada1403dc005a6cbac..4837453b2186d50da0bbcbcdc0bfe562c9f36039 100644
+index 6e4c852c93f2418ea69e485ed3a10cbe3a6e3bd2..81114915732ea4c8d772bc970a903646a7ae0c5a 100644
 --- a/src/main/java/net/minecraft/world/level/block/FarmBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FarmBlock.java
 @@ -171,7 +171,7 @@ public class FarmBlock extends Block {
@@ -18,7 +18,7 @@ index 47eb8bf604a63259c0200cada1403dc005a6cbac..4837453b2186d50da0bbcbcdc0bfe562
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index f9768a250a4a1543caa3aeab7e745e289d18d2e4..113d827713b409cc3093c39a56439d7c0d04e129 100644
+index a9d6c6713a098ca87d62b43d491bc2d9a8590741..41b804abeab390a259eb0c8ed72f75ad403471dd 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -145,6 +145,11 @@ public class PurpurWorldConfig {
@@ -30,6 +30,6 @@ index f9768a250a4a1543caa3aeab7e745e289d18d2e4..113d827713b409cc3093c39a56439d7c
 +        farmlandGetsMoistFromBelow = getBoolean("blocks.farmland.gets-moist-from-below", farmlandGetsMoistFromBelow);
 +    }
 +
-     public boolean turtleEggsBreakFromExpOrbs = true;
-     public boolean turtleEggsBreakFromItems = true;
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;
+     public boolean turtleEggsBreakFromItems = false;
+     public boolean turtleEggsBreakFromMinecarts = false;

--- a/patches/server/0051-Implement-infinite-liquids.patch
+++ b/patches/server/0051-Implement-infinite-liquids.patch
@@ -67,7 +67,7 @@ index cde93efaecd42b9081405638af3ba91cb5e184c9..c664fd77dd865037293a3e86699fd1fa
      @Override
      protected void beforeDestroyingBlock(LevelAccessor world, BlockPos pos, BlockState state,  BlockPos source) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 40a0cd68b1e35894360f0edc45bc30a5bd47622f..783c238cc0e68e52b0f20ea535a208d3bec663de 100644
+index c07064174a0ef81a9bbe628251ee1346af890ae0..5e9ce4502f5219b941ffc6f341c95d39755af664 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -221,6 +221,11 @@ public class PurpurWorldConfig {
@@ -79,9 +79,9 @@ index 40a0cd68b1e35894360f0edc45bc30a5bd47622f..783c238cc0e68e52b0f20ea535a208d3
 +        lavaInfiniteRequiredSources = getInt("blocks.lava.infinite-required-sources", lavaInfiniteRequiredSources);
 +    }
 +
-     public boolean turtleEggsBreakFromExpOrbs = true;
-     public boolean turtleEggsBreakFromItems = true;
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;
+     public boolean turtleEggsBreakFromItems = false;
+     public boolean turtleEggsBreakFromMinecarts = false;
 @@ -230,6 +235,11 @@ public class PurpurWorldConfig {
          turtleEggsBreakFromMinecarts = getBoolean("blocks.turtle_egg.break-from-minecarts", turtleEggsBreakFromMinecarts);
      }

--- a/patches/server/0052-Make-lava-flow-speed-configurable.patch
+++ b/patches/server/0052-Make-lava-flow-speed-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make lava flow speed configurable
 
 
 diff --git a/src/main/java/net/minecraft/world/level/material/LavaFluid.java b/src/main/java/net/minecraft/world/level/material/LavaFluid.java
-index 2076e4b433e0a57e3ae7053c1df77e0cdc457fc9..70ddb3b130ee59a6e200ea5af3ac89f3c3fa9e9b 100644
+index 4c230136d832d50ae16ffa037b0b30ff1101b50a..2d492d849ff73a738dfbcb16507feb89bf19a962 100644
 --- a/src/main/java/net/minecraft/world/level/material/LavaFluid.java
 +++ b/src/main/java/net/minecraft/world/level/material/LavaFluid.java
 @@ -180,7 +180,7 @@ public abstract class LavaFluid extends FlowingFluid {
@@ -18,7 +18,7 @@ index 2076e4b433e0a57e3ae7053c1df77e0cdc457fc9..70ddb3b130ee59a6e200ea5af3ac89f3
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index e1fd29d376fc52e7519d93073b3823e616cea2c1..021a25e23103f789361f6263df52436fa4b0adfe 100644
+index 5e9ce4502f5219b941ffc6f341c95d39755af664..09c131e3b5282d1ac1230ddc2677f2a49449dc48 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -222,8 +222,12 @@ public class PurpurWorldConfig {
@@ -33,4 +33,4 @@ index e1fd29d376fc52e7519d93073b3823e616cea2c1..021a25e23103f789361f6263df52436f
 +        lavaSpeedNotNether = getInt("blocks.lava.speed.not-nether", lavaSpeedNotNether);
      }
  
-     public boolean turtleEggsBreakFromExpOrbs = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;

--- a/patches/server/0069-Implement-respawn-anchor-explosion-options.patch
+++ b/patches/server/0069-Implement-respawn-anchor-explosion-options.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement respawn anchor explosion options
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/RespawnAnchorBlock.java b/src/main/java/net/minecraft/world/level/block/RespawnAnchorBlock.java
-index ec7b5e089c2911c7833e3fd7db4018ca2e0d4e85..1734e2e9ac1e3e609cf58cfd8532433fc9559284 100644
+index 088262f306755a9cb785c7a0cf0a9c66ed0965a8..a3621a126a286a2789d069382940e8aa24c4caf2 100644
 --- a/src/main/java/net/minecraft/world/level/block/RespawnAnchorBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RespawnAnchorBlock.java
 @@ -148,7 +148,7 @@ public class RespawnAnchorBlock extends Block {
@@ -18,7 +18,7 @@ index ec7b5e089c2911c7833e3fd7db4018ca2e0d4e85..1734e2e9ac1e3e609cf58cfd8532433f
  
      public static boolean canSetSpawn(Level world) {
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 813d942b4edf3d4143565c694b444092fd577cc8..61aaa72034c4b8b964b65aab7b9edb4d3471bf93 100644
+index 95f016b7c127129b71e266a3daefd55502fdb299..55ae989ae13ae9c0730f6f8df5f7eba52a560b1f 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -324,6 +324,27 @@ public class PurpurWorldConfig {
@@ -46,6 +46,6 @@ index 813d942b4edf3d4143565c694b444092fd577cc8..61aaa72034c4b8b964b65aab7b9edb4d
 +        }
 +    }
 +
-     public boolean turtleEggsBreakFromExpOrbs = true;
-     public boolean turtleEggsBreakFromItems = true;
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;
+     public boolean turtleEggsBreakFromItems = false;
+     public boolean turtleEggsBreakFromMinecarts = false;

--- a/patches/server/0077-Redstone-deactivates-spawners.patch
+++ b/patches/server/0077-Redstone-deactivates-spawners.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Redstone deactivates spawners
 
 
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index d88a23984dcea9c2119bdc245013af8b25448da3..075b4ac21707bd0b3ad2197c59359f8d33bae486 100644
+index 65c3e91ac4541c0150057dc9f012eb1ee566516e..40c199812ecf7b16fe5a17c18cb0d6d3ce258910 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 @@ -57,6 +57,7 @@ public abstract class BaseSpawner {
@@ -17,7 +17,7 @@ index d88a23984dcea9c2119bdc245013af8b25448da3..075b4ac21707bd0b3ad2197c59359f8d
      }
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 51dd20665e5cdf1e76a63367d75890d4ae8f55b6..8f085e8ba40d3bd9fca27b18b9ee156bbffe6bc3 100644
+index df4f384032f398fc9852e753dee820ffa33e10bb..85d2030c58fb97be82c97a042bc5d73e76274268 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -352,6 +352,11 @@ public class PurpurWorldConfig {
@@ -29,6 +29,6 @@ index 51dd20665e5cdf1e76a63367d75890d4ae8f55b6..8f085e8ba40d3bd9fca27b18b9ee156b
 +        spawnerDeactivateByRedstone = getBoolean("blocks.spawner.deactivate-by-redstone", spawnerDeactivateByRedstone);
 +    }
 +
-     public boolean turtleEggsBreakFromExpOrbs = true;
-     public boolean turtleEggsBreakFromItems = true;
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;
+     public boolean turtleEggsBreakFromItems = false;
+     public boolean turtleEggsBreakFromMinecarts = false;

--- a/patches/server/0122-Add-mobGriefing-bypass-to-everything-affected.patch
+++ b/patches/server/0122-Add-mobGriefing-bypass-to-everything-affected.patch
@@ -375,7 +375,7 @@ index a98f04c892d6e11e311b16af36e824857dd3bc76..430ccf1b9f5c6306bbe610d1f9058c1a
      }
  }
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index fb8d380b90338b91c7481b4c3242ab3336e32370..5e0667dbce808de7f81a68347152094036d70ec0 100644
+index 8a7538298f1f23652a3122750f9be8fdb6678150..6fbc12411573bbc4794319d41655a1e18ab62768 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -115,8 +115,11 @@ public class PurpurWorldConfig {
@@ -427,9 +427,9 @@ index fb8d380b90338b91c7481b4c3242ab3336e32370..5e0667dbce808de7f81a683471520940
      public double respawnAnchorExplosionPower = 5.0D;
      public boolean respawnAnchorExplosionFire = true;
 @@ -500,10 +513,12 @@ public class PurpurWorldConfig {
-     public boolean turtleEggsBreakFromExpOrbs = true;
-     public boolean turtleEggsBreakFromItems = true;
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;
+     public boolean turtleEggsBreakFromItems = false;
+     public boolean turtleEggsBreakFromMinecarts = false;
 +    public boolean turtleEggsBypassMobGriefing = false;
      private void turtleEggSettings() {
          turtleEggsBreakFromExpOrbs = getBoolean("blocks.turtle_egg.break-from-exp-orbs", turtleEggsBreakFromExpOrbs);

--- a/patches/server/0153-Configurable-sponge-absorption.patch
+++ b/patches/server/0153-Configurable-sponge-absorption.patch
@@ -8,7 +8,7 @@ Allows the total area and radius of water blocks the sponge can absorb to be cha
 Co-authored by: granny <granny@purpurmc.org>
 
 diff --git a/src/main/java/net/minecraft/world/level/block/SpongeBlock.java b/src/main/java/net/minecraft/world/level/block/SpongeBlock.java
-index c4667bea0708d12e228ec2a4c84fcee7e48ca08c..6469f5e25673b4e20cf0b520b28b14b2eda9130c 100644
+index 8f3cca228f8ec1ea9379fa43af4baa7b18012dd2..1737a670aa81c17233f8e9a8632f0e0876be367c 100644
 --- a/src/main/java/net/minecraft/world/level/block/SpongeBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/SpongeBlock.java
 @@ -58,7 +58,7 @@ public class SpongeBlock extends Block {
@@ -21,7 +21,7 @@ index c4667bea0708d12e228ec2a4c84fcee7e48ca08c..6469f5e25673b4e20cf0b520b28b14b2
              int i = aenumdirection.length;
  
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 4957adad4022b244ad04c04ad87563239bcc0469..ff6c402f69072ffa781593a28fc7fa0637e7e612 100644
+index 1f04cb26fb29f8c107415c1b28c39dfec264bf70..f51f9b485bb5b84d92afb84ebef3a41af9e22b09 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -629,6 +629,13 @@ public class PurpurWorldConfig {
@@ -35,6 +35,6 @@ index 4957adad4022b244ad04c04ad87563239bcc0469..ff6c402f69072ffa781593a28fc7fa06
 +        spongeAbsorptionRadius = getInt("blocks.sponge.absorption.radius", spongeAbsorptionRadius);
 +    }
 +
-     public boolean turtleEggsBreakFromExpOrbs = true;
-     public boolean turtleEggsBreakFromItems = true;
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;
+     public boolean turtleEggsBreakFromItems = false;
+     public boolean turtleEggsBreakFromMinecarts = false;

--- a/patches/server/0200-Option-for-sponges-to-work-on-lava-and-mud.patch
+++ b/patches/server/0200-Option-for-sponges-to-work-on-lava-and-mud.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Option for sponges to work on lava and mud
 Co-authored by: granny <granny@purpurmc.org>
 
 diff --git a/src/main/java/net/minecraft/world/level/block/SpongeBlock.java b/src/main/java/net/minecraft/world/level/block/SpongeBlock.java
-index 6469f5e25673b4e20cf0b520b28b14b2eda9130c..9e4146ecd36ff2698ee951660ed88290c80fd8f7 100644
+index 1737a670aa81c17233f8e9a8632f0e0876be367c..7e87b4299979c9e46abb582da7a8e54a36e8dfc5 100644
 --- a/src/main/java/net/minecraft/world/level/block/SpongeBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/SpongeBlock.java
 @@ -77,7 +77,7 @@ public class SpongeBlock extends Block {
@@ -30,7 +30,7 @@ index 6469f5e25673b4e20cf0b520b28b14b2eda9130c..9e4146ecd36ff2698ee951660ed88290
                          if (!iblockdata.is(Blocks.KELP) && !iblockdata.is(Blocks.KELP_PLANT) && !iblockdata.is(Blocks.SEAGRASS) && !iblockdata.is(Blocks.TALL_SEAGRASS)) {
                              return false;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1e2860c910db8b2b6a73a67d040528df2c44f5f5..5cbbc7e818ed2e82a2ab17d7f3be35f2fe8c3c21 100644
+index ac7238a490e1f564a66fca05ce012ad416b9591f..deba979e6987f60308c6b4a286943b18aa2974f4 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -1014,9 +1014,13 @@ public class PurpurWorldConfig {
@@ -46,4 +46,4 @@ index 1e2860c910db8b2b6a73a67d040528df2c44f5f5..5cbbc7e818ed2e82a2ab17d7f3be35f2
 +        spongeAbsorbsWaterFromMud = getBoolean("blocks.sponge.absorbs-water-from-mud", spongeAbsorbsWaterFromMud);
      }
  
-     public boolean turtleEggsBreakFromExpOrbs = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;

--- a/patches/server/0229-Turtle-eggs-random-tick-crack-chance.patch
+++ b/patches/server/0229-Turtle-eggs-random-tick-crack-chance.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Turtle eggs random tick crack chance
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java b/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
-index 189cec37228f88c97e1994c40c44461a3321df8b..1099ce368c95ec293b8e6349ee545d3256e93ac3 100644
+index 430ccf1b9f5c6306bbe610d1f9058c1a4bfa2986..b18545e1bd55fa468af6d6c03211036eb9fa146d 100644
 --- a/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
 @@ -169,7 +169,7 @@ public class TurtleEggBlock extends Block {
@@ -18,12 +18,12 @@ index 189cec37228f88c97e1994c40c44461a3321df8b..1099ce368c95ec293b8e6349ee545d32
  
      @Override
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 1b1f249659d3d6f80d442439b05dcc88eefd5841..38548885da9d34148589ae0502f0aea7f3faf46e 100644
+index b3b79975bc3d4e56246e7aec34750f50dd85c61a..0ce9870c1da0cba4e3ee7ccb05ace4fc4e1b0223 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -1076,11 +1076,13 @@ public class PurpurWorldConfig {
-     public boolean turtleEggsBreakFromItems = true;
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromItems = false;
+     public boolean turtleEggsBreakFromMinecarts = false;
      public boolean turtleEggsBypassMobGriefing = false;
 +    public int turtleEggsRandomTickCrackChance = 500;
      private void turtleEggSettings() {

--- a/patches/server/0247-Option-to-disable-turtle-egg-trampling-with-feather-.patch
+++ b/patches/server/0247-Option-to-disable-turtle-egg-trampling-with-feather-.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Option to disable turtle egg trampling with feather falling
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java b/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
-index 1099ce368c95ec293b8e6349ee545d3256e93ac3..777ba7b3dfbb8cee8b782490101127271f7320d2 100644
+index b18545e1bd55fa468af6d6c03211036eb9fa146d..9a76665c6369b4106d152370dc3d2f5645cb02b1 100644
 --- a/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/TurtleEggBlock.java
 @@ -218,7 +218,13 @@ public class TurtleEggBlock extends Block {
@@ -24,11 +24,11 @@ index 1099ce368c95ec293b8e6349ee545d3256e93ac3..777ba7b3dfbb8cee8b78249010112727
          return world.purpurConfig.turtleEggsBypassMobGriefing || world.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
          // Purpur end
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 92019e20b9a67eb3c8be875ed57943c1ee1538d6..2a898817bff68402631fbcf9318bed76548c9e21 100644
+index b291d8943dc6fe38ccc2ca2a17b53d3cfb5eb894..2c577f12f86ed843f823f5756fd7cddb8bb807a6 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -1091,12 +1091,14 @@ public class PurpurWorldConfig {
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromMinecarts = false;
      public boolean turtleEggsBypassMobGriefing = false;
      public int turtleEggsRandomTickCrackChance = 500;
 +    public boolean turtleEggsTramplingFeatherFalling = false;

--- a/patches/server/0251-Stonecutter-damage.patch
+++ b/patches/server/0251-Stonecutter-damage.patch
@@ -105,7 +105,7 @@ index c6628a28387023b334dd99a4e469126a2108c38b..3a49455509a26063a62e39fb3d3ad81e
  
      public static boolean advancementOnlyBroadcastToAffectedPlayer = false;
 diff --git a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
-index 05d82f9555b8836b48d076ec38f3aab6c070e58b..0abcb153446080c385d35cea03f6f7e8e9de8ff4 100644
+index adf1064af51c737f97c071fb65019a874a881a18..f78b58599325a93658f6c6c2df9bde1ae4fb8784 100644
 --- a/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 +++ b/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
 @@ -1086,6 +1086,11 @@ public class PurpurWorldConfig {
@@ -117,6 +117,6 @@ index 05d82f9555b8836b48d076ec38f3aab6c070e58b..0abcb153446080c385d35cea03f6f7e8
 +        stonecutterDamage = (float) getDouble("blocks.stonecutter.damage", stonecutterDamage);
 +    }
 +
-     public boolean turtleEggsBreakFromExpOrbs = true;
-     public boolean turtleEggsBreakFromItems = true;
-     public boolean turtleEggsBreakFromMinecarts = true;
+     public boolean turtleEggsBreakFromExpOrbs = false;
+     public boolean turtleEggsBreakFromItems = false;
+     public boolean turtleEggsBreakFromMinecarts = false;


### PR DESCRIPTION
I was surprised to learn that items landing on a turtle egg break the egg in the default Purpur config. To maintain the opt-in and drop-in approach Purpur generally takes, these additional entities (items, experience orbs, and minecarts) should match Vanilla behavior and not break turtle eggs unless the server owner chooses to enable it.