### PR TITLE
add `mob-griefing-override` config options

### DIFF
--- a/purpur-server/minecraft-patches/features/0015-Add-mobGriefing-override-to-everything-affected.patch
+++ b/purpur-server/minecraft-patches/features/0015-Add-mobGriefing-override-to-everything-affected.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Encode42 <me@encode42.dev>
 Date: Tue, 5 Jan 2021 22:21:56 -0500
-Subject: [PATCH] Add mobGriefing bypass to everything affected
+Subject: [PATCH] Add mobGriefing override to everything affected
 
 
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 5dd1a36b967176f96a18cb0d842ccb73b7b584ef..13a1b5dd8b1a07a584f71b1f24da28965f5e2a5d 100644
+index 5dd1a36b967176f96a18cb0d842ccb73b7b584ef..e7b7f09d224a630f61259a0d905b2ad6a6fa6986 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -1904,7 +1904,7 @@ public abstract class LivingEntity extends Entity implements Attackable {
@@ -13,12 +13,12 @@ index 5dd1a36b967176f96a18cb0d842ccb73b7b584ef..13a1b5dd8b1a07a584f71b1f24da2896
              boolean var6 = false;
              if (this.dead && entitySource instanceof WitherBoss) { // Paper
 -                if (serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+                if (serverLevel.purpurConfig.witherBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++                if (serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.witherMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
                      BlockPos blockPos = this.blockPosition();
                      BlockState blockState = Blocks.WITHER_ROSE.defaultBlockState();
                      if (this.level().getBlockState(blockPos).isAir() && blockState.canSurvive(this.level(), blockPos)) {
 diff --git a/net/minecraft/world/entity/Mob.java b/net/minecraft/world/entity/Mob.java
-index ca1d0164c90e695731f05de39c1d2fff947ecfc1..b828524d62a940f89f0c0fa926ef0423019ec212 100644
+index ca1d0164c90e695731f05de39c1d2fff947ecfc1..964c7e60a8b0171ee31b12a277a4e9f8940ab58d 100644
 --- a/net/minecraft/world/entity/Mob.java
 +++ b/net/minecraft/world/entity/Mob.java
 @@ -519,7 +519,7 @@ public abstract class Mob extends LivingEntity implements EquipmentUser, Leashab
@@ -26,12 +26,12 @@ index ca1d0164c90e695731f05de39c1d2fff947ecfc1..b828524d62a940f89f0c0fa926ef0423
              && this.isAlive()
              && !this.dead
 -            && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+            && serverLevel.purpurConfig.entitiesPickUpLootBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++            && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.entitiesPickUpLootMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
              Vec3i pickupReach = this.getPickupReach();
  
              for (ItemEntity itemEntity : this.level()
 diff --git a/net/minecraft/world/entity/ai/behavior/HarvestFarmland.java b/net/minecraft/world/entity/ai/behavior/HarvestFarmland.java
-index f15e4cfd8c0ac5e08779dbe6b9aa40bfe9ce4d8f..d90a616eca474ae940d46cda94e816bddda70183 100644
+index f15e4cfd8c0ac5e08779dbe6b9aa40bfe9ce4d8f..ec03365dc786596521d280ea4d6948c651ee8deb 100644
 --- a/net/minecraft/world/entity/ai/behavior/HarvestFarmland.java
 +++ b/net/minecraft/world/entity/ai/behavior/HarvestFarmland.java
 @@ -49,7 +49,7 @@ public class HarvestFarmland extends Behavior<Villager> {
@@ -39,12 +39,12 @@ index f15e4cfd8c0ac5e08779dbe6b9aa40bfe9ce4d8f..d90a616eca474ae940d46cda94e816bd
      @Override
      protected boolean checkExtraStartConditions(ServerLevel level, Villager owner) {
 -        if (!level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+        if (!level.purpurConfig.villagerBypassMobGriefing == !level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++        if (!level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, level.purpurConfig.villagerMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
              return false;
          } else if (!owner.getVillagerData().profession().is(VillagerProfession.FARMER) && !(level.purpurConfig.villagerClericsFarmWarts && owner.getVillagerData().profession().is(VillagerProfession.CLERIC))) { // Purpur - Option for Villager Clerics to farm Nether Wart
              return false;
 diff --git a/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java b/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java
-index e026e07ca86700c864a3dceda6817fb7b6cb11e9..f1dfe0bf047e7d331b2379a672ff7b8eae4c9c90 100644
+index e026e07ca86700c864a3dceda6817fb7b6cb11e9..cf380a13d6d54d1a9e8d10b31124942d59fca80c 100644
 --- a/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/BreakDoorGoal.java
 @@ -30,7 +30,7 @@ public class BreakDoorGoal extends DoorInteractGoal {
@@ -52,12 +52,12 @@ index e026e07ca86700c864a3dceda6817fb7b6cb11e9..f1dfe0bf047e7d331b2379a672ff7b8e
      public boolean canUse() {
          return super.canUse()
 -            && getServerLevel(this.mob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)
-+            && this.mob.level().purpurConfig.zombieBypassMobGriefing == !getServerLevel(this.mob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) // Purpur - Add mobGriefing bypass to everything affected
++            && getServerLevel(this.mob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, this.mob.level().purpurConfig.zombieMobGriefingOverride) // Purpur - Add mobGriefing override to everything affected
              && this.isValidDifficulty(this.mob.level().getDifficulty())
              && !this.isOpen();
      }
 diff --git a/net/minecraft/world/entity/ai/goal/EatBlockGoal.java b/net/minecraft/world/entity/ai/goal/EatBlockGoal.java
-index 7a75415a469bc99f45a5cfaab038181717903f1d..fc244a1fbd401f6ea92e7428b9738939e0cb2b1e 100644
+index 7a75415a469bc99f45a5cfaab038181717903f1d..3c0b94e011f029a54460c878f1f7d4f603a5e3b0 100644
 --- a/net/minecraft/world/entity/ai/goal/EatBlockGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/EatBlockGoal.java
 @@ -67,7 +67,7 @@ public class EatBlockGoal extends Goal {
@@ -65,7 +65,7 @@ index 7a75415a469bc99f45a5cfaab038181717903f1d..fc244a1fbd401f6ea92e7428b9738939
              final BlockState blockState = this.level.getBlockState(blockPos); // Paper - fix wrong block state
              if (IS_EDIBLE.test(blockState)) { // Paper - fix wrong block state
 -                if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this.mob, blockPos, blockState.getFluidState().createLegacyBlock(), !getServerLevel(this.level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING))) { // CraftBukkit // Paper - fix wrong block state
-+                if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this.mob, blockPos, blockState.getFluidState().createLegacyBlock(), !getServerLevel(this.level).purpurConfig.sheepBypassMobGriefing == !getServerLevel(this.level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING))) { // CraftBukkit // Paper - fix wrong block state // Purpur - Add mobGriefing bypass to everything affected
++                if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this.mob, blockPos, blockState.getFluidState().createLegacyBlock(), !getServerLevel(this.level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, getServerLevel(this.level).purpurConfig.sheepMobGriefingOverride))) { // CraftBukkit // Paper - fix wrong block state // Purpur - Add mobGriefing override to everything affected
                      this.level.destroyBlock(blockPos, false);
                  }
  
@@ -74,12 +74,12 @@ index 7a75415a469bc99f45a5cfaab038181717903f1d..fc244a1fbd401f6ea92e7428b9738939
                  BlockPos blockPos1 = blockPos.below();
                  if (this.level.getBlockState(blockPos1).is(Blocks.GRASS_BLOCK)) {
 -                    if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this.mob, blockPos1, Blocks.DIRT.defaultBlockState(), !getServerLevel(this.level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING))) { // CraftBukkit // Paper - Fix wrong block state
-+                    if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this.mob, blockPos1, Blocks.DIRT.defaultBlockState(), !getServerLevel(this.level).purpurConfig.sheepBypassMobGriefing == !getServerLevel(this.level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING))) { // CraftBukkit // Paper - Fix wrong block state // Purpur - Add mobGriefing bypass to everything affected
++                    if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this.mob, blockPos1, Blocks.DIRT.defaultBlockState(), !getServerLevel(this.level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, getServerLevel(this.level).purpurConfig.sheepMobGriefingOverride))) { // CraftBukkit // Paper - Fix wrong block state // Purpur - Add mobGriefing override to everything affected
                          this.level.levelEvent(2001, blockPos1, Block.getId(Blocks.GRASS_BLOCK.defaultBlockState()));
                          this.level.setBlock(blockPos1, Blocks.DIRT.defaultBlockState(), 2);
                      }
 diff --git a/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java b/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java
-index 3d40911970caf6f1de2a1ebee1df4c077703226a..9b29c0c676a45de2abdc76e0502ac06ac1e53097 100644
+index 3d40911970caf6f1de2a1ebee1df4c077703226a..179597558e93c6e9172207f716f9294de3926c49 100644
 --- a/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java
 +++ b/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java
 @@ -35,7 +35,7 @@ public class RemoveBlockGoal extends MoveToBlockGoal {
@@ -87,12 +87,12 @@ index 3d40911970caf6f1de2a1ebee1df4c077703226a..9b29c0c676a45de2abdc76e0502ac06a
      @Override
      public boolean canUse() {
 -        if (!getServerLevel(this.removerMob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+        if (!getServerLevel(this.removerMob).purpurConfig.zombieBypassMobGriefing == !getServerLevel(this.removerMob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++        if (!getServerLevel(this.removerMob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, getServerLevel(this.removerMob).purpurConfig.zombieMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
              return false;
          } else if (this.nextStartTick > 0) {
              this.nextStartTick--;
 diff --git a/net/minecraft/world/entity/animal/Fox.java b/net/minecraft/world/entity/animal/Fox.java
-index 6a531e5d93d42d3dca7a5e49fb2ba14063665d2e..e3631adee6ef690807768c90045c28570982b315 100644
+index 6a531e5d93d42d3dca7a5e49fb2ba14063665d2e..9fc8ec5886e2b747f9780e43df3ac2212f50526d 100644
 --- a/net/minecraft/world/entity/animal/Fox.java
 +++ b/net/minecraft/world/entity/animal/Fox.java
 @@ -1061,7 +1061,7 @@ public class Fox extends Animal {
@@ -100,12 +100,12 @@ index 6a531e5d93d42d3dca7a5e49fb2ba14063665d2e..e3631adee6ef690807768c90045c2857
  
          protected void onReachedTarget() {
 -            if (getServerLevel(Fox.this.level()).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+            if (getServerLevel(Fox.this.level()).purpurConfig.foxBypassMobGriefing ^ getServerLevel(Fox.this.level()).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++            if (getServerLevel(Fox.this.level()).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, getServerLevel(Fox.this.level()).purpurConfig.foxMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
                  BlockState blockState = Fox.this.level().getBlockState(this.blockPos);
                  if (blockState.is(Blocks.SWEET_BERRY_BUSH)) {
                      this.pickSweetBerries(blockState);
 diff --git a/net/minecraft/world/entity/animal/Rabbit.java b/net/minecraft/world/entity/animal/Rabbit.java
-index 6c1e23e96352aa777c4e0c7d00f7620aa3f29a32..1c88e12d743325a429cad27928ea1ac43a696e8a 100644
+index 6c1e23e96352aa777c4e0c7d00f7620aa3f29a32..09b618be3ae8baed11f4d411923edbc9b26ccca8 100644
 --- a/net/minecraft/world/entity/animal/Rabbit.java
 +++ b/net/minecraft/world/entity/animal/Rabbit.java
 @@ -647,7 +647,7 @@ public class Rabbit extends Animal {
@@ -113,12 +113,12 @@ index 6c1e23e96352aa777c4e0c7d00f7620aa3f29a32..1c88e12d743325a429cad27928ea1ac4
          public boolean canUse() {
              if (this.nextStartTick <= 0) {
 -                if (!getServerLevel(this.rabbit).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+                if (!getServerLevel(this.rabbit).purpurConfig.rabbitBypassMobGriefing == !getServerLevel(this.rabbit).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++                if (!getServerLevel(this.rabbit).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, getServerLevel(this.rabbit).purpurConfig.rabbitMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
                      return false;
                  }
  
 diff --git a/net/minecraft/world/entity/animal/SnowGolem.java b/net/minecraft/world/entity/animal/SnowGolem.java
-index 764429b9d20ac105c9ae3b050adf5d3defbd6038..1bf6fdc0149975fefbb73563e0d4861b178459b8 100644
+index 764429b9d20ac105c9ae3b050adf5d3defbd6038..af3af77e5d6420044fa6d5aa62e64311247bc1a8 100644
 --- a/net/minecraft/world/entity/animal/SnowGolem.java
 +++ b/net/minecraft/world/entity/animal/SnowGolem.java
 @@ -135,7 +135,7 @@ public class SnowGolem extends AbstractGolem implements Shearable, RangedAttackM
@@ -126,12 +126,12 @@ index 764429b9d20ac105c9ae3b050adf5d3defbd6038..1bf6fdc0149975fefbb73563e0d4861b
              }
  
 -            if (!serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+            if (!serverLevel.purpurConfig.snowGolemBypassMobGriefing == !serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++            if (!serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.snowGolemMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
                  return;
              }
  
 diff --git a/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 793567170b33ba21016b8767598d294fca4acec4..f014b4ca2baf97edf472ce4d8af1209eaf4d53d1 100644
+index 793567170b33ba21016b8767598d294fca4acec4..967c360e11beeb0150920e80d2e2bcbbfd305ab2 100644
 --- a/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -543,7 +543,7 @@ public class EnderDragon extends Mob implements Enemy {
@@ -139,12 +139,12 @@ index 793567170b33ba21016b8767598d294fca4acec4..f014b4ca2baf97edf472ce4d8af1209e
                      BlockState blockState = level.getBlockState(blockPos);
                      if (!blockState.isAir() && !blockState.is(BlockTags.DRAGON_TRANSPARENT)) {
 -                        if (level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) && !blockState.is(BlockTags.DRAGON_IMMUNE)) {
-+                        if (level.purpurConfig.enderDragonBypassMobGriefing ^ level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) && !blockState.is(BlockTags.DRAGON_IMMUNE)) { // Purpur - Add mobGriefing bypass to everything affected
++                        if (level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, level.purpurConfig.enderDragonMobGriefingOverride) && !blockState.is(BlockTags.DRAGON_IMMUNE)) { // Purpur - Add mobGriefing override to everything affected
                              // CraftBukkit start - Add blocks to list rather than destroying them
                              //flag1 = level.removeBlock(blockPos, false) || flag1;
                              flag1 = true;
 diff --git a/net/minecraft/world/entity/boss/wither/WitherBoss.java b/net/minecraft/world/entity/boss/wither/WitherBoss.java
-index f0ec9334d9e6bf879568a085db691c46f7c652b6..951de2194f8e669e454edd8678cd254e94d18ab7 100644
+index f0ec9334d9e6bf879568a085db691c46f7c652b6..38772967805dc73ffaae19d95b4f2d203e5a2be4 100644
 --- a/net/minecraft/world/entity/boss/wither/WitherBoss.java
 +++ b/net/minecraft/world/entity/boss/wither/WitherBoss.java
 @@ -494,7 +494,7 @@ public class WitherBoss extends Monster implements RangedAttackMob {
@@ -152,12 +152,12 @@ index f0ec9334d9e6bf879568a085db691c46f7c652b6..951de2194f8e669e454edd8678cd254e
              if (this.destroyBlocksTick > 0) {
                  this.destroyBlocksTick--;
 -                if (this.destroyBlocksTick == 0 && level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+                if (this.destroyBlocksTick == 0 && level.purpurConfig.witherBypassMobGriefing ^ level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++                if (this.destroyBlocksTick == 0 && level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, level.purpurConfig.witherMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
                      boolean flag = false;
                      int alternativeTarget = Mth.floor(this.getBbWidth() / 2.0F + 1.0F);
                      int floor = Mth.floor(this.getBbHeight());
 diff --git a/net/minecraft/world/entity/monster/EnderMan.java b/net/minecraft/world/entity/monster/EnderMan.java
-index c01c91db94136700f9501624763e3bd735986a9f..0cae67d67af733b0bc6558f8cc1056b45554e3ce 100644
+index c01c91db94136700f9501624763e3bd735986a9f..9ba0ff75dcee5f331bc8e51ac1c53273c92e3e3b 100644
 --- a/net/minecraft/world/entity/monster/EnderMan.java
 +++ b/net/minecraft/world/entity/monster/EnderMan.java
 @@ -509,7 +509,7 @@ public class EnderMan extends Monster implements NeutralMob {
@@ -165,7 +165,7 @@ index c01c91db94136700f9501624763e3bd735986a9f..0cae67d67af733b0bc6558f8cc1056b4
              if (!enderman.level().purpurConfig.endermanAllowGriefing) return false; // Purpur - Add enderman and creeper griefing controls
              return this.enderman.getCarriedBlock() != null
 -                && getServerLevel(this.enderman).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)
-+                && getServerLevel(this.enderman).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) == !this.enderman.level().purpurConfig.endermanBypassMobGriefing // Purpur - Add mobGriefing bypass to everything affected
++                && getServerLevel(this.enderman).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, this.enderman.level().purpurConfig.endermanMobGriefingOverride) // Purpur - Add mobGriefing override to everything affected
                  && this.enderman.getRandom().nextInt(reducedTickDelay(2000)) == 0;
          }
  
@@ -174,12 +174,12 @@ index c01c91db94136700f9501624763e3bd735986a9f..0cae67d67af733b0bc6558f8cc1056b4
              if (!enderman.level().purpurConfig.endermanAllowGriefing) return false; // Purpur - Add enderman and creeper griefing controls
              return this.enderman.getCarriedBlock() == null
 -                && getServerLevel(this.enderman).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)
-+                && getServerLevel(this.enderman).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) == !this.enderman.level().purpurConfig.endermanBypassMobGriefing // Purpur - Add mobGriefing bypass to everything affected
++                && getServerLevel(this.enderman).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, this.enderman.level().purpurConfig.endermanMobGriefingOverride) // Purpur - Add mobGriefing override to everything affected
                  && this.enderman.getRandom().nextInt(reducedTickDelay(20)) == 0;
          }
  
 diff --git a/net/minecraft/world/entity/monster/Evoker.java b/net/minecraft/world/entity/monster/Evoker.java
-index 5773dd99ad2b014dde6666f4b32a1e6ee024a9fc..b14b72f7bbf6cb65b1515c12bae47187fe1371b5 100644
+index 5773dd99ad2b014dde6666f4b32a1e6ee024a9fc..6cba6b164749987c161790bccb5d842047fbf53c 100644
 --- a/net/minecraft/world/entity/monster/Evoker.java
 +++ b/net/minecraft/world/entity/monster/Evoker.java
 @@ -323,7 +323,7 @@ public class Evoker extends SpellcasterIllager {
@@ -187,12 +187,12 @@ index 5773dd99ad2b014dde6666f4b32a1e6ee024a9fc..b14b72f7bbf6cb65b1515c12bae47187
              } else {
                  ServerLevel serverLevel = getServerLevel(Evoker.this.level());
 -                if (!serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+                if (!serverLevel.purpurConfig.evokerBypassMobGriefing == !serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++                if (!serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.evokerMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
                      return false;
                  } else {
                      List<Sheep> nearbyEntities = serverLevel.getNearbyEntities(
 diff --git a/net/minecraft/world/entity/monster/Ravager.java b/net/minecraft/world/entity/monster/Ravager.java
-index 3adf0ec66db61b556a06ffe0fe835b57f8520948..568a0d17600a82109263de715f3d54fc24039452 100644
+index 3adf0ec66db61b556a06ffe0fe835b57f8520948..007b35d1411aeda9cce3f8be431815367fab957c 100644
 --- a/net/minecraft/world/entity/monster/Ravager.java
 +++ b/net/minecraft/world/entity/monster/Ravager.java
 @@ -178,7 +178,7 @@ public class Ravager extends Raider {
@@ -200,12 +200,12 @@ index 3adf0ec66db61b556a06ffe0fe835b57f8520948..568a0d17600a82109263de715f3d54fc
              if (this.level() instanceof ServerLevel serverLevel
                  && this.horizontalCollision
 -                && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
-+                && serverLevel.purpurConfig.ravagerBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) { // Purpur - Add mobGriefing bypass to everything affected
++                && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.ravagerMobGriefingOverride)) { // Purpur - Add mobGriefing override to everything affected
                  boolean flag = false;
                  AABB aabb = this.getBoundingBox().inflate(0.2);
  
 diff --git a/net/minecraft/world/entity/monster/Silverfish.java b/net/minecraft/world/entity/monster/Silverfish.java
-index c200d57841304ba0d7a76fdd9a440fe9f2b25136..ff3761507f2025fd1e652afee03a18de3508676a 100644
+index c200d57841304ba0d7a76fdd9a440fe9f2b25136..6f4aaeb645d9638764c3516d2f1501661ac56170 100644
 --- a/net/minecraft/world/entity/monster/Silverfish.java
 +++ b/net/minecraft/world/entity/monster/Silverfish.java
 @@ -170,7 +170,7 @@ public class Silverfish extends Monster {
@@ -213,7 +213,7 @@ index c200d57841304ba0d7a76fdd9a440fe9f2b25136..ff3761507f2025fd1e652afee03a18de
              } else {
                  RandomSource random = this.mob.getRandom();
 -                if (getServerLevel(this.mob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) && random.nextInt(reducedTickDelay(10)) == 0) {
-+                if (getServerLevel(this.mob).purpurConfig.silverfishBypassMobGriefing ^ getServerLevel(this.mob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) && random.nextInt(reducedTickDelay(10)) == 0) { // Purpur - Add mobGriefing bypass to everything affected
++                if (getServerLevel(this.mob).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, getServerLevel(this.mob).purpurConfig.silverfishMobGriefingOverride) && random.nextInt(reducedTickDelay(10)) == 0) { // Purpur - Add mobGriefing override to everything affected
                      this.selectedDirection = Direction.getRandom(random);
                      BlockPos blockPos = BlockPos.containing(this.mob.getX(), this.mob.getY() + 0.5, this.mob.getZ()).relative(this.selectedDirection);
                      BlockState blockState = this.mob.level().getBlockState(blockPos);
@@ -222,12 +222,12 @@ index c200d57841304ba0d7a76fdd9a440fe9f2b25136..ff3761507f2025fd1e652afee03a18de
                              if (block instanceof InfestedBlock) {
                                  // CraftBukkit start
 -                                BlockState afterState = getServerLevel(level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) ? blockState.getFluidState().createLegacyBlock() : ((InfestedBlock) block).hostStateByInfested(level.getBlockState(blockPos1)); // Paper - fix wrong block state
-+                                BlockState afterState = getServerLevel(level).purpurConfig.silverfishBypassMobGriefing ^ getServerLevel(level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) ? blockState.getFluidState().createLegacyBlock() : ((InfestedBlock) block).hostStateByInfested(level.getBlockState(blockPos1)); // Paper - fix wrong block state // Purpur - Add mobGriefing bypass to everything affected
++                                BlockState afterState = getServerLevel(level).getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, getServerLevel(level).purpurConfig.silverfishMobGriefingOverride) ? blockState.getFluidState().createLegacyBlock() : ((InfestedBlock) block).hostStateByInfested(level.getBlockState(blockPos1)); // Paper - fix wrong block state // Purpur - Add mobGriefing override to everything affected
                                  if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(this.silverfish, blockPos1, afterState)) { // Paper - fix wrong block state
                                      continue;
                                  }
 diff --git a/net/minecraft/world/entity/monster/piglin/Piglin.java b/net/minecraft/world/entity/monster/piglin/Piglin.java
-index b37038568b83db1602dca06aa06d72c4c4978cdd..8d37820522b12f2e513ca38c6ccdbb6ef3c2fc71 100644
+index b37038568b83db1602dca06aa06d72c4c4978cdd..6b404571f2086c280b16d253e218c750bf085c37 100644
 --- a/net/minecraft/world/entity/monster/piglin/Piglin.java
 +++ b/net/minecraft/world/entity/monster/piglin/Piglin.java
 @@ -449,7 +449,7 @@ public class Piglin extends AbstractPiglin implements CrossbowAttackMob, Invento
@@ -235,12 +235,12 @@ index b37038568b83db1602dca06aa06d72c4c4978cdd..8d37820522b12f2e513ca38c6ccdbb6e
      @Override
      public boolean wantsToPickUp(ServerLevel level, ItemStack stack) {
 -        return level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) && this.canPickUpLoot() && PiglinAi.wantsToPickup(this, stack);
-+        return level.purpurConfig.piglinBypassMobGriefing ^ level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) && this.canPickUpLoot() && PiglinAi.wantsToPickup(this, stack); // Purpur - Add mobGriefing bypass to everything affected
++        return level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, level.purpurConfig.piglinMobGriefingOverride) && this.canPickUpLoot() && PiglinAi.wantsToPickup(this, stack); // Purpur - Add mobGriefing override to everything affected
      }
  
      protected boolean canReplaceCurrentItem(ItemStack candidate) {
 diff --git a/net/minecraft/world/entity/projectile/LargeFireball.java b/net/minecraft/world/entity/projectile/LargeFireball.java
-index db1b5bce212a5147be82504469f1fa9660812ebc..b97ea6fea26182945b6360644f17d172166574d3 100644
+index db1b5bce212a5147be82504469f1fa9660812ebc..9e994953a8a8757496892441c155fba5a511c19b 100644
 --- a/net/minecraft/world/entity/projectile/LargeFireball.java
 +++ b/net/minecraft/world/entity/projectile/LargeFireball.java
 @@ -19,20 +19,20 @@ public class LargeFireball extends Fireball {
@@ -248,14 +248,14 @@ index db1b5bce212a5147be82504469f1fa9660812ebc..b97ea6fea26182945b6360644f17d172
      public LargeFireball(EntityType<? extends LargeFireball> entityType, Level level) {
          super(entityType, level);
 -        this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING); // CraftBukkit
-+        this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.purpurConfig.fireballsBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING); // CraftBukkit // Purpur - Add mobGriefing bypass to everything affected
++        this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.fireballsMobGriefingOverride); // CraftBukkit // Purpur - Add mobGriefing override to everything affected
      }
  
      public LargeFireball(Level level, LivingEntity owner, Vec3 movement, int explosionPower) {
          super(EntityType.FIREBALL, owner, movement, level);
          this.explosionPower = explosionPower;
 -        this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING); // CraftBukkit
-+        this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.purpurConfig.fireballsBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING); // CraftBukkit // Purpur - Add mobGriefing bypass to everything affected
++        this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.fireballsMobGriefingOverride); // CraftBukkit // Purpur - Add mobGriefing override to everything affected
      }
  
      @Override
@@ -263,12 +263,12 @@ index db1b5bce212a5147be82504469f1fa9660812ebc..b97ea6fea26182945b6360644f17d172
          super.onHit(result);
          if (this.level() instanceof ServerLevel serverLevel) {
 -            boolean _boolean = serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
-+            boolean _boolean = serverLevel.purpurConfig.fireballsBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING); // Purpur - Add mobGriefing bypass to everything affected
++            boolean _boolean = serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.fireballsMobGriefingOverride); // Purpur - Add mobGriefing override to everything affected
              // CraftBukkit start - fire ExplosionPrimeEvent
              org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent((org.bukkit.entity.Explosive) this.getBukkitEntity());
              if (event.callEvent()) {
 diff --git a/net/minecraft/world/entity/projectile/Projectile.java b/net/minecraft/world/entity/projectile/Projectile.java
-index 4487c03183d20a187d391dd124abb7b926508b5b..3f0fe1190f5ec11efb148d481e0ed5d97f177969 100644
+index 4487c03183d20a187d391dd124abb7b926508b5b..0a1cee73ee7d895dba55745647daa4870038515c 100644
 --- a/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/net/minecraft/world/entity/projectile/Projectile.java
 @@ -466,7 +466,7 @@ public abstract class Projectile extends Entity implements TraceableEntity {
@@ -276,12 +276,12 @@ index 4487c03183d20a187d391dd124abb7b926508b5b..3f0fe1190f5ec11efb148d481e0ed5d9
      public boolean mayInteract(ServerLevel level, BlockPos pos) {
          Entity owner = this.getOwner();
 -        return owner instanceof Player ? owner.mayInteract(level, pos) : owner == null || level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
-+        return owner instanceof Player ? owner.mayInteract(level, pos) : owner == null || level.purpurConfig.projectilesBypassMobGriefing ^ level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING); // Purpur - Add mobGriefing bypass to everything affected
++        return owner instanceof Player ? owner.mayInteract(level, pos) : owner == null || level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, level.purpurConfig.projectilesMobGriefingOverride); // Purpur - Add mobGriefing override to everything affected
      }
  
      public boolean mayBreak(ServerLevel level) {
 diff --git a/net/minecraft/world/entity/projectile/SmallFireball.java b/net/minecraft/world/entity/projectile/SmallFireball.java
-index 8c84cea43fc0e42a576004663670977eac99f1a6..808aa5dcb27c87b6ba5c1eee639486067447e370 100644
+index 8c84cea43fc0e42a576004663670977eac99f1a6..6a0ec832226894687b28f35e1a8a190ba1542201 100644
 --- a/net/minecraft/world/entity/projectile/SmallFireball.java
 +++ b/net/minecraft/world/entity/projectile/SmallFireball.java
 @@ -25,7 +25,7 @@ public class SmallFireball extends Fireball {
@@ -289,12 +289,12 @@ index 8c84cea43fc0e42a576004663670977eac99f1a6..808aa5dcb27c87b6ba5c1eee63948606
          // CraftBukkit start
          if (this.getOwner() != null && this.getOwner() instanceof Mob) {
 -            this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
-+            this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.purpurConfig.fireballsBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING); // Purpur - Add mobGriefing bypass to everything affected
++            this.isIncendiary = (level instanceof ServerLevel serverLevel) && serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.fireballsMobGriefingOverride); // Purpur - Add mobGriefing override to everything affected
          }
          // CraftBukkit end
      }
 diff --git a/net/minecraft/world/entity/raid/Raider.java b/net/minecraft/world/entity/raid/Raider.java
-index e81ae747fe95c22321fc69791a6509d601826fd6..77bb3aa7ff042aab6464aac55c846cb9082e5b97 100644
+index e81ae747fe95c22321fc69791a6509d601826fd6..76ebbab40f5bac6d5f588410d3c5e6716cbe0679 100644
 --- a/net/minecraft/world/entity/raid/Raider.java
 +++ b/net/minecraft/world/entity/raid/Raider.java
 @@ -400,7 +400,7 @@ public abstract class Raider extends PatrollingMonster {
@@ -302,12 +302,30 @@ index e81ae747fe95c22321fc69791a6509d601826fd6..77bb3aa7ff042aab6464aac55c846cb9
  
          private boolean cannotPickUpBanner() {
 -            if (!getServerLevel(this.mob).getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_MOBGRIEFING) || !this.mob.canPickUpLoot()) return false; // Paper - respect game and entity rules for picking up items
-+            if (!this.mob.level().purpurConfig.pillagerBypassMobGriefing == !getServerLevel(this.mob).getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_MOBGRIEFING) || !this.mob.canPickUpLoot()) return false; // Paper - respect game and entity rules for picking up items // Purpur - Add mobGriefing bypass to everything affected
++            if (!getServerLevel(this.mob).getGameRules().getBoolean(net.minecraft.world.level.GameRules.RULE_MOBGRIEFING, this.mob.level().purpurConfig.pillagerMobGriefingOverride) || !this.mob.canPickUpLoot()) return false; // Paper - respect game and entity rules for picking up items // Purpur - Add mobGriefing override to everything affected
              if (!this.mob.hasActiveRaid()) {
                  return true;
              } else if (this.mob.getCurrentRaid().isOver()) {
+diff --git a/net/minecraft/world/level/GameRules.java b/net/minecraft/world/level/GameRules.java
+index 02bc5d83b92a594ec519f0a02b0517fdb4b9e954..92fe6acbd530e985da23f50e615817309915122c 100644
+--- a/net/minecraft/world/level/GameRules.java
++++ b/net/minecraft/world/level/GameRules.java
+@@ -343,6 +343,13 @@ public class GameRules {
+         this.<T>getRule(key).setFrom(rule, level); // CraftBukkit - per-world
+     }
+ 
++    public boolean getBoolean(GameRules.Key<GameRules.BooleanValue> key, Boolean gameRuleOverride) {
++        if (gameRuleOverride != null) {
++            return gameRuleOverride;
++        }
++        return this.getBoolean(key);
++    }
++
+     public boolean getBoolean(GameRules.Key<GameRules.BooleanValue> key) {
+         return this.getRule(key).get();
+     }
 diff --git a/net/minecraft/world/level/block/CropBlock.java b/net/minecraft/world/level/block/CropBlock.java
-index b370b955ac8636275dfada4f38a7ca10297f7dac..275eabf64977cdf262de55124c3e5f88d8667213 100644
+index b370b955ac8636275dfada4f38a7ca10297f7dac..d345235db5a8d5f1ebbeb5bbb5e7924cb1a75518 100644
 --- a/net/minecraft/world/level/block/CropBlock.java
 +++ b/net/minecraft/world/level/block/CropBlock.java
 @@ -169,7 +169,7 @@ public class CropBlock extends VegetationBlock implements BonemealableBlock {
@@ -315,12 +333,12 @@ index b370b955ac8636275dfada4f38a7ca10297f7dac..275eabf64977cdf262de55124c3e5f88
      protected void entityInside(BlockState state, Level level, BlockPos pos, Entity entity, InsideBlockEffectApplier effectApplier) {
          if (!new io.papermc.paper.event.entity.EntityInsideBlockEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(level, pos)).callEvent()) { return; } // Paper - Add EntityInsideBlockEvent
 -        if (level instanceof ServerLevel serverLevel && entity instanceof Ravager && serverLevel.purpurConfig.ravagerGriefableBlocks.contains(serverLevel.getBlockState(pos).getBlock()) && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity, pos, Blocks.AIR.defaultBlockState(), !serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING))) { // CraftBukkit // Purpur - Configurable ravager griefable blocks list
-+        if (level instanceof ServerLevel serverLevel && entity instanceof Ravager && serverLevel.purpurConfig.ravagerGriefableBlocks.contains(serverLevel.getBlockState(pos).getBlock()) && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity, pos, Blocks.AIR.defaultBlockState(), !serverLevel.purpurConfig.ravagerBypassMobGriefing == !serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING))) { // CraftBukkit // Purpur - Configurable ravager griefable blocks list // Purpur - Add mobGriefing bypass to everything affected
++        if (level instanceof ServerLevel serverLevel && entity instanceof Ravager && serverLevel.purpurConfig.ravagerGriefableBlocks.contains(serverLevel.getBlockState(pos).getBlock()) && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity, pos, Blocks.AIR.defaultBlockState(), !serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.ravagerMobGriefingOverride))) { // CraftBukkit // Purpur - Configurable ravager griefable blocks list // Purpur - Add mobGriefing override to everything affected
              serverLevel.destroyBlock(pos, true, entity);
          }
  
 diff --git a/net/minecraft/world/level/block/FarmBlock.java b/net/minecraft/world/level/block/FarmBlock.java
-index 9883e6d1a1b76155c8ba1817fda6615b4742e18e..c816bd47577cbc898b10d0cfd9c40404429ef929 100644
+index 9883e6d1a1b76155c8ba1817fda6615b4742e18e..dc1ad33f801c308871931d271f97ff9185e9effb 100644
 --- a/net/minecraft/world/level/block/FarmBlock.java
 +++ b/net/minecraft/world/level/block/FarmBlock.java
 @@ -114,7 +114,7 @@ public class FarmBlock extends Block {
@@ -328,12 +346,12 @@ index 9883e6d1a1b76155c8ba1817fda6615b4742e18e..c816bd47577cbc898b10d0cfd9c40404
              && (serverLevel.purpurConfig.farmlandTrampleHeight >= 0D ? fallDistance >= serverLevel.purpurConfig.farmlandTrampleHeight : level.random.nextFloat() < fallDistance - 0.5) // Purpur - Configurable farmland trample height
              && entity instanceof LivingEntity
 -            && (entity instanceof Player || serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING))
-+            && (entity instanceof Player || serverLevel.purpurConfig.farmlandBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) // Purpur - Add mobGriefing bypass to everything affected
++            && (entity instanceof Player || serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.farmlandMobGriefingOverride)) // Purpur - Add mobGriefing override to everything affected
              && entity.getBbWidth() * entity.getBbWidth() * entity.getBbHeight() > 0.512F) {
                  // CraftBukkit start - Interact soil
                  org.bukkit.event.Cancellable cancellable;
 diff --git a/net/minecraft/world/level/block/PowderSnowBlock.java b/net/minecraft/world/level/block/PowderSnowBlock.java
-index 248ac9bc820a96fc7653471308b18834fc735a77..5c6ebde129289f2f7feb44dc1083aa030f55fbff 100644
+index 248ac9bc820a96fc7653471308b18834fc735a77..ef70ba88e492904c426c7d35df442fa6f8d68844 100644
 --- a/net/minecraft/world/level/block/PowderSnowBlock.java
 +++ b/net/minecraft/world/level/block/PowderSnowBlock.java
 @@ -89,7 +89,7 @@ public class PowderSnowBlock extends Block implements BucketPickup {
@@ -341,12 +359,12 @@ index 248ac9bc820a96fc7653471308b18834fc735a77..5c6ebde129289f2f7feb44dc1083aa03
                      && entity1.mayInteract(serverLevel, blockPos)) {
                      // CraftBukkit start
 -                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity1, pos, Blocks.AIR.defaultBlockState(), !(serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) || entity1 instanceof Player))) {
-+                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity1, pos, Blocks.AIR.defaultBlockState(), !(serverLevel.purpurConfig.powderSnowBypassMobGriefing ^ serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) || entity1 instanceof Player))) { // Purpur - Add mobGriefing bypass to everything affected
++                    if (!org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity1, pos, Blocks.AIR.defaultBlockState(), !(serverLevel.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, serverLevel.purpurConfig.powderSnowMobGriefingOverride) || entity1 instanceof Player))) { // Purpur - Add mobGriefing override to everything affected
                          return;
                      }
                      // CraftBukkit end
 diff --git a/net/minecraft/world/level/block/TurtleEggBlock.java b/net/minecraft/world/level/block/TurtleEggBlock.java
-index a23626dbfacf98ef1bc7918ca35406fa71307bed..bb3bba0d0bf89e82b929fe95247f50ccba964c02 100644
+index a23626dbfacf98ef1bc7918ca35406fa71307bed..41e51cb4f1a2443361b52c8523688e2c307a1d75 100644
 --- a/net/minecraft/world/level/block/TurtleEggBlock.java
 +++ b/net/minecraft/world/level/block/TurtleEggBlock.java
 @@ -214,7 +214,7 @@ public class TurtleEggBlock extends Block {
@@ -354,7 +372,7 @@ index a23626dbfacf98ef1bc7918ca35406fa71307bed..bb3bba0d0bf89e82b929fe95247f50cc
          if (entity instanceof Player) return true;
  
 -        return level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING);
-+        return level.purpurConfig.turtleEggsBypassMobGriefing ^ level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING); // Purpur - Add mobGriefing bypass to everything affected
++        return level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, level.purpurConfig.turtleEggsMobGriefingOverride); // Purpur - Add mobGriefing override to everything affected
          // Purpur end - Add turtle egg block options
      }
  }

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -74,8 +74,8 @@ public class PurpurConfig {
         commands = new HashMap<>();
         commands.put("purpur", new PurpurCommand("purpur"));
 
-        version = getInt("config-version", 42);
-        set("config-version", 42);
+        version = getInt("config-version", 43);
+        set("config-version", 43);
 
         readConfig(PurpurConfig.class, null);
 

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -84,6 +84,11 @@ public class PurpurWorldConfig {
         return predicate.test(bool);
     }
 
+    private Boolean getBooleanOrDefault(String path, Boolean def) {
+        String val = getString(path, BooleanUtils.toString(def, "true", "false", "default")).toLowerCase();
+        return BooleanUtils.toBooleanObject(val, "true", "false", "default");
+    }
+
     private double getDouble(String path, double def) {
         if (PurpurConfig.config.get("world-settings.default." + path) == null) {
             PurpurConfig.config.addDefault("world-settings.default." + path, def);
@@ -144,9 +149,9 @@ public class PurpurWorldConfig {
     public int raidCooldownSeconds = 0;
     public int animalBreedingCooldownSeconds = 0;
     public boolean persistentDroppableEntityDisplayNames = true;
-    public boolean entitiesPickUpLootBypassMobGriefing = false;
-    public boolean fireballsBypassMobGriefing = false;
-    public boolean projectilesBypassMobGriefing = false;
+    public Boolean entitiesPickUpLootMobGriefingOverride = null;
+    public Boolean fireballsMobGriefingOverride = null;
+    public Boolean projectilesMobGriefingOverride = null;
     public boolean noteBlockIgnoreAbove = false;
     public boolean imposeTeleportRestrictionsOnGateways = false;
     public boolean imposeTeleportRestrictionsOnNetherPortals = false;
@@ -173,9 +178,20 @@ public class PurpurWorldConfig {
         raidCooldownSeconds = getInt("gameplay-mechanics.raid-cooldown-seconds", raidCooldownSeconds);
         animalBreedingCooldownSeconds = getInt("gameplay-mechanics.animal-breeding-cooldown-seconds", animalBreedingCooldownSeconds);
         persistentDroppableEntityDisplayNames = getBoolean("gameplay-mechanics.persistent-droppable-entity-display-names", persistentDroppableEntityDisplayNames);
-        entitiesPickUpLootBypassMobGriefing = getBoolean("gameplay-mechanics.entities-pick-up-loot-bypass-mob-griefing", entitiesPickUpLootBypassMobGriefing);
-        fireballsBypassMobGriefing = getBoolean("gameplay-mechanics.fireballs-bypass-mob-griefing", fireballsBypassMobGriefing);
-        projectilesBypassMobGriefing = getBoolean("gameplay-mechanics.projectiles-bypass-mob-griefing", projectilesBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("gameplay-mechanics.entities-pick-up-loot-bypass-mob-griefing", false);
+            set("gameplay-mechanics.entities-pick-up-loot-bypass-mob-griefing", null);
+            set("gameplay-mechanics.entities-pick-up-loot-mob-griefing-override", oldVal ? true : "default");
+            boolean oldVal2 = getBoolean("gameplay-mechanics.fireballs-bypass-mob-griefing", false);
+            set("gameplay-mechanics.fireballs-bypass-mob-griefing", null);
+            set("gameplay-mechanics.fireballs-mob-griefing-override", oldVal2 ? true : "default");
+            boolean oldVal3 = getBoolean("gameplay-mechanics.projectiles-bypass-mob-griefing", false);
+            set("gameplay-mechanics.projectiles-bypass-mob-griefing", null);
+            set("gameplay-mechanics.projectiles-mob-griefing-override", oldVal3 ? true : "default");
+        }
+        entitiesPickUpLootMobGriefingOverride = getBooleanOrDefault("gameplay-mechanics.entities-pick-up-loot-mob-griefing-override", entitiesPickUpLootMobGriefingOverride);
+        fireballsMobGriefingOverride = getBooleanOrDefault("gameplay-mechanics.fireballs-mob-griefing-override", fireballsMobGriefingOverride);
+        projectilesMobGriefingOverride = getBooleanOrDefault("gameplay-mechanics.projectiles-mob-griefing-override", projectilesMobGriefingOverride);
         noteBlockIgnoreAbove = getBoolean("gameplay-mechanics.note-block-ignore-above", noteBlockIgnoreAbove);
         imposeTeleportRestrictionsOnGateways = getBoolean("gameplay-mechanics.impose-teleport-restrictions-on-gateways", imposeTeleportRestrictionsOnGateways);
         imposeTeleportRestrictionsOnNetherPortals = getBoolean("gameplay-mechanics.impose-teleport-restrictions-on-nether-portals", imposeTeleportRestrictionsOnNetherPortals);
@@ -992,7 +1008,7 @@ public class PurpurWorldConfig {
         endCrystalPlaceAnywhere = getBoolean("gameplay-mechanics.item.end-crystal.place-anywhere", endCrystalPlaceAnywhere);
     }
 
-    public boolean farmlandBypassMobGriefing = false;
+    public Boolean farmlandMobGriefingOverride = null;
     public boolean farmlandGetsMoistFromBelow = false;
     public boolean farmlandAlpha = false;
     public boolean farmlandTramplingDisabled = false;
@@ -1000,7 +1016,12 @@ public class PurpurWorldConfig {
     public boolean farmlandTramplingFeatherFalling = false;
     public double farmlandTrampleHeight = -1D;
     private void farmlandSettings() {
-        farmlandBypassMobGriefing = getBoolean("blocks.farmland.bypass-mob-griefing", farmlandBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("blocks.farmland.bypass-mob-griefing", false);
+            set("blocks.farmland.bypass-mob-griefing", null);
+            set("blocks.farmland.mob-griefing-override", oldVal ? true : "default");
+        }
+        farmlandMobGriefingOverride = getBooleanOrDefault("blocks.farmland.mob-griefing-override", farmlandMobGriefingOverride);
         farmlandGetsMoistFromBelow = getBoolean("blocks.farmland.gets-moist-from-below", farmlandGetsMoistFromBelow);
         farmlandAlpha = getBoolean("blocks.farmland.use-alpha-farmland", farmlandAlpha);
         farmlandTramplingDisabled = getBoolean("blocks.farmland.disable-trampling", farmlandTramplingDisabled);
@@ -1053,9 +1074,14 @@ public class PurpurWorldConfig {
         magmaBlockDamageWhenSneaking = getBoolean("blocks.magma-block.damage-when-sneaking", magmaBlockDamageWhenSneaking);
     }
 
-    public boolean powderSnowBypassMobGriefing = false;
+    public Boolean powderSnowMobGriefingOverride = null;
     private void powderSnowSettings() {
-        powderSnowBypassMobGriefing = getBoolean("blocks.powder_snow.bypass-mob-griefing", powderSnowBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("blocks.powder_snow.bypass-mob-griefing", false);
+            set("blocks.powder_snow.bypass-mob-griefing", null);
+            set("blocks.powder_snow.mob-griefing-override", oldVal ? true : "default");
+        }
+        powderSnowMobGriefingOverride = getBooleanOrDefault("blocks.powder_snow.mob-griefing-override", powderSnowMobGriefingOverride);
     }
 
     public int railActivationRange = 8;
@@ -1125,14 +1151,19 @@ public class PurpurWorldConfig {
     public boolean turtleEggsBreakFromExpOrbs = false;
     public boolean turtleEggsBreakFromItems = false;
     public boolean turtleEggsBreakFromMinecarts = false;
-    public boolean turtleEggsBypassMobGriefing = false;
+    public Boolean turtleEggsMobGriefingOverride = null;
     public int turtleEggsRandomTickCrackChance = 500;
     public boolean turtleEggsTramplingFeatherFalling = false;
     private void turtleEggSettings() {
         turtleEggsBreakFromExpOrbs = getBoolean("blocks.turtle_egg.break-from-exp-orbs", turtleEggsBreakFromExpOrbs);
         turtleEggsBreakFromItems = getBoolean("blocks.turtle_egg.break-from-items", turtleEggsBreakFromItems);
         turtleEggsBreakFromMinecarts = getBoolean("blocks.turtle_egg.break-from-minecarts", turtleEggsBreakFromMinecarts);
-        turtleEggsBypassMobGriefing = getBoolean("blocks.turtle_egg.bypass-mob-griefing", turtleEggsBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("blocks.turtle_egg.bypass-mob-griefing", false);
+            set("blocks.turtle_egg.bypass-mob-griefing", null);
+            set("blocks.turtle_egg.mob-griefing-override", oldVal ? true : "default");
+        }
+        turtleEggsMobGriefingOverride = getBooleanOrDefault("blocks.turtle_egg.mob-griefing-override", turtleEggsMobGriefingOverride);
         turtleEggsRandomTickCrackChance = getInt("blocks.turtle_egg.random-tick-crack-chance", turtleEggsRandomTickCrackChance);
         turtleEggsTramplingFeatherFalling = getBoolean("blocks.turtle_egg.feather-fall-distance-affects-trampling", turtleEggsTramplingFeatherFalling);
     }
@@ -1488,7 +1519,7 @@ public class PurpurWorldConfig {
     public double creeperScale = 1.0D;
     public double creeperChargedChance = 0.0D;
     public boolean creeperAllowGriefing = true;
-    public boolean creeperBypassMobGriefing = false;
+    public Boolean creeperMobGriefingOverride = null;
     public boolean creeperTakeDamageFromWater = false;
     public boolean creeperExplodeWhenKilled = false;
     public boolean creeperHealthRadius = false;
@@ -1508,7 +1539,12 @@ public class PurpurWorldConfig {
         creeperScale = Mth.clamp(getDouble("mobs.creeper.attributes.scale", creeperScale), 0.0625D, 16.0D);
         creeperChargedChance = getDouble("mobs.creeper.naturally-charged-chance", creeperChargedChance);
         creeperAllowGriefing = getBoolean("mobs.creeper.allow-griefing", creeperAllowGriefing);
-        creeperBypassMobGriefing = getBoolean("mobs.creeper.bypass-mob-griefing", creeperBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.creeper.bypass-mob-griefing", false);
+            set("mobs.creeper.bypass-mob-griefing", null);
+            set("mobs.creeper.mob-griefing-override", oldVal ? true : "default");
+        }
+        creeperMobGriefingOverride = getBooleanOrDefault("mobs.creeper.mob-griefing-override", creeperMobGriefingOverride);
         creeperTakeDamageFromWater = getBoolean("mobs.creeper.takes-damage-from-water", creeperTakeDamageFromWater);
         creeperExplodeWhenKilled = getBoolean("mobs.creeper.explode-when-killed", creeperExplodeWhenKilled);
         creeperHealthRadius = getBoolean("mobs.creeper.health-impacts-explosion", creeperHealthRadius);
@@ -1640,7 +1676,7 @@ public class PurpurWorldConfig {
     public double enderDragonMaxY = 320D;
     public double enderDragonMaxHealth = 200.0D;
     public boolean enderDragonAlwaysDropsFullExp = false;
-    public boolean enderDragonBypassMobGriefing = false;
+    public Boolean enderDragonMobGriefingOverride = null;
     public boolean enderDragonTakeDamageFromWater = false;
     public boolean enderDragonCanRideVehicles = false;
     private void enderDragonSettings() {
@@ -1659,7 +1695,12 @@ public class PurpurWorldConfig {
         }
         enderDragonMaxHealth = getDouble("mobs.ender_dragon.attributes.max_health", enderDragonMaxHealth);
         enderDragonAlwaysDropsFullExp = getBoolean("mobs.ender_dragon.always-drop-full-exp", enderDragonAlwaysDropsFullExp);
-        enderDragonBypassMobGriefing = getBoolean("mobs.ender_dragon.bypass-mob-griefing", enderDragonBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.ender_dragon.bypass-mob-griefing", false);
+            set("mobs.ender_dragon.bypass-mob-griefing", null);
+            set("mobs.ender_dragon.mob-griefing-override", oldVal ? true : "default");
+        }
+        enderDragonMobGriefingOverride = getBooleanOrDefault("mobs.ender_dragon.mob-griefing-override", enderDragonMobGriefingOverride);
         enderDragonTakeDamageFromWater = getBoolean("mobs.ender_dragon.takes-damage-from-water", enderDragonTakeDamageFromWater);
         enderDragonCanRideVehicles = getBoolean("mobs.ender_dragon.can-ride-vehicles", enderDragonCanRideVehicles);
     }
@@ -1671,7 +1712,7 @@ public class PurpurWorldConfig {
     public double endermanScale = 1.0D;
     public boolean endermanAllowGriefing = true;
     public boolean endermanDespawnEvenWithBlock = false;
-    public boolean endermanBypassMobGriefing = false;
+    public Boolean endermanMobGriefingOverride = null;
     public boolean endermanTakeDamageFromWater = true;
     public boolean endermanAggroEndermites = true;
     public boolean endermanAggroEndermitesOnlyIfPlayerSpawned = false;
@@ -1695,7 +1736,12 @@ public class PurpurWorldConfig {
         endermanScale = Mth.clamp(getDouble("mobs.enderman.attributes.scale", endermanScale), 0.0625D, 16.0D);
         endermanAllowGriefing = getBoolean("mobs.enderman.allow-griefing", endermanAllowGriefing);
         endermanDespawnEvenWithBlock = getBoolean("mobs.enderman.can-despawn-with-held-block", endermanDespawnEvenWithBlock);
-        endermanBypassMobGriefing = getBoolean("mobs.enderman.bypass-mob-griefing", endermanBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.enderman.bypass-mob-griefing", false);
+            set("mobs.enderman.bypass-mob-griefing", null);
+            set("mobs.enderman.mob-griefing-override", oldVal ? true : "default");
+        }
+        endermanMobGriefingOverride = getBooleanOrDefault("mobs.enderman.mob-griefing-override", endermanMobGriefingOverride);
         endermanTakeDamageFromWater = getBoolean("mobs.enderman.takes-damage-from-water", endermanTakeDamageFromWater);
         endermanAggroEndermites = getBoolean("mobs.enderman.aggressive-towards-endermites", endermanAggroEndermites);
         endermanAggroEndermitesOnlyIfPlayerSpawned = getBoolean("mobs.enderman.aggressive-towards-endermites-only-spawned-by-player-thrown-ender-pearls", endermanAggroEndermitesOnlyIfPlayerSpawned);
@@ -1731,7 +1777,7 @@ public class PurpurWorldConfig {
     public boolean evokerControllable = true;
     public double evokerMaxHealth = 24.0D;
     public double evokerScale = 1.0D;
-    public boolean evokerBypassMobGriefing = false;
+    public Boolean evokerMobGriefingOverride = null;
     public boolean evokerTakeDamageFromWater = false;
     public boolean evokerAlwaysDropExp = false;
     private void evokerSettings() {
@@ -1745,7 +1791,12 @@ public class PurpurWorldConfig {
         }
         evokerMaxHealth = getDouble("mobs.evoker.attributes.max_health", evokerMaxHealth);
         evokerScale = Mth.clamp(getDouble("mobs.evoker.attributes.scale", evokerScale), 0.0625D, 16.0D);
-        evokerBypassMobGriefing = getBoolean("mobs.evoker.bypass-mob-griefing", evokerBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.evoker.bypass-mob-griefing", false);
+            set("mobs.evoker.bypass-mob-griefing", null);
+            set("mobs.evoker.mob-griefing-override", oldVal ? true : "default");
+        }
+        evokerMobGriefingOverride = getBooleanOrDefault("mobs.evoker.mob-griefing-override", evokerMobGriefingOverride);
         evokerTakeDamageFromWater = getBoolean("mobs.evoker.takes-damage-from-water", evokerTakeDamageFromWater);
         evokerAlwaysDropExp = getBoolean("mobs.evoker.always-drop-exp", evokerAlwaysDropExp);
     }
@@ -1757,7 +1808,7 @@ public class PurpurWorldConfig {
     public double foxScale = 1.0D;
     public boolean foxTypeChangesWithTulips = false;
     public int foxBreedingTicks = 6000;
-    public boolean foxBypassMobGriefing = false;
+    public Boolean foxMobGriefingOverride = null;
     public boolean foxTakeDamageFromWater = false;
     public boolean foxAlwaysDropExp = false;
     private void foxSettings() {
@@ -1773,7 +1824,12 @@ public class PurpurWorldConfig {
         foxScale = Mth.clamp(getDouble("mobs.fox.attributes.scale", foxScale), 0.0625D, 16.0D);
         foxTypeChangesWithTulips = getBoolean("mobs.fox.tulips-change-type", foxTypeChangesWithTulips);
         foxBreedingTicks = getInt("mobs.fox.breeding-delay-ticks", foxBreedingTicks);
-        foxBypassMobGriefing = getBoolean("mobs.fox.bypass-mob-griefing", foxBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.fox.bypass-mob-griefing", false);
+            set("mobs.fox.bypass-mob-griefing", null);
+            set("mobs.fox.mob-griefing-override", oldVal ? true : "default");
+        }
+        foxMobGriefingOverride = getBooleanOrDefault("mobs.fox.mob-griefing-override", foxMobGriefingOverride);
         foxTakeDamageFromWater = getBoolean("mobs.fox.takes-damage-from-water", foxTakeDamageFromWater);
         foxAlwaysDropExp = getBoolean("mobs.fox.always-drop-exp", foxAlwaysDropExp);
     }
@@ -2354,7 +2410,7 @@ public class PurpurWorldConfig {
     public boolean piglinControllable = true;
     public double piglinMaxHealth = 16.0D;
     public double piglinScale = 1.0D;
-    public boolean piglinBypassMobGriefing = false;
+    public Boolean piglinMobGriefingOverride = null;
     public boolean piglinTakeDamageFromWater = false;
     public int piglinPortalSpawnModifier = 2000;
     public boolean piglinAlwaysDropExp = false;
@@ -2371,7 +2427,12 @@ public class PurpurWorldConfig {
         }
         piglinMaxHealth = getDouble("mobs.piglin.attributes.max_health", piglinMaxHealth);
         piglinScale = Mth.clamp(getDouble("mobs.piglin.attributes.scale", piglinScale), 0.0625D, 16.0D);
-        piglinBypassMobGriefing = getBoolean("mobs.piglin.bypass-mob-griefing", piglinBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.piglin.bypass-mob-griefing", false);
+            set("mobs.piglin.bypass-mob-griefing", null);
+            set("mobs.piglin.mob-griefing-override", oldVal ? true : "default");
+        }
+        piglinMobGriefingOverride = getBooleanOrDefault("mobs.piglin.mob-griefing-override", piglinMobGriefingOverride);
         piglinTakeDamageFromWater = getBoolean("mobs.piglin.takes-damage-from-water", piglinTakeDamageFromWater);
         piglinPortalSpawnModifier = getInt("mobs.piglin.portal-spawn-modifier", piglinPortalSpawnModifier);
         piglinAlwaysDropExp = getBoolean("mobs.piglin.always-drop-exp", piglinAlwaysDropExp);
@@ -2406,7 +2467,7 @@ public class PurpurWorldConfig {
     public boolean pillagerControllable = true;
     public double pillagerMaxHealth = 24.0D;
     public double pillagerScale = 1.0D;
-    public boolean pillagerBypassMobGriefing = false;
+    public Boolean pillagerMobGriefingOverride = null;
     public boolean pillagerTakeDamageFromWater = false;
     public boolean pillagerAlwaysDropExp = false;
     private void pillagerSettings() {
@@ -2420,7 +2481,12 @@ public class PurpurWorldConfig {
         }
         pillagerMaxHealth = getDouble("mobs.pillager.attributes.max_health", pillagerMaxHealth);
         pillagerScale = Mth.clamp(getDouble("mobs.pillager.attributes.scale", pillagerScale), 0.0625D, 16.0D);
-        pillagerBypassMobGriefing = getBoolean("mobs.pillager.bypass-mob-griefing", pillagerBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.pillager.bypass-mob-griefing", false);
+            set("mobs.pillager.bypass-mob-griefing", null);
+            set("mobs.pillager.mob-griefing-override", oldVal ? true : "default");
+        }
+        pillagerMobGriefingOverride = getBooleanOrDefault("mobs.pillager.mob-griefing-override", pillagerMobGriefingOverride);
         pillagerTakeDamageFromWater = getBoolean("mobs.pillager.takes-damage-from-water", pillagerTakeDamageFromWater);
         pillagerAlwaysDropExp = getBoolean("mobs.pillager.always-drop-exp", pillagerAlwaysDropExp);
     }
@@ -2482,7 +2548,7 @@ public class PurpurWorldConfig {
     public double rabbitNaturalToast = 0.0D;
     public double rabbitNaturalKiller = 0.0D;
     public int rabbitBreedingTicks = 6000;
-    public boolean rabbitBypassMobGriefing = false;
+    public Boolean rabbitMobGriefingOverride = null;
     public boolean rabbitTakeDamageFromWater = false;
     public boolean rabbitAlwaysDropExp = false;
     private void rabbitSettings() {
@@ -2499,7 +2565,12 @@ public class PurpurWorldConfig {
         rabbitNaturalToast = getDouble("mobs.rabbit.spawn-toast-chance", rabbitNaturalToast);
         rabbitNaturalKiller = getDouble("mobs.rabbit.spawn-killer-rabbit-chance", rabbitNaturalKiller);
         rabbitBreedingTicks = getInt("mobs.rabbit.breeding-delay-ticks", rabbitBreedingTicks);
-        rabbitBypassMobGriefing = getBoolean("mobs.rabbit.bypass-mob-griefing", rabbitBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.rabbit.bypass-mob-griefing", false);
+            set("mobs.rabbit.bypass-mob-griefing", null);
+            set("mobs.rabbit.mob-griefing-override", oldVal ? true : "default");
+        }
+        rabbitMobGriefingOverride = getBooleanOrDefault("mobs.rabbit.mob-griefing-override", rabbitMobGriefingOverride);
         rabbitTakeDamageFromWater = getBoolean("mobs.rabbit.takes-damage-from-water", rabbitTakeDamageFromWater);
         rabbitAlwaysDropExp = getBoolean("mobs.rabbit.always-drop-exp", rabbitAlwaysDropExp);
     }
@@ -2509,7 +2580,7 @@ public class PurpurWorldConfig {
     public boolean ravagerControllable = true;
     public double ravagerMaxHealth = 100.0D;
     public double ravagerScale = 1.0D;
-    public boolean ravagerBypassMobGriefing = false;
+    public Boolean ravagerMobGriefingOverride = null;
     public boolean ravagerTakeDamageFromWater = false;
     public List<Block> ravagerGriefableBlocks = new ArrayList<>();
     public boolean ravagerAlwaysDropExp = false;
@@ -2525,7 +2596,12 @@ public class PurpurWorldConfig {
         }
         ravagerMaxHealth = getDouble("mobs.ravager.attributes.max_health", ravagerMaxHealth);
         ravagerScale = Mth.clamp(getDouble("mobs.ravager.attributes.scale", ravagerScale), 0.0625D, 16.0D);
-        ravagerBypassMobGriefing = getBoolean("mobs.ravager.bypass-mob-griefing", ravagerBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.ravager.bypass-mob-griefing", false);
+            set("mobs.ravager.bypass-mob-griefing", null);
+            set("mobs.ravager.mob-griefing-override", oldVal ? true : "default");
+        }
+        ravagerMobGriefingOverride = getBooleanOrDefault("mobs.ravager.mob-griefing-override", ravagerMobGriefingOverride);
         ravagerTakeDamageFromWater = getBoolean("mobs.ravager.takes-damage-from-water", ravagerTakeDamageFromWater);
         List<String> defaultRavagerGriefableBlocks = List.of(
             "minecraft:oak_leaves",
@@ -2595,7 +2671,7 @@ public class PurpurWorldConfig {
     public double sheepMaxHealth = 8.0D;
     public double sheepScale = 1.0D;
     public int sheepBreedingTicks = 6000;
-    public boolean sheepBypassMobGriefing = false;
+    public Boolean sheepMobGriefingOverride = null;
     public boolean sheepTakeDamageFromWater = false;
     public boolean sheepAlwaysDropExp = false;
     private void sheepSettings() {
@@ -2610,7 +2686,12 @@ public class PurpurWorldConfig {
         sheepMaxHealth = getDouble("mobs.sheep.attributes.max_health", sheepMaxHealth);
         sheepScale = Mth.clamp(getDouble("mobs.sheep.attributes.scale", sheepScale), 0.0625D, 16.0D);
         sheepBreedingTicks = getInt("mobs.sheep.breeding-delay-ticks", sheepBreedingTicks);
-        sheepBypassMobGriefing = getBoolean("mobs.sheep.bypass-mob-griefing", sheepBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.sheep.bypass-mob-griefing", false);
+            set("mobs.sheep.bypass-mob-griefing", null);
+            set("mobs.sheep.mob-griefing-override", oldVal ? true : "default");
+        }
+        sheepMobGriefingOverride = getBooleanOrDefault("mobs.sheep.mob-griefing-override", sheepMobGriefingOverride);
         sheepTakeDamageFromWater = getBoolean("mobs.sheep.takes-damage-from-water", sheepTakeDamageFromWater);
         sheepAlwaysDropExp = getBoolean("mobs.sheep.always-drop-exp", sheepAlwaysDropExp);
     }
@@ -2656,7 +2737,7 @@ public class PurpurWorldConfig {
     public double silverfishScale = 1.0D;
     public double silverfishMovementSpeed = 0.25D;
     public double silverfishAttackDamage = 1.0D;
-    public boolean silverfishBypassMobGriefing = false;
+    public Boolean silverfishMobGriefingOverride = null;
     public boolean silverfishTakeDamageFromWater = false;
     public boolean silverfishAlwaysDropExp = false;
     private void silverfishSettings() {
@@ -2672,7 +2753,12 @@ public class PurpurWorldConfig {
         silverfishScale = Mth.clamp(getDouble("mobs.silverfish.attributes.scale", silverfishScale), 0.0625D, 16.0D);
         silverfishMovementSpeed = getDouble("mobs.silverfish.attributes.movement_speed", silverfishMovementSpeed);
         silverfishAttackDamage = getDouble("mobs.silverfish.attributes.attack_damage", silverfishAttackDamage);
-        silverfishBypassMobGriefing = getBoolean("mobs.silverfish.bypass-mob-griefing", silverfishBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.silverfish.bypass-mob-griefing", false);
+            set("mobs.silverfish.bypass-mob-griefing", null);
+            set("mobs.silverfish.mob-griefing-override", oldVal ? true : "default");
+        }
+        silverfishMobGriefingOverride = getBooleanOrDefault("mobs.silverfish.mob-griefing-override", silverfishMobGriefingOverride);
         silverfishTakeDamageFromWater = getBoolean("mobs.silverfish.takes-damage-from-water", silverfishTakeDamageFromWater);
         silverfishAlwaysDropExp = getBoolean("mobs.silverfish.always-drop-exp", silverfishAlwaysDropExp);
     }
@@ -2785,7 +2871,7 @@ public class PurpurWorldConfig {
     public int snowGolemSnowBallMax = 20;
     public float snowGolemSnowBallModifier = 10.0F;
     public double snowGolemAttackDistance = 1.25D;
-    public boolean snowGolemBypassMobGriefing = false;
+    public Boolean snowGolemMobGriefingOverride = null;
     public boolean snowGolemTakeDamageFromWater = true;
     public boolean snowGolemAlwaysDropExp = false;
     private void snowGolemSettings() {
@@ -2805,7 +2891,12 @@ public class PurpurWorldConfig {
         snowGolemSnowBallMax = getInt("mobs.snow_golem.max-shoot-interval-ticks", snowGolemSnowBallMax);
         snowGolemSnowBallModifier = (float) getDouble("mobs.snow_golem.snow-ball-modifier", snowGolemSnowBallModifier);
         snowGolemAttackDistance = getDouble("mobs.snow_golem.attack-distance", snowGolemAttackDistance);
-        snowGolemBypassMobGriefing = getBoolean("mobs.snow_golem.bypass-mob-griefing", snowGolemBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.snow_golem.bypass-mob-griefing", false);
+            set("mobs.snow_golem.bypass-mob-griefing", null);
+            set("mobs.snow_golem.mob-griefing-override", oldVal ? true : "default");
+        }
+        snowGolemMobGriefingOverride = getBooleanOrDefault("mobs.snow_golem.mob-griefing-override", snowGolemMobGriefingOverride);
         snowGolemTakeDamageFromWater = getBoolean("mobs.snow_golem.takes-damage-from-water", snowGolemTakeDamageFromWater);
         snowGolemAlwaysDropExp = getBoolean("mobs.snow_golem.always-drop-exp", snowGolemAlwaysDropExp);
     }
@@ -3044,7 +3135,7 @@ public class PurpurWorldConfig {
     public int villagerBreedingTicks = 6000;
     public boolean villagerClericsFarmWarts = false;
     public boolean villagerClericFarmersThrowWarts = true;
-    public boolean villagerBypassMobGriefing = false;
+    public Boolean villagerMobGriefingOverride = null;
     public boolean villagerTakeDamageFromWater = false;
     public boolean villagerAllowTrading = true;
     public boolean villagerAlwaysDropExp = false;
@@ -3075,7 +3166,12 @@ public class PurpurWorldConfig {
         villagerBreedingTicks = getInt("mobs.villager.breeding-delay-ticks", villagerBreedingTicks);
         villagerClericsFarmWarts = getBoolean("mobs.villager.clerics-farm-warts", villagerClericsFarmWarts);
         villagerClericFarmersThrowWarts = getBoolean("mobs.villager.cleric-wart-farmers-throw-warts-at-villagers", villagerClericFarmersThrowWarts);
-        villagerBypassMobGriefing = getBoolean("mobs.villager.bypass-mob-griefing", villagerBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.villager.bypass-mob-griefing", false);
+            set("mobs.villager.bypass-mob-griefing", null);
+            set("mobs.villager.mob-griefing-override", oldVal ? true : "default");
+        }
+        villagerMobGriefingOverride = getBooleanOrDefault("mobs.villager.mob-griefing-override", villagerMobGriefingOverride);
         villagerTakeDamageFromWater = getBoolean("mobs.villager.takes-damage-from-water", villagerTakeDamageFromWater);
         villagerAllowTrading = getBoolean("mobs.villager.allow-trading", villagerAllowTrading);
         villagerAlwaysDropExp = getBoolean("mobs.villager.always-drop-exp", villagerAlwaysDropExp);
@@ -3192,7 +3288,7 @@ public class PurpurWorldConfig {
     public double witherScale = 1.0D;
     public float witherHealthRegenAmount = 1.0f;
     public int witherHealthRegenDelay = 20;
-    public boolean witherBypassMobGriefing = false;
+    public Boolean witherMobGriefingOverride = null;
     public boolean witherTakeDamageFromWater = false;
     public boolean witherCanRideVehicles = false;
     public float witherExplosionRadius = 1.0F;
@@ -3216,7 +3312,12 @@ public class PurpurWorldConfig {
         witherScale = Mth.clamp(getDouble("mobs.wither.attributes.scale", witherScale), 0.0625D, 16.0D);
         witherHealthRegenAmount = (float) getDouble("mobs.wither.health-regen-amount", witherHealthRegenAmount);
         witherHealthRegenDelay = getInt("mobs.wither.health-regen-delay", witherHealthRegenDelay);
-        witherBypassMobGriefing = getBoolean("mobs.wither.bypass-mob-griefing", witherBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.wither.bypass-mob-griefing", false);
+            set("mobs.wither.bypass-mob-griefing", null);
+            set("mobs.wither.mob-griefing-override", oldVal ? true : "default");
+        }
+        witherMobGriefingOverride = getBooleanOrDefault("mobs.wither.mob-griefing-override", witherMobGriefingOverride);
         witherTakeDamageFromWater = getBoolean("mobs.wither.takes-damage-from-water", witherTakeDamageFromWater);
         witherCanRideVehicles = getBoolean("mobs.wither.can-ride-vehicles", witherCanRideVehicles);
         witherExplosionRadius = (float) getDouble("mobs.wither.explosion-radius", witherExplosionRadius);
@@ -3312,7 +3413,7 @@ public class PurpurWorldConfig {
     public double zombieJockeyChance = 0.05D;
     public boolean zombieJockeyTryExistingChickens = true;
     public boolean zombieAggressiveTowardsVillagerWhenLagging = true;
-    public boolean zombieBypassMobGriefing = false;
+    public Boolean zombieMobGriefingOverride = null;
     public boolean zombieTakeDamageFromWater = false;
     public boolean zombieAlwaysDropExp = false;
     public double zombieHeadVisibilityPercent = 0.5D;
@@ -3332,7 +3433,12 @@ public class PurpurWorldConfig {
         zombieJockeyChance = getDouble("mobs.zombie.jockey.chance", zombieJockeyChance);
         zombieJockeyTryExistingChickens = getBoolean("mobs.zombie.jockey.try-existing-chickens", zombieJockeyTryExistingChickens);
         zombieAggressiveTowardsVillagerWhenLagging = getBoolean("mobs.zombie.aggressive-towards-villager-when-lagging", zombieAggressiveTowardsVillagerWhenLagging);
-        zombieBypassMobGriefing = getBoolean("mobs.zombie.bypass-mob-griefing", zombieBypassMobGriefing);
+        if (PurpurConfig.version < 43) {
+            boolean oldVal = getBoolean("mobs.zombie.bypass-mob-griefing", false);
+            set("mobs.zombie.bypass-mob-griefing", null);
+            set("mobs.zombie.mob-griefing-override", oldVal ? true : "default");
+        }
+        zombieMobGriefingOverride = getBooleanOrDefault("mobs.zombie.mob-griefing-override", zombieMobGriefingOverride);
         zombieTakeDamageFromWater = getBoolean("mobs.zombie.takes-damage-from-water", zombieTakeDamageFromWater);
         zombieAlwaysDropExp = getBoolean("mobs.zombie.always-drop-exp", zombieAlwaysDropExp);
         zombieHeadVisibilityPercent = getDouble("mobs.zombie.head-visibility-percent", zombieHeadVisibilityPercent);


### PR DESCRIPTION
Replaces the `bypass-mob-griefing` options, closes #1647

Docs PR: PurpurMC/PurpurDocs#112