### PR TITLE
Fix phantom high speed by modifying the speed

### DIFF
--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -177,7 +177,7 @@ index f0c452ddc4b299a930de261722cc41a89aa78eeb..8e8ddab59de508c84c4182e105a11554
      protected ParticleOptions getInkParticle() {
          return ParticleTypes.GLOW_SQUID_INK;
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 96e47e6145a4cce8c154a05f9b155c1ba74bfa6a..d272f5e789cb6c03ede0bece14fc3fe976a02ff3 100644
+index 96e47e6145a4cce8c154a05f9b155c1ba74bfa6a..388d2e87696d9d3ec265355ec3602a03aa3151bb 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -238,9 +238,9 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -210,7 +210,34 @@ index 96e47e6145a4cce8c154a05f9b155c1ba74bfa6a..d272f5e789cb6c03ede0bece14fc3fe9
  
      @Override
      protected void checkFallDamage(double y, boolean onGround, BlockState state, BlockPos pos) {
-@@ -3629,8 +3630,10 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3026,6 +3027,26 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+             this.move(MoverType.SELF, this.getDeltaMovement());
+             this.setDeltaMovement(this.getDeltaMovement().scale(0.5));
+         } else {
++            // Purpur start - Ridables
++            if (this.getRider() != null && this.isControllable()) {
++                float f = 0.91F;
++                if (this.onGround()) {
++                    f = this.level().getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getBlock().getFriction() * 0.91F;
++                }
++
++                float f1 = 0.16277137F / (f * f * f);
++                f = 0.91F;
++                if (this.onGround()) {
++                    f = this.level().getBlockState(this.getBlockPosBelowThatAffectsMyMovement()).getBlock().getFriction() * 0.91F;
++                }
++
++                this.moveRelative(this.onGround() ? 0.1F * f1 : 0.02F, relative);
++                this.move(MoverType.SELF, this.getDeltaMovement());
++                this.setDeltaMovement(this.getDeltaMovement().scale(f));
++                return;
++            }
++            // Purpur end - Ridables
++
+             this.moveRelative(amount, relative);
+             this.move(MoverType.SELF, this.getDeltaMovement());
+             this.setDeltaMovement(this.getDeltaMovement().scale(0.91F));
+@@ -3629,8 +3650,10 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
          this.pushEntities();
          profilerFiller.pop();
          // Paper start - Add EntityMoveEvent
@@ -223,7 +250,7 @@ index 96e47e6145a4cce8c154a05f9b155c1ba74bfa6a..d272f5e789cb6c03ede0bece14fc3fe9
                  Location from = new Location(this.level().getWorld(), this.xo, this.yo, this.zo, this.yRotO, this.xRotO);
                  Location to = new Location(this.level().getWorld(), this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
                  io.papermc.paper.event.entity.EntityMoveEvent event = new io.papermc.paper.event.entity.EntityMoveEvent(this.getBukkitLivingEntity(), from, to.clone());
-@@ -3640,6 +3643,21 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3640,6 +3663,21 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
                      this.absSnapTo(event.getTo().getX(), event.getTo().getY(), event.getTo().getZ(), event.getTo().getYaw(), event.getTo().getPitch());
                  }
              }
@@ -3813,7 +3840,7 @@ index 889c31cc9257fbbd5df8325ccee9ce39b026ec4b..4a1299d6cee2807522de0c2d0d4745c5
  
      @Override
 diff --git a/net/minecraft/world/entity/monster/Phantom.java b/net/minecraft/world/entity/monster/Phantom.java
-index 2abb55d84507fd29817760cb0068dd083f7f1c37..2b9a90a0ad137119a5980bd5fbfc563234e672e7 100644
+index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb3714f4bf 100644
 --- a/net/minecraft/world/entity/monster/Phantom.java
 +++ b/net/minecraft/world/entity/monster/Phantom.java
 @@ -62,6 +62,52 @@ public class Phantom extends Mob implements Enemy {
@@ -3903,7 +3930,7 @@ index 2abb55d84507fd29817760cb0068dd083f7f1c37..2b9a90a0ad137119a5980bd5fbfc5632
          this.travelFlying(travelVector, 0.2F);
 +        // Purpur start - Ridables
 +        if (this.getRider() != null && this.isControllable() && !this.onGround) {
-+            float speed = (float) this.getAttributeValue(Attributes.FLYING_SPEED) * 0.1F;
++            float speed = (float) this.getAttributeValue(Attributes.FLYING_SPEED);
 +            this.setSpeed(speed);
 +            Vec3 mot = this.getDeltaMovement();
 +            this.move(net.minecraft.world.entity.MoverType.SELF, mot.multiply(speed, speed, speed));

--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -42,7 +42,7 @@ index 83eff33884bffddfafc85eeb4a2900104a396e2e..3c7159d0981c948e71a5612ba4083acc
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 63ef4690ff76df961fcc51dabd0f4f3d7de09fe9..7adb3d1f75896f1e31747e3356b124948a1c77c0 100644
+index f292626a6ab2ae3f71f76aebdd2b4cf576183331..cb83141c70f28569d91df6553ae368bfacb9a0e2 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -861,6 +861,15 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -3813,7 +3813,7 @@ index 889c31cc9257fbbd5df8325ccee9ce39b026ec4b..4a1299d6cee2807522de0c2d0d4745c5
  
      @Override
 diff --git a/net/minecraft/world/entity/monster/Phantom.java b/net/minecraft/world/entity/monster/Phantom.java
-index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb3714f4bf 100644
+index 2abb55d84507fd29817760cb0068dd083f7f1c37..2b9a90a0ad137119a5980bd5fbfc563234e672e7 100644
 --- a/net/minecraft/world/entity/monster/Phantom.java
 +++ b/net/minecraft/world/entity/monster/Phantom.java
 @@ -62,6 +62,52 @@ public class Phantom extends Mob implements Enemy {
@@ -3903,7 +3903,7 @@ index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb
          this.travelFlying(travelVector, 0.2F);
 +        // Purpur start - Ridables
 +        if (this.getRider() != null && this.isControllable() && !this.onGround) {
-+            float speed = (float) this.getAttributeValue(Attributes.FLYING_SPEED);
++            float speed = (float) this.getAttributeValue(Attributes.FLYING_SPEED) * 0.1F;
 +            this.setSpeed(speed);
 +            Vec3 mot = this.getDeltaMovement();
 +            this.move(net.minecraft.world.entity.MoverType.SELF, mot.multiply(speed, speed, speed));

--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -42,7 +42,7 @@ index 83eff33884bffddfafc85eeb4a2900104a396e2e..3c7159d0981c948e71a5612ba4083acc
      @Override
      public @Nullable LevelChunk getChunkIfLoaded(int x, int z) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index f292626a6ab2ae3f71f76aebdd2b4cf576183331..cb83141c70f28569d91df6553ae368bfacb9a0e2 100644
+index 63ef4690ff76df961fcc51dabd0f4f3d7de09fe9..7adb3d1f75896f1e31747e3356b124948a1c77c0 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -861,6 +861,15 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -3813,7 +3813,7 @@ index 889c31cc9257fbbd5df8325ccee9ce39b026ec4b..4a1299d6cee2807522de0c2d0d4745c5
  
      @Override
 diff --git a/net/minecraft/world/entity/monster/Phantom.java b/net/minecraft/world/entity/monster/Phantom.java
-index 2abb55d84507fd29817760cb0068dd083f7f1c37..3b343c29b86292f5965a84bd180a7866e76bcac1 100644
+index 2abb55d84507fd29817760cb0068dd083f7f1c37..855ec37a7e4110e37823ecf62f67f5cb3714f4bf 100644
 --- a/net/minecraft/world/entity/monster/Phantom.java
 +++ b/net/minecraft/world/entity/monster/Phantom.java
 @@ -62,6 +62,52 @@ public class Phantom extends Mob implements Enemy {
@@ -3907,7 +3907,7 @@ index 2abb55d84507fd29817760cb0068dd083f7f1c37..3b343c29b86292f5965a84bd180a7866
 +            this.setSpeed(speed);
 +            Vec3 mot = this.getDeltaMovement();
 +            this.move(net.minecraft.world.entity.MoverType.SELF, mot.multiply(speed, speed, speed));
-+            this.setDeltaMovement(net.minecraft.world.phys.Vec3.ZERO);
++            this.setDeltaMovement(mot.scale(0.9D));
 +        }
 +        // Purpur end - Ridables
      }

--- a/purpur-server/minecraft-patches/features/0008-Implement-elytra-settings.patch
+++ b/purpur-server/minecraft-patches/features/0008-Implement-elytra-settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement elytra settings
 
 
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index ae0c2f41c522656bde37d4f31699ee6172b5a79d..4f149e5e17d2d2f2964e2f6626e20f52121e72d9 100644
+index bc26752293f8edd7d40bfc161b235c2a6eaf2c29..de3bb90db932cc452a81b0a2b267f00a51f0e47b 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
-@@ -3699,7 +3699,18 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3719,7 +3719,18 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
                          .filter(equipmentSlot1 -> canGlideUsing(this.getItemBySlot(equipmentSlot1), equipmentSlot1))
                          .toList();
                      EquipmentSlot equipmentSlot = Util.getRandom(list, this.random);
@@ -51,7 +51,7 @@ index 83cfe63b0245f79d0873477ab3aae75f690ecb68..f32370217735b5e9556a0df7652682d8
                          itemInHand.shrink(1); // Moved up from below
                      } else {
 diff --git a/net/minecraft/world/item/ItemStack.java b/net/minecraft/world/item/ItemStack.java
-index 52aaa325476af53eca97fc14ad5f82fbb9193c80..d512ee6b1039b80b908816b625ef1aa9cd50461c 100644
+index 7041e93158ffab707f14ff6e48c3977bebf275a9..b95acf4c688a9113a34e9be2639536245c66c83e 100644
 --- a/net/minecraft/world/item/ItemStack.java
 +++ b/net/minecraft/world/item/ItemStack.java
 @@ -700,6 +700,14 @@ public final class ItemStack implements DataComponentHolder {

--- a/purpur-server/minecraft-patches/features/0018-API-for-any-mob-to-burn-daylight.patch
+++ b/purpur-server/minecraft-patches/features/0018-API-for-any-mob-to-burn-daylight.patch
@@ -35,7 +35,7 @@ index 34e0fbef06b0c7aededf27fe9dc64f3f6f33e3ae..ce3e5ec505ac37c820436bcf7c7d6452
          this.type = entityType;
          this.level = level;
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 70808e9f092953a3edf7001b318c91228844f73c..98096df5f83196a6fee8d26637a1816807952f3f 100644
+index 78875973599112f8b5602bec78ce075aac0df94c..c935fe512480fe927d72570674579a5685bde366 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -286,6 +286,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -62,7 +62,7 @@ index 70808e9f092953a3edf7001b318c91228844f73c..98096df5f83196a6fee8d26637a18168
          this.lastHurtByPlayer = EntityReference.read(input, "last_hurt_by_player");
          this.lastHurtByPlayerMemoryTime = input.getIntOr("last_hurt_by_player_memory_time", 0);
          this.lastHurtByMob = EntityReference.read(input, "last_hurt_by_mob");
-@@ -3666,6 +3669,32 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+@@ -3686,6 +3689,32 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
          if (this.level() instanceof ServerLevel serverLevel && this.isSensitiveToWater() && this.isInWaterOrRain()) {
              this.hurtServer(serverLevel, this.damageSources().drown(), 1.0F);
          }


### PR DESCRIPTION
As noticed, thanks to Billy !

In older versions, <1.21.6, Minecraft multiplies the vector by 0.02 and now in 1.21.6 they multiply it by 0.2

This might be a Minecraft bug, but the simplest fix (Thank to Billy again) would to multiply the speed by 0.1 to match the older versions.

This pr is working as intended (tested)