### PR TITLE
Switch to NogyangSpigot Fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "NogyangSpigot"]
+	path = NogyangSpigot
+	url = https://github.com/GAME-CLI-SRV-DEV/NogyangSpigot

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -143,4 +143,5 @@ tasks.register("printPurpurVersion") {
     doLast {
         println(project.version)
     }
+ }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ patchTasks {
                     outputDir = layout.projectDirectory.dir("Purpur-api")
                 }
                 register("server") {
-                    upstreamDir = paperDir.dir("NogyangSpigot-Server")
+                    upstreamDir = paperDir.dir("NogyangSpigot-server")
                     patchDir = layout.projectDirectory.dir("patches/server")
                     outputDir = layout.projectDirectory.dir("Purpur-server")
                     importMcDev = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,14 +85,14 @@ paperweight {
 			
 patchTasks {
                 register("api") {
-                    upstreamDir = paperDir.dir("Paper-API")
+                    upstreamDir = paperDir.dir("NogyangSpigot-API")
                     patchDir = layout.projectDirectory.dir("patches/api")
-                    outputDir = layout.projectDirectory.dir("$projectName-api")
+                    outputDir = layout.projectDirectory.dir("Purpur-api")
                 }
                 register("server") {
-                    upstreamDir = paperDir.dir("Paper-Server")
+                    upstreamDir = paperDir.dir("NogyangSpigot-Server")
                     patchDir = layout.projectDirectory.dir("patches/server")
-                    outputDir = layout.projectDirectory.dir("$projectName-server")
+                    outputDir = layout.projectDirectory.dir("Purpur-server")
                     importMcDev = true
                 }
                 register("generatedApi") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ repositories {
     }
 }
 
-val paperDir = layout.projectDirectory.dir("work/NogyangSpigot")
+val paperDir = layout.projectDirectory.dir("NogyangSpigot")
 val initSubmodules by tasks.registering {
     outputs.upToDateWhen { false }
     doLast {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ paperweight {
 			
 patchTasks {
                 register("api") {
-                    upstreamDir = paperDir.dir("NogyangSpigot-API")
+                    upstreamDir = paperDir.dir("NogyangSpigot-api")
                     patchDir = layout.projectDirectory.dir("patches/api")
                     outputDir = layout.projectDirectory.dir("Purpur-api")
                 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,6 @@ group = org.purpurmc.purpur
 version = 1.20.6-R0.1-SNAPSHOT
 
 mcVersion = 1.20.6
-paperCommit = bd5867a96f792f0eb32c1d249bb4bbc1d8338d14
 
 org.gradle.caching = true
 org.gradle.parallel = true


### PR DESCRIPTION
i checked out NogyangSpigot and the api patched correctly as a submodule.
from future purpur builds instead of Using Paper as a upstream, Use NogyangSpigot as a submodule.

Tasks:

- [ ] Fix Server Patches
