### PR TITLE
Fix mobs not burning in daylight

### DIFF
--- a/purpur-server/minecraft-patches/features/0018-API-for-any-mob-to-burn-daylight.patch
+++ b/purpur-server/minecraft-patches/features/0018-API-for-any-mob-to-burn-daylight.patch
@@ -35,7 +35,7 @@ index 34e0fbef06b0c7aededf27fe9dc64f3f6f33e3ae..ce3e5ec505ac37c820436bcf7c7d6452
          this.type = entityType;
          this.level = level;
 diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
-index 385f7664d51056efd47f685514a98b71784e8ba3..4bd5e7cbaab0998e782bc67d3ba079a80ac40789 100644
+index f22862464068180a4276175bf79c40394523703f..8a7c533e3504e5a19cf374dcb12fe0e69931a002 100644
 --- a/net/minecraft/world/entity/LivingEntity.java
 +++ b/net/minecraft/world/entity/LivingEntity.java
 @@ -286,6 +286,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
@@ -122,7 +122,7 @@ index e05cf29c630d43c66614012c50b9dd4ece4c44f6..b0a5f79eb2c3ea84fd37eaa653a4f2c8
  
      @Override
 diff --git a/net/minecraft/world/entity/monster/AbstractSkeleton.java b/net/minecraft/world/entity/monster/AbstractSkeleton.java
-index 352d0655374e05da787225c3fce8803fa547c99d..53ab51ffa5dd7d30a25f17dea0d9106bf30b49ba 100644
+index 352d0655374e05da787225c3fce8803fa547c99d..d6487d994e2a76b3e34efde5fe063e288454cf1e 100644
 --- a/net/minecraft/world/entity/monster/AbstractSkeleton.java
 +++ b/net/minecraft/world/entity/monster/AbstractSkeleton.java
 @@ -64,11 +64,12 @@ public abstract class AbstractSkeleton extends Monster implements RangedAttackMo
@@ -130,7 +130,7 @@ index 352d0655374e05da787225c3fce8803fa547c99d..53ab51ffa5dd7d30a25f17dea0d9106b
          }
      };
 -    private boolean shouldBurnInDay = true; // Paper - shouldBurnInDay API
-+    //private boolean shouldBurnInDay = true; // Paper - shouldBurnInDay API // Purpur - moved to LivingEntity; keep methods for ABI compatibility - API for any mob to burn daylight
++    public boolean shouldBurnInDay = true; // Paper - shouldBurnInDay API // Purpur - moved to LivingEntity; keep methods for ABI compatibility - API for any mob to burn daylight
  
      protected AbstractSkeleton(EntityType<? extends AbstractSkeleton> entityType, Level level) {
          super(entityType, level);
@@ -271,7 +271,7 @@ index 67dc738faef3ab414bf791692090aaea3dbe7385..2c7f11e165ea9f59dca6de559c7bcba3
      }
  
 diff --git a/net/minecraft/world/entity/monster/Zombie.java b/net/minecraft/world/entity/monster/Zombie.java
-index 51cd12a8173d9f95c6a7c2503c3e0e4d40c427c5..147c030a2f8fd0d430070a36946fa42af177ea68 100644
+index 51cd12a8173d9f95c6a7c2503c3e0e4d40c427c5..3178787759a7c933fa0ce7ebebba6b0039dca801 100644
 --- a/net/minecraft/world/entity/monster/Zombie.java
 +++ b/net/minecraft/world/entity/monster/Zombie.java
 @@ -92,11 +92,12 @@ public class Zombie extends Monster {
@@ -279,7 +279,7 @@ index 51cd12a8173d9f95c6a7c2503c3e0e4d40c427c5..147c030a2f8fd0d430070a36946fa42a
      private int inWaterTime = 0;
      public int conversionTime;
 -    private boolean shouldBurnInDay = true; // Paper - Add more Zombie API
-+    //private boolean shouldBurnInDay = true; // Paper - Add more Zombie API // Purpur - implemented in LivingEntity - API for any mob to burn daylight
++    public boolean shouldBurnInDay = true; // Paper - Add more Zombie API // Purpur - implemented in LivingEntity - API for any mob to burn daylight
  
      public Zombie(EntityType<? extends Zombie> entityType, Level level) {
          super(entityType, level);


### PR DESCRIPTION
Mobs don't burn in daylight e.g. zombies, skeletons etc... using ```/summon```

I saw creating a mob using ```/summon``` will always have the value ```shouldBurnInDay = false``` since it doesn't override it from LivingEntity

A simple fix would be to uncomment the variables in Zombie and AbstractSkeleton and set them to true, as done with phantoms (who were already working before because of that).