### PR TITLE
Fix llama not moving when ridden, Fixes #1507

### DIFF
--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -2384,10 +2384,10 @@ index 2a1d720557c0bd4895a32723e34512c0a557e4f2..f1cb2e315e1d86f9fcd87db11d3ee7a8
      protected void randomizeAttributes(RandomSource random) {
          this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(generateMaxHealth(random::nextInt));
 diff --git a/net/minecraft/world/entity/animal/horse/Llama.java b/net/minecraft/world/entity/animal/horse/Llama.java
-index 5e3382351b1b5728750534f64babc85c4da3ac54..cb7af093a452b6febf6727e934e1492b67fbc18b 100644
+index 5e3382351b1b5728750534f64babc85c4da3ac54..f7c6b2188ed3801417c7497dbc36749def3e5057 100644
 --- a/net/minecraft/world/entity/animal/horse/Llama.java
 +++ b/net/minecraft/world/entity/animal/horse/Llama.java
-@@ -84,7 +84,51 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
+@@ -84,7 +84,58 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
          super(entityType, level);
          this.getNavigation().setRequiredPathLength(40.0F);
          this.maxDomestication = 30; // Paper - Missing entity API; configure max temper instead of a hardcoded value
@@ -2433,13 +2433,20 @@ index 5e3382351b1b5728750534f64babc85c4da3ac54..cb7af093a452b6febf6727e934e1492b
 +
 +    @Override
 +    public boolean isSaddled() {
-+        return super.isSaddled() || (isTamed());
++        return super.isWearingBodyArmor() || this.isTamed();
++    }
++
++    @Nullable
++    @Override
++    public LivingEntity getControllingPassenger() {
++        Entity firstPassenger = this.getFirstPassenger();
++        return !this.isNoAi() && firstPassenger instanceof net.minecraft.world.entity.Mob mob && firstPassenger.canControlVehicle() ? mob : null;
      }
 +    // Purpur end - Ridables
  
      public boolean isTraderLlama() {
          return false;
-@@ -127,6 +171,7 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
+@@ -127,6 +178,7 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
      @Override
      protected void registerGoals() {
          this.goalSelector.addGoal(0, new FloatGoal(this));
@@ -2447,7 +2454,7 @@ index 5e3382351b1b5728750534f64babc85c4da3ac54..cb7af093a452b6febf6727e934e1492b
          this.goalSelector.addGoal(1, new RunAroundLikeCrazyGoal(this, 1.2));
          this.goalSelector.addGoal(2, new LlamaFollowCaravanGoal(this, 2.1F));
          this.goalSelector.addGoal(3, new RangedAttackGoal(this, 1.25, 40, 20.0F));
-@@ -137,6 +182,7 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
+@@ -137,6 +189,7 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
          this.goalSelector.addGoal(7, new WaterAvoidingRandomStrollGoal(this, 0.7));
          this.goalSelector.addGoal(8, new LookAtPlayerGoal(this, Player.class, 6.0F));
          this.goalSelector.addGoal(9, new RandomLookAroundGoal(this));
@@ -2455,18 +2462,6 @@ index 5e3382351b1b5728750534f64babc85c4da3ac54..cb7af093a452b6febf6727e934e1492b
          this.targetSelector.addGoal(1, new Llama.LlamaHurtByTargetGoal(this));
          this.targetSelector.addGoal(2, new Llama.LlamaAttackWolfGoal(this));
      }
-@@ -540,4 +586,11 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
-             return this.name;
-         }
-     }
-+
-+    @Nullable
-+    @Override
-+    public LivingEntity getControllingPassenger() {
-+        Entity firstPassenger = this.getFirstPassenger();
-+        return !this.isNoAi() && firstPassenger instanceof net.minecraft.world.entity.Mob mob && firstPassenger.canControlVehicle() ? mob : null;
-+    }
- }
 diff --git a/net/minecraft/world/entity/animal/horse/Mule.java b/net/minecraft/world/entity/animal/horse/Mule.java
 index 39725b7a6bac9390406733cd51d7341d0cb363d1..b1c96936ba8dcba4435a649dd7e6ec3c921c3702 100644
 --- a/net/minecraft/world/entity/animal/horse/Mule.java

--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -2384,7 +2384,7 @@ index 2a1d720557c0bd4895a32723e34512c0a557e4f2..f1cb2e315e1d86f9fcd87db11d3ee7a8
      protected void randomizeAttributes(RandomSource random) {
          this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(generateMaxHealth(random::nextInt));
 diff --git a/net/minecraft/world/entity/animal/horse/Llama.java b/net/minecraft/world/entity/animal/horse/Llama.java
-index 5e3382351b1b5728750534f64babc85c4da3ac54..da6450f7573ca9797577d5afae2bb1365d112177 100644
+index 5e3382351b1b5728750534f64babc85c4da3ac54..cb7af093a452b6febf6727e934e1492b67fbc18b 100644
 --- a/net/minecraft/world/entity/animal/horse/Llama.java
 +++ b/net/minecraft/world/entity/animal/horse/Llama.java
 @@ -84,7 +84,51 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
@@ -2455,6 +2455,18 @@ index 5e3382351b1b5728750534f64babc85c4da3ac54..da6450f7573ca9797577d5afae2bb136
          this.targetSelector.addGoal(1, new Llama.LlamaHurtByTargetGoal(this));
          this.targetSelector.addGoal(2, new Llama.LlamaAttackWolfGoal(this));
      }
+@@ -540,4 +586,11 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
+             return this.name;
+         }
+     }
++
++    @Nullable
++    @Override
++    public LivingEntity getControllingPassenger() {
++        Entity firstPassenger = this.getFirstPassenger();
++        return !this.isNoAi() && firstPassenger instanceof net.minecraft.world.entity.Mob mob && firstPassenger.canControlVehicle() ? mob : null;
++    }
+ }
 diff --git a/net/minecraft/world/entity/animal/horse/Mule.java b/net/minecraft/world/entity/animal/horse/Mule.java
 index 39725b7a6bac9390406733cd51d7341d0cb363d1..b1c96936ba8dcba4435a649dd7e6ec3c921c3702 100644
 --- a/net/minecraft/world/entity/animal/horse/Mule.java

--- a/purpur-server/minecraft-patches/features/0002-Configurable-entity-base-attributes.patch
+++ b/purpur-server/minecraft-patches/features/0002-Configurable-entity-base-attributes.patch
@@ -23,7 +23,7 @@ index 8e8ddab59de508c84c4182e105a11554387dcce0..1896f91e10a5e17332836d5354813a18
      protected ParticleOptions getInkParticle() {
          return ParticleTypes.GLOW_SQUID_INK;
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index d272f5e789cb6c03ede0bece14fc3fe976a02ff3..41b6b18130d89b3c3c31bbb2d184fa735a8cd99c 100644
+index 4f67ae2491d053d3d7261440c029da512dc1002b..7d0a8048cea101be9747a2b89713288f53ce6637 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -291,6 +291,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -712,10 +712,10 @@ index f1cb2e315e1d86f9fcd87db11d3ee7a81cfe12f6..53c0eac62018a0d88e30b8c13de94216
      protected void randomizeAttributes(RandomSource random) {
          this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(generateMaxHealth(random::nextInt));
 diff --git a/net/minecraft/world/entity/animal/horse/Llama.java b/net/minecraft/world/entity/animal/horse/Llama.java
-index da6450f7573ca9797577d5afae2bb1365d112177..6fe6507edbf4c3c2795b8fe000d230d5fe6a2486 100644
+index f7c6b2188ed3801417c7497dbc36749def3e5057..3bc0f670a84216e5a62d1e3a9fb26bd85a0cd79a 100644
 --- a/net/minecraft/world/entity/animal/horse/Llama.java
 +++ b/net/minecraft/world/entity/animal/horse/Llama.java
-@@ -130,6 +130,23 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
+@@ -137,6 +137,23 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
      }
      // Purpur end - Ridables
  
@@ -1222,7 +1222,7 @@ index 0335e85f196363c06597812149e9a93cba57fa9e..5b0794bd87423715cada1f860b4141fd
          EntityType<Husk> entityType, ServerLevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 diff --git a/net/minecraft/world/entity/monster/Illusioner.java b/net/minecraft/world/entity/monster/Illusioner.java
-index 304a1ce41071e5597859b1235fa014f966ff5cfb..c45786fa6b9c7834b73fa0266ad4f37dfdfb8937 100644
+index bb2649001f0b31676a51378745818d5c5b15c443..6311261d71aa062ba497a73cd22cb5dbdf2a4cdb 100644
 --- a/net/minecraft/world/entity/monster/Illusioner.java
 +++ b/net/minecraft/world/entity/monster/Illusioner.java
 @@ -74,6 +74,16 @@ public class Illusioner extends SpellcasterIllager implements RangedAttackMob {

--- a/purpur-server/minecraft-patches/features/0012-Make-entity-breeding-times-configurable.patch
+++ b/purpur-server/minecraft-patches/features/0012-Make-entity-breeding-times-configurable.patch
@@ -150,7 +150,7 @@ index 869a0154c81593db8933f9daa6a7d3a9d02facc5..37b6bfa8dc1fd4ed0006f6531d2056bc
                  this.partner.resetLove();
                  serverLevel.addFreshEntityWithPassengers(fox, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.BREEDING); // CraftBukkit - added SpawnReason
 diff --git a/net/minecraft/world/entity/animal/HappyGhast.java b/net/minecraft/world/entity/animal/HappyGhast.java
-index 801fc7e1a6ec56a6cde5b787daebe3c8c008cc93..50a64a312cb6af0f39117993553b66de1f095150 100644
+index 6c80c12313147fb022d1bb0c8694fcf85174ae7c..136b918f053cacbc4fa60b0ed434619c5e07adf5 100644
 --- a/net/minecraft/world/entity/animal/HappyGhast.java
 +++ b/net/minecraft/world/entity/animal/HappyGhast.java
 @@ -140,6 +140,13 @@ public class HappyGhast extends Animal {
@@ -451,10 +451,10 @@ index 53c0eac62018a0d88e30b8c13de94216ff829cd8..3678c767818abb9e4180c2ade378ca09
      protected void randomizeAttributes(RandomSource random) {
          this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(generateMaxHealth(random::nextInt));
 diff --git a/net/minecraft/world/entity/animal/horse/Llama.java b/net/minecraft/world/entity/animal/horse/Llama.java
-index 6fe6507edbf4c3c2795b8fe000d230d5fe6a2486..9cfc31b9acca44c56b78ba6d935bcb6c1d6c5697 100644
+index 3bc0f670a84216e5a62d1e3a9fb26bd85a0cd79a..45d0977b5016a8728b11ec13c528b160598c80e2 100644
 --- a/net/minecraft/world/entity/animal/horse/Llama.java
 +++ b/net/minecraft/world/entity/animal/horse/Llama.java
-@@ -147,6 +147,13 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
+@@ -154,6 +154,13 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
      }
      // Purpur end - Configurable entity base attributes
  

--- a/purpur-server/minecraft-patches/features/0017-Toggle-for-water-sensitive-mob-damage.patch
+++ b/purpur-server/minecraft-patches/features/0017-Toggle-for-water-sensitive-mob-damage.patch
@@ -513,10 +513,10 @@ index 3678c767818abb9e4180c2ade378ca09761ad784..2928159447a87ea8cc945e73e2e81ad1
      protected void randomizeAttributes(RandomSource random) {
          this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(generateMaxHealth(random::nextInt));
 diff --git a/net/minecraft/world/entity/animal/horse/Llama.java b/net/minecraft/world/entity/animal/horse/Llama.java
-index 9cfc31b9acca44c56b78ba6d935bcb6c1d6c5697..017482c8818a854b23237e27e3304498d800569d 100644
+index 45d0977b5016a8728b11ec13c528b160598c80e2..ea25c48cb60aff6fbc82a364789beff92b054a88 100644
 --- a/net/minecraft/world/entity/animal/horse/Llama.java
 +++ b/net/minecraft/world/entity/animal/horse/Llama.java
-@@ -154,6 +154,13 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
+@@ -161,6 +161,13 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
      }
      // Purpur end - Make entity breeding times configurable
  
@@ -899,7 +899,7 @@ index 75cb1db5584c04e442583ab2f50a26132ed48bfb..9baec22561093d64157d93449e84c23b
          EntityType<Husk> entityType, ServerLevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 diff --git a/net/minecraft/world/entity/monster/Illusioner.java b/net/minecraft/world/entity/monster/Illusioner.java
-index c45786fa6b9c7834b73fa0266ad4f37dfdfb8937..b2e59058c71eb0b05670be8dcddfff073ae2d0db 100644
+index 6311261d71aa062ba497a73cd22cb5dbdf2a4cdb..4b68c0e999c37b3a3b62b522e2fcc805d2483943 100644
 --- a/net/minecraft/world/entity/monster/Illusioner.java
 +++ b/net/minecraft/world/entity/monster/Illusioner.java
 @@ -84,6 +84,13 @@ public class Illusioner extends SpellcasterIllager implements RangedAttackMob {

--- a/purpur-server/minecraft-patches/features/0020-Mobs-always-drop-experience.patch
+++ b/purpur-server/minecraft-patches/features/0020-Mobs-always-drop-experience.patch
@@ -509,10 +509,10 @@ index 2928159447a87ea8cc945e73e2e81ad1dbe13680..f1080a40f759b30b921b88b4f6edd35f
      protected void randomizeAttributes(RandomSource random) {
          this.getAttribute(Attributes.MAX_HEALTH).setBaseValue(generateMaxHealth(random::nextInt));
 diff --git a/net/minecraft/world/entity/animal/horse/Llama.java b/net/minecraft/world/entity/animal/horse/Llama.java
-index 017482c8818a854b23237e27e3304498d800569d..1bef43f42aee02a0a00556318607072ce9814860 100644
+index ea25c48cb60aff6fbc82a364789beff92b054a88..455a84ffa16152137409777e1fddbab5a21bd57d 100644
 --- a/net/minecraft/world/entity/animal/horse/Llama.java
 +++ b/net/minecraft/world/entity/animal/horse/Llama.java
-@@ -161,6 +161,13 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
+@@ -168,6 +168,13 @@ public class Llama extends AbstractChestedHorse implements RangedAttackMob {
      }
      // Purpur end - Toggle for water sensitive mob damage
  
@@ -869,7 +869,7 @@ index 3f331215ef49c52fa3a53bcf744159d2221111f5..a4ce65911a5d778f60bcedb3acd9fe59
          EntityType<Husk> entityType, ServerLevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 diff --git a/net/minecraft/world/entity/monster/Illusioner.java b/net/minecraft/world/entity/monster/Illusioner.java
-index b2e59058c71eb0b05670be8dcddfff073ae2d0db..93eaafe260312f26840a2afee8375b8a95d97ba2 100644
+index 4b68c0e999c37b3a3b62b522e2fcc805d2483943..2ea8c8480dcc15eb5b4bc9686554ec912ef1f3f4 100644
 --- a/net/minecraft/world/entity/monster/Illusioner.java
 +++ b/net/minecraft/world/entity/monster/Illusioner.java
 @@ -91,6 +91,13 @@ public class Illusioner extends SpellcasterIllager implements RangedAttackMob {


### PR DESCRIPTION
The issue was ```AbstractHorse``` overrides ```getControllingPassenger()``` which for the llama will always return false.

The fix was to override that method in the ```Llama``` to match the other mobs, which now makes the llama ridable and moving.