### PR TITLE
Fix phantom high speed by modifying the speed

### DIFF
--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -42,7 +42,7 @@ index 83eff33884bffddfafc85eeb4a2900104a396e2e..3c7159d0981c948e71a5612ba4083acc
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 63ef4690ff76df961fcc51dabd0f4f3d7de09fe9..7adb3d1f75896f1e31747e3356b124948a1c77c0 100644
+index f292626a6ab2ae3f71f76aebdd2b4cf576183331..cb83141c70f28569d91df6553ae368bfacb9a0e2 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -861,6 +861,15 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -3813,7 +3813,7 @@ index 889c31cc9257fbbd5df8325ccee9ce39b026ec4b..4a1299d6cee2807522de0c2d0d4745c5
  
      @Override
 diff --git a/net/minecraft/world/entity/monster/Phantom.java b/net/minecraft/world/entity/monster/Phantom.java
-index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb3714f4bf 100644
+index 2abb55d84507fd29817760cb0068dd083f7f1c37..3b343c29b86292f5965a84bd180a7866e76bcac1 100644
 --- a/net/minecraft/world/entity/monster/Phantom.java
 +++ b/net/minecraft/world/entity/monster/Phantom.java
 @@ -62,6 +62,52 @@ public class Phantom extends Mob implements Enemy {
@@ -3907,7 +3907,7 @@ index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb
 +            this.setSpeed(speed);
 +            Vec3 mot = this.getDeltaMovement();
 +            this.move(net.minecraft.world.entity.MoverType.SELF, mot.multiply(speed, speed, speed));
-+            this.setDeltaMovement(mot.scale(0.9D));
++            this.setDeltaMovement(net.minecraft.world.phys.Vec3.ZERO);
 +        }
 +        // Purpur end - Ridables
      }

--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -42,7 +42,7 @@ index 83eff33884bffddfafc85eeb4a2900104a396e2e..3c7159d0981c948e71a5612ba4083acc
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 63ef4690ff76df961fcc51dabd0f4f3d7de09fe9..7adb3d1f75896f1e31747e3356b124948a1c77c0 100644
+index f292626a6ab2ae3f71f76aebdd2b4cf576183331..cb83141c70f28569d91df6553ae368bfacb9a0e2 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -861,6 +861,15 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -3813,7 +3813,7 @@ index 889c31cc9257fbbd5df8325ccee9ce39b026ec4b..4a1299d6cee2807522de0c2d0d4745c5
  
      @Override
 diff --git a/net/minecraft/world/entity/monster/Phantom.java b/net/minecraft/world/entity/monster/Phantom.java
-index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb3714f4bf 100644
+index 2abb55d84507fd29817760cb0068dd083f7f1c37..2b9a90a0ad137119a5980bd5fbfc563234e672e7 100644
 --- a/net/minecraft/world/entity/monster/Phantom.java
 +++ b/net/minecraft/world/entity/monster/Phantom.java
 @@ -62,6 +62,52 @@ public class Phantom extends Mob implements Enemy {
@@ -3903,7 +3903,7 @@ index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb
          this.travelFlying(travelVector, 0.2F);
 +        // Purpur start - Ridables
 +        if (this.getRider() != null && this.isControllable() && !this.onGround) {
-+            float speed = (float) this.getAttributeValue(Attributes.FLYING_SPEED);
++            float speed = (float) this.getAttributeValue(Attributes.FLYING_SPEED) * 0.1F;
 +            this.setSpeed(speed);
 +            Vec3 mot = this.getDeltaMovement();
 +            this.move(net.minecraft.world.entity.MoverType.SELF, mot.multiply(speed, speed, speed));

--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -42,7 +42,7 @@ index 83eff33884bffddfafc85eeb4a2900104a396e2e..3c7159d0981c948e71a5612ba4083acc
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index f292626a6ab2ae3f71f76aebdd2b4cf576183331..cb83141c70f28569d91df6553ae368bfacb9a0e2 100644
+index 63ef4690ff76df961fcc51dabd0f4f3d7de09fe9..7adb3d1f75896f1e31747e3356b124948a1c77c0 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -861,6 +861,15 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -3813,7 +3813,7 @@ index 889c31cc9257fbbd5df8325ccee9ce39b026ec4b..4a1299d6cee2807522de0c2d0d4745c5
  
      @Override
 diff --git a/net/minecraft/world/entity/monster/Phantom.java b/net/minecraft/world/entity/monster/Phantom.java
-index 2abb55d84507fd29817760cb0068dd083f7f1c37..3b343c29b86292f5965a84bd180a7866e76bcac1 100644
+index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb3714f4bf 100644
 --- a/net/minecraft/world/entity/monster/Phantom.java
 +++ b/net/minecraft/world/entity/monster/Phantom.java
 @@ -62,6 +62,52 @@ public class Phantom extends Mob implements Enemy {
@@ -3907,7 +3907,7 @@ index 2abb55d84507fd29817760cb0068dd083f7f1c37..3b343c29b86292f5965a84bd180a7866
 +            this.setSpeed(speed);
 +            Vec3 mot = this.getDeltaMovement();
 +            this.move(net.minecraft.world.entity.MoverType.SELF, mot.multiply(speed, speed, speed));
-+            this.setDeltaMovement(net.minecraft.world.phys.Vec3.ZERO);
++            this.setDeltaMovement(mot.scale(0.9D));
 +        }
 +        // Purpur end - Ridables
      }


### PR DESCRIPTION
As noticed, thanks to Billy !

In older versions, <1.21.6, Minecraft multiplies the vector by 0.02 and now in 1.21.6 they multiply it by 0.2

This might be a Minecraft bug, but the simplest fix (Thank to Billy again) would to multiply the speed by 0.1 to match the older versions.

This pr is working as intended (tested)