### PR TITLE
Add check for max growth age special case

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/GrowingPlantHeadBlock.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/GrowingPlantHeadBlock.java.patch
@@ -5,7 +5,7 @@
      @Override
      public BlockState getStateForPlacement(RandomSource random) {
 -        return this.defaultBlockState().setValue(AGE, Integer.valueOf(random.nextInt(25)));
-+        return this.defaultBlockState().setValue(AGE, Integer.valueOf(random.nextInt(getMaxGrowthAge()))); // Purpur - kelp, cave, weeping, and twisting configurable max growth age
++        return this.defaultBlockState().setValue(AGE, Integer.valueOf(getMaxGrowthAge() == 0 ? 0 : random.nextInt(getMaxGrowthAge()))); // Purpur - kelp, cave, weeping, and twisting configurable max growth age
      }
  
      @Override


### PR DESCRIPTION
If set `settings.blocks.xxx.max-growth-age` to 0, the server will crash when loaded the world (ticking fluid), since there is a `random.nextInt(bound)` in `GrowingPlantHeadBlock#getStateForPlacement`, the bound should be a int > 0, and the random range is 0 (inclusive) to bound (exclusive).

So just add a check for this special case, directly use 0, instead of calling nextInt
<img width="1020" alt="2025-04-12 15 24 02" src="https://github.com/user-attachments/assets/f9231e6c-0e90-4e00-87e2-8f4fbaff48f2" />

Based on the minecraft wiki, the vanilla growth age range for Twisting Vines, Kelp, etc, are 0~25, so I think no need to check cases of <0, just assume the user will set a value between 0 and 25 in purpur config 

---
Crash stacktrace
![image](https://github.com/user-attachments/assets/84d3b58b-34cf-4d17-8442-3e8a7b7de2dd)
