### PR TITLE
add VaultStateChangeEvent

### DIFF
--- a/patches/api/0049-add-VaultStateChangeEvent.patch
+++ b/patches/api/0049-add-VaultStateChangeEvent.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Czopek?=
+ <44530932+Grabsky@users.noreply.github.com>
+Date: Mon, 2 Dec 2024 18:59:00 +0100
+Subject: [PATCH] add VaultStateChangeEvent
+
+
+diff --git a/src/main/java/org/purpurmc/purpur/event/block/VaultStateChangeEvent.java b/src/main/java/org/purpurmc/purpur/event/block/VaultStateChangeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..d73a449cb4da3dec441242ae6db54a74a6f09a14
+--- /dev/null
++++ b/src/main/java/org/purpurmc/purpur/event/block/VaultStateChangeEvent.java
+@@ -0,0 +1,63 @@
++package org.purpurmc.purpur.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.block.data.type.Vault;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++import org.jspecify.annotations.NullMarked;
++import org.jetbrains.annotations.ApiStatus;
++import org.jetbrains.annotations.NotNull;
++
++@NullMarked
++public class VaultStateChangeEvent extends BlockEvent implements Cancellable {
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++    private boolean cancel;
++    private final @NotNull Vault.State previousState;
++    private final @NotNull Vault.State newState;
++
++    @ApiStatus.Internal
++    public VaultStateChangeEvent(final @NotNull Block theBlock, final @NotNull Vault.State previousState, final @NotNull Vault.State newState) {
++        super(theBlock);
++        this.previousState = previousState;
++        this.newState = newState;
++    }
++
++    /**
++     * Returns previous {@link Vault.State} of block involved in this event.
++     *
++     * @return the previous state
++     */
++    public @NotNull Vault.State getPreviousState() {
++        return previousState;
++    }
++
++    /**
++     * Returns the new {@link Vault.State} of block involved in this event.
++     *
++     * @return the new state
++     */
++    public @NotNull Vault.State getNewState() {
++        return newState;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    @Override
++    public void setCancelled(final boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++}

--- a/patches/server/0295-add-VaultStateChangeEvent.patch
+++ b/patches/server/0295-add-VaultStateChangeEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] add VaultStateChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/vault/VaultBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/vault/VaultBlockEntity.java
-index 4045ae665450f6e3f5630cb25cc53be850afd1a8..91437b2c3edf615f120bb9ffd971fa001c9512de 100644
+index 4045ae665450f6e3f5630cb25cc53be850afd1a8..6a67340361440f7f287dbf1717dd60279d9af1b5 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/vault/VaultBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/vault/VaultBlockEntity.java
 @@ -347,8 +347,13 @@ public class VaultBlockEntity extends BlockEntity {
@@ -21,7 +21,7 @@ index 4045ae665450f6e3f5630cb25cc53be850afd1a8..91437b2c3edf615f120bb9ffd971fa00
 +                world.setBlock(pos, newState, 3);
 +                vaultstate.onTransition(world, pos, vaultstate1, config, sharedData, (Boolean) newState.getValue(VaultBlock.OMINOUS));
 +            }
-+            // Purpur stop - VaultStateChangeEvent
++            // Purpur end - VaultStateChangeEvent
          }
  
          static void cycleDisplayItemFromLootTable(ServerLevel world, VaultState state, VaultConfig config, VaultSharedData sharedData, BlockPos pos) {

--- a/patches/server/0295-add-VaultStateChangeEvent.patch
+++ b/patches/server/0295-add-VaultStateChangeEvent.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Czopek?=
+ <44530932+Grabsky@users.noreply.github.com>
+Date: Mon, 2 Dec 2024 18:59:12 +0100
+Subject: [PATCH] add VaultStateChangeEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/vault/VaultBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/vault/VaultBlockEntity.java
+index 4045ae665450f6e3f5630cb25cc53be850afd1a8..91437b2c3edf615f120bb9ffd971fa001c9512de 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/vault/VaultBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/vault/VaultBlockEntity.java
+@@ -347,8 +347,13 @@ public class VaultBlockEntity extends BlockEntity {
+             VaultState vaultstate = (VaultState) oldState.getValue(VaultBlock.STATE);
+             VaultState vaultstate1 = (VaultState) newState.getValue(VaultBlock.STATE);
+ 
+-            world.setBlock(pos, newState, 3);
+-            vaultstate.onTransition(world, pos, vaultstate1, config, sharedData, (Boolean) newState.getValue(VaultBlock.OMINOUS));
++            // Purpur start - VaultStateChangeEvent
++            final org.purpurmc.purpur.event.block.VaultStateChangeEvent event = new org.purpurmc.purpur.event.block.VaultStateChangeEvent(org.bukkit.craftbukkit.block.CraftBlock.at(world.getLevel(), pos), org.bukkit.block.data.type.Vault.State.valueOf(vaultstate.name()), org.bukkit.block.data.type.Vault.State.valueOf(vaultstate1.name()));
++            if (event.callEvent()) {
++                world.setBlock(pos, newState, 3);
++                vaultstate.onTransition(world, pos, vaultstate1, config, sharedData, (Boolean) newState.getValue(VaultBlock.OMINOUS));
++            }
++            // Purpur stop - VaultStateChangeEvent
+         }
+ 
+         static void cycleDisplayItemFromLootTable(ServerLevel world, VaultState state, VaultConfig config, VaultSharedData sharedData, BlockPos pos) {


### PR DESCRIPTION
Simplified version of https://github.com/PaperMC/Paper/discussions/11679. May extend this API further in the future but it is already good enough for use-case described in the discussion thread.

I don't know if I put the implementation in the right place because currently - I'm afraid - the event is also called when `Vault.State` is changed via API and doing so inside the event can create an indefinite loop if handled incorrectly. I'm not sure what should I do about this.