### PR TITLE
Add configurable smooth snow accumulation

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -109,7 +109,7 @@
                          skeletonHorse.setAge(0);
                          skeletonHorse.setPos(blockPos.getX(), blockPos.getY(), blockPos.getZ());
                          this.addFreshEntity(skeletonHorse, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING); // CraftBukkit
-@@ -986,9 +_,39 @@
+@@ -986,9 +_,41 @@
                  if (blockState.is(Blocks.SNOW)) {
                      int layersValue = blockState.getValue(SnowLayerBlock.LAYERS);
                      if (layersValue < Math.min(_int, 8)) {
@@ -118,9 +118,10 @@
 -                        org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockFormEvent(this, heightmapPos, blockState1, null); // CraftBukkit
 +                        // Purpur start - Smooth snow accumulation
 +                        boolean canSnow = true;
-+                        // Ensure snow doesn't get more than 4 layers taller than its neighbors
-+                        if (layersValue >= 4 && org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulation) {
-+                            int layersValueMin = layersValue - 4;
++                        // Ensure snow doesn't get more than N layers taller than its neighbors
++                        // We only need to check blocks that are taller than the minimum step height
++                        if (layersValue >= org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep && org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep > 0) {
++                            int layersValueMin = layersValue - org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep;
 +                            for (int x = -1; x <= 1 && canSnow; x++) {
 +                                for (int z = -1; z <= 1; z++) {
 +                                    if (x != 0 && z != 0) {
@@ -129,6 +130,7 @@
 +                                    BlockPos blockPosNeighbor = heightmapPos.offset(x, 0, z);
 +                                    BlockState blockStateNeighbor = this.getBlockState(blockPosNeighbor);
 +                                    if (blockStateNeighbor.is(Blocks.AIR)) {
++                                        // Since our layer is tall enough already, if we have a short layer or air, skip
 +                                        canSnow = false;
 +                                        break;
 +                                    } else if (!blockStateNeighbor.is(Blocks.SNOW)) {

--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -109,7 +109,7 @@
                          skeletonHorse.setAge(0);
                          skeletonHorse.setPos(blockPos.getX(), blockPos.getY(), blockPos.getZ());
                          this.addFreshEntity(skeletonHorse, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING); // CraftBukkit
-@@ -986,9 +_,41 @@
+@@ -986,9 +_,35 @@
                  if (blockState.is(Blocks.SNOW)) {
                      int layersValue = blockState.getValue(SnowLayerBlock.LAYERS);
                      if (layersValue < Math.min(_int, 8)) {
@@ -122,26 +122,20 @@
 +                        // We only need to check blocks that are taller than the minimum step height
 +                        if (layersValue >= org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep && org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep > 0) {
 +                            int layersValueMin = layersValue - org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulationStep;
-+                            for (int x = -1; x <= 1 && canSnow; x++) {
-+                                for (int z = -1; z <= 1; z++) {
-+                                    if (x != 0 && z != 0) {
-+                                        continue; // Skip corners
-+                                    }
-+                                    BlockPos blockPosNeighbor = heightmapPos.offset(x, 0, z);
-+                                    BlockState blockStateNeighbor = this.getBlockState(blockPosNeighbor);
-+                                    if (blockStateNeighbor.is(Blocks.AIR)) {
-+                                        // Since our layer is tall enough already, if we have a short layer or air, skip
-+                                        canSnow = false;
-+                                        break;
-+                                    } else if (!blockStateNeighbor.is(Blocks.SNOW)) {
-+                                        // Consider a block to be a full 8 layers of snow
-+                                        continue;
-+                                    }
++                            for (Direction direction : Direction.Plane.HORIZONTAL) {
++                                BlockPos blockPosNeighbor = heightmapPos.relative(direction);
++                                BlockState blockStateNeighbor = this.getBlockState(blockPosNeighbor);
++                                if (blockStateNeighbor.is(Blocks.SNOW)) {
++                                    // Special check for snow layers, if neighbors are too short, don't accumulate
 +                                    int layersValueNeighbor = blockStateNeighbor.getValue(SnowLayerBlock.LAYERS);
 +                                    if (layersValueNeighbor <= layersValueMin) {
 +                                        canSnow = false;
 +                                        break;
 +                                    }
++                                } else if (!Block.isFaceFull(blockStateNeighbor.getCollisionShape(this, blockPosNeighbor), direction.getOpposite())) {
++                                    // Since our layer is tall enough already, if we have a non-full neighbor block, don't accumulate
++                                    canSnow = false;
++                                    break;
 +                                }
 +                            }
 +                        }

--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -135,7 +135,7 @@
 +                                        break;
 +                                    } else if (!blockStateNeighbor.is(Blocks.SNOW)) {
 +                                        // Consider a block to be a full 8 layers of snow
-+                                        break;
++                                        continue;
 +                                    }
 +                                    int layersValueNeighbor = blockStateNeighbor.getValue(SnowLayerBlock.LAYERS);
 +                                    if (layersValueNeighbor <= layersValueMin) {

--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -109,6 +109,49 @@
                          skeletonHorse.setAge(0);
                          skeletonHorse.setPos(blockPos.getX(), blockPos.getY(), blockPos.getZ());
                          this.addFreshEntity(skeletonHorse, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING); // CraftBukkit
+@@ -986,9 +_,39 @@
+                 if (blockState.is(Blocks.SNOW)) {
+                     int layersValue = blockState.getValue(SnowLayerBlock.LAYERS);
+                     if (layersValue < Math.min(_int, 8)) {
+-                        BlockState blockState1 = blockState.setValue(SnowLayerBlock.LAYERS, Integer.valueOf(layersValue + 1));
+-                        Block.pushEntitiesUp(blockState, blockState1, this, heightmapPos);
+-                        org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockFormEvent(this, heightmapPos, blockState1, null); // CraftBukkit
++                        // Purpur start - Smooth snow accumulation
++                        boolean canSnow = true;
++                        // Ensure snow doesn't get more than 4 layers taller than its neighbors
++                        if (layersValue >= 4 && org.purpurmc.purpur.PurpurConfig.smoothSnowAccumulation) {
++                            int layersValueMin = layersValue - 4;
++                            for (int x = -1; x <= 1 && canSnow; x++) {
++                                for (int z = -1; z <= 1; z++) {
++                                    if (x != 0 && z != 0) {
++                                        continue; // Skip corners
++                                    }
++                                    BlockPos blockPosNeighbor = heightmapPos.offset(x, 0, z);
++                                    BlockState blockStateNeighbor = this.getBlockState(blockPosNeighbor);
++                                    if (blockStateNeighbor.is(Blocks.AIR)) {
++                                        canSnow = false;
++                                        break;
++                                    } else if (!blockStateNeighbor.is(Blocks.SNOW)) {
++                                        // Consider a block to be a full 8 layers of snow
++                                        break;
++                                    }
++                                    int layersValueNeighbor = blockStateNeighbor.getValue(SnowLayerBlock.LAYERS);
++                                    if (layersValueNeighbor <= layersValueMin) {
++                                        canSnow = false;
++                                        break;
++                                    }
++                                }
++                            }
++                        }
++                        if (canSnow) {
++                            BlockState blockState1 = blockState.setValue(SnowLayerBlock.LAYERS, Integer.valueOf(layersValue + 1));
++                            Block.pushEntitiesUp(blockState, blockState1, this, heightmapPos);
++                            org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockFormEvent(this, heightmapPos, blockState1, null); // CraftBukkit
++                        }
++                        // Purpur end - Smooth snow accumulation
+                     }
+                 } else {
+                     org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockFormEvent(this, heightmapPos, Blocks.SNOW.defaultBlockState(), null); // CraftBukkit
 @@ -1009,7 +_,7 @@
                  pointOfInterestType -> pointOfInterestType.is(PoiTypes.LIGHTNING_ROD),
                  blockPos -> blockPos.getY() == this.getHeight(Heightmap.Types.WORLD_SURFACE, blockPos.getX(), blockPos.getZ()) - 1,

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -332,7 +332,7 @@ public class PurpurConfig {
     public static boolean cryingObsidianValidForPortalFrame = false;
     public static int beeInsideBeeHive = 3;
     public static boolean anvilCumulativeCost = true;
-    public static boolean smoothSnowAccumulation = false;
+    public static int smoothSnowAccumulationStep = 0;
     public static int lightningRodRange = 128;
     public static Set<Enchantment> grindstoneIgnoredEnchants = new HashSet<>();
     public static boolean grindstoneRemoveAttributes = false;
@@ -376,7 +376,16 @@ public class PurpurConfig {
         cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
         beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
         anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);
-        smoothSnowAccumulation = getBoolean("settings.blocks.snow.smooth-accumulation", smoothSnowAccumulation);
+        smoothSnowAccumulationStep = getInt("settings.blocks.snow.smooth-accumulation-step", smoothSnowAccumulationStep);
+        if (smoothSnowAccumulationStep > 7) {
+            smoothSnowAccumulationStep = 7;
+            log(Level.WARNING, "blocks.snow.smooth-accumulation-step is set to above maximum allowed value of 7");
+            log(Level.WARNING, "Using value of 7 to prevent issues");
+        } else if (smoothSnowAccumulationStep < 0) {
+            smoothSnowAccumulationStep = 0;
+            log(Level.WARNING, "blocks.snow.smooth-accumulation-step is set to below minimum allowed value of 0");
+            log(Level.WARNING, "Using value of 0 to prevent issues");
+        }
         lightningRodRange = getInt("settings.blocks.lightning_rod.range", lightningRodRange);
         ArrayList<String> defaultCurses = new ArrayList<>(){{
             add("minecraft:binding_curse");

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -332,6 +332,7 @@ public class PurpurConfig {
     public static boolean cryingObsidianValidForPortalFrame = false;
     public static int beeInsideBeeHive = 3;
     public static boolean anvilCumulativeCost = true;
+    public static boolean smoothSnowAccumulation = false;
     public static int lightningRodRange = 128;
     public static Set<Enchantment> grindstoneIgnoredEnchants = new HashSet<>();
     public static boolean grindstoneRemoveAttributes = false;
@@ -375,6 +376,7 @@ public class PurpurConfig {
         cryingObsidianValidForPortalFrame = getBoolean("settings.blocks.crying_obsidian.valid-for-portal-frame", cryingObsidianValidForPortalFrame);
         beeInsideBeeHive = getInt("settings.blocks.beehive.max-bees-inside", beeInsideBeeHive);
         anvilCumulativeCost = getBoolean("settings.blocks.anvil.cumulative-cost", anvilCumulativeCost);
+        smoothSnowAccumulation = getBoolean("settings.blocks.snow.smooth-accumulation", smoothSnowAccumulation);
         lightningRodRange = getInt("settings.blocks.lightning_rod.range", lightningRodRange);
         ArrayList<String> defaultCurses = new ArrayList<>(){{
             add("minecraft:binding_curse");


### PR DESCRIPTION
I always thought it'd be nice if Minecraft snow accumulated higher than 1 layer, and while the newer `snowAccumulationHeight` gamerule allows it to accumulate to 8 layers, I always thought it just looked kind of ugly. The snow is too thick in places, and it makes traversing mountains a pain and your house gets buried...

This adds a simple check to see if the neighboring snow blocks are already building up, before allowing a snow layer to accumulate. It just makes it a little bit gentler, and makes it much more manageable to use snowAccumulationHeight without just being frustrated.