### PR TITLE
Add configuration setting to re-add End void rings

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/DensityFunctions.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/DensityFunctions.java.patch
@@ -5,7 +5,7 @@
              int i2 = x % 2;
              int i3 = z % 2;
 -            float f = 100.0F - Mth.sqrt((long)x * (long)x + (long)z * (long)z) * 8.0F; // Paper - cast ints to long to avoid integer overflow
-+            float f = org.purpurmc.purpur.PurpurConfig.generateEndVoidRings ? 100.0F - Mth.sqrt(x * x + z * z) * 8.0F : 100.0F - Mth.sqrt((long)x * (long)x + (long)z * (long)z) * 8.0F; // Purpur - Setting to reintroduce end void rings
++            float f = 100.0F - Mth.sqrt(org.purpurmc.purpur.PurpurConfig.generateEndVoidRings ? x * x + z * z : (long)x * (long)x + (long)z * (long)z) * 8.0F; // Paper - cast ints to long to avoid integer overflow // Purpur - Setting to reintroduce end void rings
              f = Mth.clamp(f, -100.0F, 80.0F);
  
              NoiseCache cache = noiseCache.get().computeIfAbsent(noise, noiseKey -> new NoiseCache()); // Paper - Perf: Optimize end generation

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/DensityFunctions.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/DensityFunctions.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/levelgen/DensityFunctions.java
++++ b/net/minecraft/world/level/levelgen/DensityFunctions.java
+@@ -528,7 +_,7 @@
+             int i1 = z / 2;
+             int i2 = x % 2;
+             int i3 = z % 2;
+-            float f = 100.0F - Mth.sqrt((long)x * (long)x + (long)z * (long)z) * 8.0F; // Paper - cast ints to long to avoid integer overflow
++            float f = org.purpurmc.purpur.PurpurConfig.generateEndVoidRings ? 100.0F - Mth.sqrt(x * x + z * z) * 8.0F : 100.0F - Mth.sqrt((long)x * (long)x + (long)z * (long)z) * 8.0F; // Purpur - Setting to reintroduce end void rings
+             f = Mth.clamp(f, -100.0F, 80.0F);
+ 
+             NoiseCache cache = noiseCache.get().computeIfAbsent(noise, noiseKey -> new NoiseCache()); // Paper - Perf: Optimize end generation

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -610,4 +610,9 @@ public class PurpurConfig {
             startupCommands.add(command);
         });
     }
+    
+    public static boolean generateEndVoidRings = false;
+    private static void generateEndVoidRings() {
+        generateEndVoidRings = getBoolean("settings.generate-end-void-rings", generateEndVoidRings);
+    }
 }


### PR DESCRIPTION
For players who want the End void rings to be re-added to Purpur given that Paper has patched it. Players who are interested in building large-scale map art (especially transparent map art) or building large space-based structures in the void will benefit from changing the configuration settings.

This PR adds a simple global setting switch `generate-end-void-rings` to toggle the rings (default set to `false` to have the fixed terrain generation).

**Requesting backport of this config setting into 1.21.4.**