### PR TITLE
Fix floating warning log when the kick event is canceled

### DIFF
--- a/purpur-server/minecraft-patches/features/0022-Fix-floating-disconnect-logging.patch
+++ b/purpur-server/minecraft-patches/features/0022-Fix-floating-disconnect-logging.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Pedro <43187922+pedroagrs@users.noreply.github.com>
+Date: Sun, 30 Mar 2025 05:34:11 -0300
+Subject: [PATCH] Fix floating disconnect logging
+
+
+diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
+index c089a01765945277aafc62cb3566d81162c40c1d..ec1617663ae8c98668dde6c5ffd7553d3b11b8f6 100644
+--- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
+@@ -25,6 +25,7 @@ import net.minecraft.server.MinecraftServer;
+ import net.minecraft.server.level.ClientInformation;
+ import net.minecraft.util.VisibleForDebug;
+ import net.minecraft.util.profiling.Profiler;
++import org.bukkit.event.player.PlayerKickEvent.Cause;
+ import org.slf4j.Logger;
+ 
+ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPacketListener, org.bukkit.craftbukkit.entity.CraftPlayer.TransferCookieConnection { // CraftBukkit
+@@ -402,6 +403,15 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+             // Do not kick the player
+             return;
+         }
++
++        // Purpur start - Fix floating logging when the kick event is canceled
++        if (cause == Cause.FLYING_PLAYER) {
++            LOGGER.warn("{} was kicked for floating too long!", this.player.getName().getString());
++        } else if (cause == Cause.FLYING_VEHICLE) {
++            LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getName().getString());
++        }
++        // Purpur end - Fix floating logging when the kick event is canceled
++
+         // Send the possibly modified leave message
+         this.disconnect0(new DisconnectionDetails(io.papermc.paper.adventure.PaperAdventure.asVanilla(event.reason()), disconnectionDetails.report(), disconnectionDetails.bugReportLink()), event.leaveMessage()); // Paper - Adventure & use kick event leave message
+     }
+diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 96e8b37d9e953d59cf0b48ac97f2adf622ec92e9..be107643da44bcb5e542a39ca98854f6d865f23b 100644
+--- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -359,7 +359,7 @@ public class ServerGamePacketListenerImpl
+         this.knownMovePacketCount = this.receivedMovePacketCount;
+         if (this.clientIsFloating && !this.player.isSleeping() && !this.player.isPassenger() && !this.player.isDeadOrDying()) {
+             if (++this.aboveGroundTickCount > this.getMaximumFlyingTicks(this.player)) {
+-                LOGGER.warn("{} was kicked for floating too long!", this.player.getName().getString());
++                // LOGGER.warn("{} was kicked for floating too long!", this.player.getName().getString()); // Purpur - Logging moved to disconnect() method
+                 this.disconnect(io.papermc.paper.configuration.GlobalConfiguration.get().messages.kick.flyingPlayer, org.bukkit.event.player.PlayerKickEvent.Cause.FLYING_PLAYER); // Paper - use configurable kick message & kick event cause
+                 return;
+             }
+@@ -378,7 +378,7 @@ public class ServerGamePacketListenerImpl
+             this.vehicleLastGoodZ = this.lastVehicle.getZ();
+             if (this.clientVehicleIsFloating && this.lastVehicle.getControllingPassenger() == this.player) {
+                 if (++this.aboveGroundVehicleTickCount > this.getMaximumFlyingTicks(this.lastVehicle)) {
+-                    LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getName().getString());
++                    // LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getName().getString()); // Purpur - Logging moved to disconnect() method
+                     this.disconnect(io.papermc.paper.configuration.GlobalConfiguration.get().messages.kick.flyingVehicle, org.bukkit.event.player.PlayerKickEvent.Cause.FLYING_VEHICLE); // Paper - use configurable kick message & kick event cause
+                     return;
+                 }


### PR DESCRIPTION
No description; the title is self-explanatory.