### PR TITLE
Add an option to make mobs not burn in daylight

### DIFF
--- a/purpur-server/minecraft-patches/features/0018-API-for-any-mob-to-burn-daylight.patch
+++ b/purpur-server/minecraft-patches/features/0018-API-for-any-mob-to-burn-daylight.patch
@@ -35,7 +35,7 @@ index 34e0fbef06b0c7aededf27fe9dc64f3f6f33e3ae..ce3e5ec505ac37c820436bcf7c7d6452
          this.type = entityType;
          this.level = level;
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 385f7664d51056efd47f685514a98b71784e8ba3..4bd5e7cbaab0998e782bc67d3ba079a80ac40789 100644
+index f22862464068180a4276175bf79c40394523703f..8a7c533e3504e5a19cf374dcb12fe0e69931a002 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -286,6 +286,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -185,6 +185,38 @@ index 352d0655374e05da787225c3fce8803fa547c99d..53ab51ffa5dd7d30a25f17dea0d9106b
      }
      // Paper end - shouldBurnInDay API
  
+diff --git a/net/minecraft/world/entity/monster/Bogged.java b/net/minecraft/world/entity/monster/Bogged.java
+index cace310ad4ad320a8a5745c6af3ec4b57e75b6a5..fb9a39c353fd5e9d3996f8a6e7f4606ce4908383 100644
+--- a/net/minecraft/world/entity/monster/Bogged.java
++++ b/net/minecraft/world/entity/monster/Bogged.java
+@@ -197,4 +197,11 @@ public class Bogged extends AbstractSkeleton implements Shearable {
+     public boolean readyForShearing() {
+         return !this.isSheared() && this.isAlive();
+     }
++
++    // Purpur start - API for any mob to burn daylight
++    @Override
++    public boolean shouldBurnInDay() {
++        return this.shouldBurnInDay && this.level().purpurConfig.boggedBurnInDaylight;
++    }
++    // Purpur end - API for any mob to burn daylight
+ }
+diff --git a/net/minecraft/world/entity/monster/Drowned.java b/net/minecraft/world/entity/monster/Drowned.java
+index 6e8ae9aa0b5051b7fb303476e52ba2cc76c29c84..9de3e78622d8224982d5e37ef9057cfb143aa41c 100644
+--- a/net/minecraft/world/entity/monster/Drowned.java
++++ b/net/minecraft/world/entity/monster/Drowned.java
+@@ -577,5 +577,11 @@ public class Drowned extends Zombie implements RangedAttackMob {
+             this.drowned.stopUsingItem();
+             this.drowned.setAggressive(false);
+         }
++
++        // Purpur start - API for any mob to burn daylight
++        public boolean shouldBurnInDay() {
++            return this.drowned.shouldBurnInDay && this.drowned.level().purpurConfig.drownedBurnInDaylight;
++        }
++        // Purpur end - API for any mob to burn daylight
+     }
+ }
 diff --git a/net/minecraft/world/entity/monster/Husk.java b/net/minecraft/world/entity/monster/Husk.java
 index 9baec22561093d64157d93449e84c23b3f238b39..3f331215ef49c52fa3a53bcf744159d2221111f5 100644
 --- a/net/minecraft/world/entity/monster/Husk.java
@@ -270,8 +302,38 @@ index 67dc738faef3ab414bf791692090aaea3dbe7385..2c7f11e165ea9f59dca6de559c7bcba3
          // Paper end
      }
  
+diff --git a/net/minecraft/world/entity/monster/Skeleton.java b/net/minecraft/world/entity/monster/Skeleton.java
+index 555ada78c81ce912bf8d57a9a094102804b372ef..81ef6b254c76fbe5d52008166b5ef423165bdb52 100644
+--- a/net/minecraft/world/entity/monster/Skeleton.java
++++ b/net/minecraft/world/entity/monster/Skeleton.java
+@@ -231,4 +231,10 @@ public class Skeleton extends AbstractSkeleton {
+         return net.minecraft.world.InteractionResult.SUCCESS;
+     }
+     // Purpur end - Skeletons eat wither roses
++
++    // Purpur start - API for any mob to burn daylight
++    public boolean shouldBurnInDay() {
++        return this.shouldBurnInDay && this.level().purpurConfig.skeletonBurnInDaylight;
++    }
++    // Purpur end - API for any mob to burn daylight
+ }
+diff --git a/net/minecraft/world/entity/monster/Stray.java b/net/minecraft/world/entity/monster/Stray.java
+index e4ae604d4d0756edc9418634d9958338997c8203..91f51edf79f87719ddfaf558384779a29536f62d 100644
+--- a/net/minecraft/world/entity/monster/Stray.java
++++ b/net/minecraft/world/entity/monster/Stray.java
+@@ -95,4 +95,10 @@ public class Stray extends AbstractSkeleton {
+ 
+         return abstractArrow;
+     }
++
++    // Purpur start - API for any mob to burn daylight
++    public boolean shouldBurnInDay() {
++        return this.shouldBurnInDay && this.level().purpurConfig.strayBurnInDaylight;
++    }
++    // Purpur end - API for any mob to burn daylight
+ }
 diff --git a/net/minecraft/world/entity/monster/Zombie.java b/net/minecraft/world/entity/monster/Zombie.java
-index 51cd12a8173d9f95c6a7c2503c3e0e4d40c427c5..147c030a2f8fd0d430070a36946fa42af177ea68 100644
+index 51cd12a8173d9f95c6a7c2503c3e0e4d40c427c5..3a4aff19c78550304ea5a6887e05d4cf62c29a49 100644
 --- a/net/minecraft/world/entity/monster/Zombie.java
 +++ b/net/minecraft/world/entity/monster/Zombie.java
 @@ -92,11 +92,12 @@ public class Zombie extends Monster {
@@ -319,15 +381,19 @@ index 51cd12a8173d9f95c6a7c2503c3e0e4d40c427c5..147c030a2f8fd0d430070a36946fa42a
          super.aiStep();
      }
  
-@@ -374,6 +353,7 @@ public class Zombie extends Monster {
+@@ -374,6 +353,11 @@ public class Zombie extends Monster {
          // CraftBukkit end
      }
  
-+    public boolean shouldBurnInDay() { return this.isSunSensitive(); } // Purpur - for ABI compatibility - API for any mob to burn daylight
++    // Purpur start - API for any mob to burn daylight
++    public boolean shouldBurnInDay() {
++        return this.isSunSensitive() && this.level().purpurConfig.zombieBurnInDaylight;
++    }
++    // Purpur end - API for any mob to burn daylight
      public boolean isSunSensitive() {
          return this.shouldBurnInDay; // Paper - Add more Zombie API
      }
-@@ -511,7 +491,7 @@ public class Zombie extends Monster {
+@@ -511,7 +495,7 @@ public class Zombie extends Monster {
          output.putBoolean("CanBreakDoors", this.canBreakDoors());
          output.putInt("InWaterTime", this.isInWater() ? this.inWaterTime : -1);
          output.putInt("DrownedConversionTime", this.isUnderWaterConverting() ? this.conversionTime : -1);
@@ -336,7 +402,7 @@ index 51cd12a8173d9f95c6a7c2503c3e0e4d40c427c5..147c030a2f8fd0d430070a36946fa42a
      }
  
      @Override
-@@ -526,7 +506,7 @@ public class Zombie extends Monster {
+@@ -526,7 +510,7 @@ public class Zombie extends Monster {
          } else {
              this.getEntityData().set(DATA_DROWNED_CONVERSION_ID, false);
          }
@@ -345,3 +411,18 @@ index 51cd12a8173d9f95c6a7c2503c3e0e4d40c427c5..147c030a2f8fd0d430070a36946fa42a
      }
  
      @Override
+diff --git a/net/minecraft/world/entity/monster/ZombieVillager.java b/net/minecraft/world/entity/monster/ZombieVillager.java
+index 606fe4bd9c3359e42a025a866873e147ee16a40e..642b5549c4048001642a4f1ab43b92f19f55e8e1 100644
+--- a/net/minecraft/world/entity/monster/ZombieVillager.java
++++ b/net/minecraft/world/entity/monster/ZombieVillager.java
+@@ -426,4 +426,10 @@ public class ZombieVillager extends Zombie implements VillagerDataHolder {
+             return super.applyImplicitComponent(component, value);
+         }
+     }
++
++    // Purpur start - API for any mob to burn daylight
++    public boolean shouldBurnInDay() {
++        return this.shouldBurnInDay && this.level().purpurConfig.zombieVillagerBurnInDaylight;
++    }
++    // Purpur end - API for any mob to burn daylight
+ }

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -74,8 +74,8 @@ public class PurpurConfig {
         commands = new HashMap<>();
         commands.put("purpur", new PurpurCommand("purpur"));
 
-        version = getInt("config-version", 43);
-        set("config-version", 43);
+        version = getInt("config-version", 44);
+        set("config-version", 44);
 
         readConfig(PurpurConfig.class, null);
 

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurWorldConfig.java
@@ -1328,12 +1328,14 @@ public class PurpurWorldConfig {
     public boolean boggedControllable = true;
     public double boggedMaxHealth = 16.0D;
     public double boggedScale = 1.0D;
+    public boolean boggedBurnInDaylight = true;
     private void boggedSettings() {
         boggedRidable = getBoolean("mobs.bogged.ridable", boggedRidable);
         boggedRidableInWater = getBoolean("mobs.bogged.ridable-in-water", boggedRidableInWater);
         boggedControllable = getBoolean("mobs.bogged.controllable", boggedControllable);
         boggedMaxHealth = getDouble("mobs.bogged.attributes.max_health", boggedMaxHealth);
         boggedScale = Mth.clamp(getDouble("mobs.bogged.attributes.scale", boggedScale), 0.0625D, 16.0D);
+        boggedBurnInDaylight = getBoolean("mobs.bogged.burn-in-daylight", boggedBurnInDaylight);
     }
 
     public boolean camelRidableInWater = false;
@@ -1620,6 +1622,7 @@ public class PurpurWorldConfig {
     public boolean drownedTakeDamageFromWater = false;
     public boolean drownedBreakDoors = false;
     public boolean drownedAlwaysDropExp = false;
+    public boolean drownedBurnInDaylight = true;
     private void drownedSettings() {
         drownedRidable = getBoolean("mobs.drowned.ridable", drownedRidable);
         drownedRidableInWater = getBoolean("mobs.drowned.ridable-in-water", drownedRidableInWater);
@@ -1638,6 +1641,7 @@ public class PurpurWorldConfig {
         drownedTakeDamageFromWater = getBoolean("mobs.drowned.takes-damage-from-water", drownedTakeDamageFromWater);
         drownedBreakDoors = getBoolean("mobs.drowned.can-break-doors", drownedBreakDoors);
         drownedAlwaysDropExp = getBoolean("mobs.drowned.always-drop-exp", drownedAlwaysDropExp);
+        drownedBurnInDaylight = getBoolean("mobs.drowned.burn-in-daylight", drownedBurnInDaylight);
     }
 
     public boolean elderGuardianRidable = false;
@@ -2792,6 +2796,7 @@ public class PurpurWorldConfig {
     public int skeletonFeedWitherRoses = 0;
     public String skeletonBowAccuracy = "14 - difficulty * 4";
     public Map<Integer, Float> skeletonBowAccuracyMap = new HashMap<>();
+    public boolean skeletonBurnInDaylight = true;
     private void skeletonSettings() {
         skeletonRidable = getBoolean("mobs.skeleton.ridable", skeletonRidable);
         skeletonRidableInWater = getBoolean("mobs.skeleton.ridable-in-water", skeletonRidableInWater);
@@ -2819,6 +2824,7 @@ public class PurpurWorldConfig {
             }
             skeletonBowAccuracyMap.put(i, divergence);
         }
+        skeletonBurnInDaylight = getBoolean("mobs.skeleton.burn-in-daylight", skeletonBurnInDaylight);
     }
 
     public boolean skeletonHorseRidable = false;
@@ -2989,6 +2995,7 @@ public class PurpurWorldConfig {
     public double strayScale = 1.0D;
     public boolean strayTakeDamageFromWater = false;
     public boolean strayAlwaysDropExp = false;
+    public boolean strayBurnInDaylight = true;
     private void straySettings() {
         strayRidable = getBoolean("mobs.stray.ridable", strayRidable);
         strayRidableInWater = getBoolean("mobs.stray.ridable-in-water", strayRidableInWater);
@@ -3002,6 +3009,7 @@ public class PurpurWorldConfig {
         strayScale = Mth.clamp(getDouble("mobs.stray.attributes.scale", strayScale), 0.0625D, 16.0D);
         strayTakeDamageFromWater = getBoolean("mobs.stray.takes-damage-from-water", strayTakeDamageFromWater);
         strayAlwaysDropExp = getBoolean("mobs.stray.always-drop-exp", strayAlwaysDropExp);
+        strayBurnInDaylight = getBoolean("mobs.stray.burn-in-daylight", strayBurnInDaylight);
     }
 
     public boolean striderRidable = false;
@@ -3435,6 +3443,7 @@ public class PurpurWorldConfig {
     public boolean zombieTakeDamageFromWater = false;
     public boolean zombieAlwaysDropExp = false;
     public double zombieHeadVisibilityPercent = 0.5D;
+    public boolean zombieBurnInDaylight = true;
     private void zombieSettings() {
         zombieRidable = getBoolean("mobs.zombie.ridable", zombieRidable);
         zombieRidableInWater = getBoolean("mobs.zombie.ridable-in-water", zombieRidableInWater);
@@ -3460,6 +3469,7 @@ public class PurpurWorldConfig {
         zombieTakeDamageFromWater = getBoolean("mobs.zombie.takes-damage-from-water", zombieTakeDamageFromWater);
         zombieAlwaysDropExp = getBoolean("mobs.zombie.always-drop-exp", zombieAlwaysDropExp);
         zombieHeadVisibilityPercent = getDouble("mobs.zombie.head-visibility-percent", zombieHeadVisibilityPercent);
+        zombieBurnInDaylight = getBoolean("mobs.zombie.burn-in-daylight", zombieBurnInDaylight);
     }
 
     public boolean zombieHorseRidable = false;
@@ -3509,6 +3519,7 @@ public class PurpurWorldConfig {
     public int zombieVillagerCuringTimeMax = 6000;
     public boolean zombieVillagerCureEnabled = true;
     public boolean zombieVillagerAlwaysDropExp = false;
+    public boolean zombieVillagerBurnInDaylight = true;
     private void zombieVillagerSettings() {
         zombieVillagerRidable = getBoolean("mobs.zombie_villager.ridable", zombieVillagerRidable);
         zombieVillagerRidableInWater = getBoolean("mobs.zombie_villager.ridable-in-water", zombieVillagerRidableInWater);
@@ -3529,6 +3540,7 @@ public class PurpurWorldConfig {
         zombieVillagerCuringTimeMax = getInt("mobs.zombie_villager.curing_time.max", zombieVillagerCuringTimeMax);
         zombieVillagerCureEnabled = getBoolean("mobs.zombie_villager.cure.enabled", zombieVillagerCureEnabled);
         zombieVillagerAlwaysDropExp = getBoolean("mobs.zombie_villager.always-drop-exp", zombieVillagerAlwaysDropExp);
+        zombieVillagerBurnInDaylight = getBoolean("mobs.zombie_villager.burn-in-daylight", zombieVillagerBurnInDaylight);
     }
 
     public boolean zombifiedPiglinRidable = false;


### PR DESCRIPTION
I saw the phantom has the config to disable burning in daylight.

Therefore I added it to other specific mobs that burn: Bogged, Drowned, Skeleton, Stray, Zombie and Zombie Villager.

It's probably can be done using plugins, but it's better to have them directly without using any.