### PR TITLE
Fix shulker box contents drop when destroyed

### DIFF
--- a/patches/server/0186-option-to-disable-shulker-box-items-from-dropping-co.patch
+++ b/patches/server/0186-option-to-disable-shulker-box-items-from-dropping-co.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] option to disable shulker box items from dropping contents
 
 
 diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
-index 3253361d91e2a2e68d354eaf3dd3e3cd486e191d..2649188930653610b8aaaeb18797c80879cd572a 100644
+index 3253361d91e2a2e68d354eaf3dd3e3cd486e191d..4fc0176d75b213d08c0b21c3a0a4ef46f76328a6 100644
 --- a/src/main/java/net/minecraft/world/item/BlockItem.java
 +++ b/src/main/java/net/minecraft/world/item/BlockItem.java
 @@ -260,6 +260,7 @@ public class BlockItem extends Item {
          ItemContainerContents itemcontainercontents = (ItemContainerContents) entity.getItem().set(DataComponents.CONTAINER, ItemContainerContents.EMPTY);
  
          if (itemcontainercontents != null) {
-+            if (entity.level().purpurConfig.shulkerBoxItemDropContentsWhenDestroyed && entity.getItem().is(Items.SHULKER_BOX)) // Purpur
++            if (entity.level().purpurConfig.shulkerBoxItemDropContentsWhenDestroyed && entity.getItem().getBukkitStack().getType().name().endsWith("SHULKER_BOX")) // Purpur
              ItemUtils.onContainerDestroyed(entity, itemcontainercontents.nonEmptyItemsCopy());
          }
  


### PR DESCRIPTION
Before the change, only purple shulker box can drop contents when destroyed (burned), and this pull request fix it.