### PR TITLE
Fire EntityTeleportHinderedEvent when attempting to teleport a player with passengers

### DIFF
--- a/patches/server/0293-Fire-EntityTeleportHinderedEvent-when-attempting-to-.patch
+++ b/patches/server/0293-Fire-EntityTeleportHinderedEvent-when-attempting-to-.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Villagers654 <110007851+Villagers654@users.noreply.github.com>
+Date: Mon, 22 Jul 2024 21:03:09 -0400
+Subject: [PATCH] Fire EntityTeleportHinderedEvent when attempting to teleport
+ a player with passengers
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index b9130d040acff1e5cb7a475be93b03cdbe229683..e3100e65fea02374d4393bab48d63ddeaecef0ab 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1458,6 +1458,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+ 
+         if (entity.isVehicle() && !ignorePassengers) { // Paper - Teleport API
++            if (!new org.purpurmc.purpur.event.entity.EntityTeleportHinderedEvent(entity.getBukkitEntity(), org.purpurmc.purpur.event.entity.EntityTeleportHinderedEvent.Reason.IS_VEHICLE, cause).callEvent()) // Purpur start
+             return false;
+         }
+ 


### PR DESCRIPTION
Fires EntityTeleportHinderedEvent when a player has passengers before preventing the teleport from continuing, restoring the functionality of this event prior to 1.21, so that plugins can mount passengers to players without breaking Player#teleport

This is my first time ever using this patch system... I think I did it correctly as it was a very minor change (it certainly works when I tested!) but if I did something wrong and/or stupid feel free to let me know lol