### PR TITLE
Add permission nodes for using gamemaster blocks and bypassing other features.

### DIFF
--- a/purpur-server/minecraft-patches/features/0021-Add-bypass-permission-for-force-gamemode.patch
+++ b/purpur-server/minecraft-patches/features/0021-Add-bypass-permission-for-force-gamemode.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Mon, 14 Jul 2025 16:17:13 -0400
+Subject: [PATCH] Add bypass permission for force-gamemode
+
+
+diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
+index f17f54c93d3a10dbae9e2316849667e647904777..907f4d23db4a969509a652a36a8ab6c95a8c25ce 100644
+--- a/net/minecraft/server/level/ServerPlayer.java
++++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -2722,7 +2722,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+     public void loadGameTypes(@Nullable ValueInput input) {
+         // Paper start - Expand PlayerGameModeChangeEvent
+         if (this.server.getForcedGameType() != null && this.server.getForcedGameType() != readPlayerMode(input, "playerGameType")) {
+-            if (new org.bukkit.event.player.PlayerGameModeChangeEvent(this.getBukkitEntity(), org.bukkit.GameMode.getByValue(this.server.getDefaultGameType().getId()), org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.DEFAULT_GAMEMODE, null).callEvent()) {
++            if (!getBukkitEntity().hasPermission("minecraft.force-gamemode.bypass") && new org.bukkit.event.player.PlayerGameModeChangeEvent(this.getBukkitEntity(), org.bukkit.GameMode.getByValue(this.server.getDefaultGameType().getId()), org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.DEFAULT_GAMEMODE, null).callEvent()) {
+                 this.gameMode.setGameModeForPlayer(this.server.getForcedGameType(), GameType.DEFAULT_MODE);
+             } else {
+                 this.gameMode.setGameModeForPlayer(readPlayerMode(input, "playerGameType"), readPlayerMode(input, "previousPlayerGameType"));

--- a/purpur-server/minecraft-patches/features/0021-Add-bypass-permission-in-vanilla-for-spawn-protectio.patch
+++ b/purpur-server/minecraft-patches/features/0021-Add-bypass-permission-in-vanilla-for-spawn-protectio.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Sun, 13 Jul 2025 22:28:28 -0400
+Subject: [PATCH] Add bypass permission in vanilla for spawn protection
+
+
+diff --git a/net/minecraft/server/dedicated/DedicatedServer.java b/net/minecraft/server/dedicated/DedicatedServer.java
+index 670553243d26e2faab8a21f099a846d4d1df7927..84ddd5f8632f3621a964470e5879386e48bcb43f 100644
+--- a/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -543,6 +543,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+             return false;
+         } else if (this.getSpawnProtectionRadius() <= 0) {
+             return false;
++        } else if (player instanceof ServerPlayer serverPlayer && serverPlayer.getBukkitEntity().hasPermission("minecraft.spawn-protection.bypass")) {
++            return false;
+         } else {
+             BlockPos sharedSpawnPos = level.getSharedSpawnPos();
+             int abs = Mth.abs(pos.getX() - sharedSpawnPos.getX());

--- a/purpur-server/minecraft-patches/features/0021-Add-permission-node-for-spam-bypass.patch
+++ b/purpur-server/minecraft-patches/features/0021-Add-permission-node-for-spam-bypass.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Sun, 13 Jul 2025 00:10:53 -0400
+Subject: [PATCH] Add permission node for spam bypass
+
+
+diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index a63ade75461b68a780c56bfb5ff7c61f99f76744..5795bee75ea308b59af92e92668f787072ac3608 100644
+--- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -844,7 +844,7 @@ public class ServerGamePacketListenerImpl
+     public void handleCustomCommandSuggestions(ServerboundCommandSuggestionPacket packet) {
+         // PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level()); // Paper - AsyncTabCompleteEvent; run this async
+         // CraftBukkit start
+-        if (!this.tabSpamThrottler.isIncrementAndUnderThreshold() && !this.server.getPlayerList().isOp(this.player.getGameProfile()) && !this.server.isSingleplayerOwner(this.player.getGameProfile())) { // Paper - configurable tab spam limits
++        if (!this.tabSpamThrottler.isIncrementAndUnderThreshold() && !this.server.getPlayerList().isOp(this.player.getGameProfile()) && !this.server.isSingleplayerOwner(this.player.getGameProfile()) && !(this.server.getPlayerList().getPlayer(this.player.getUUID())).getBukkitEntity().hasPermission("minecraft.spam.bypass")) { // Paper - configurable tab spam limits
+             this.disconnectAsync(Component.translatable("disconnect.spam"), org.bukkit.event.player.PlayerKickEvent.Cause.SPAM); // Paper - Kick event cause // Paper - add proper async disconnect
+             return;
+         }
+@@ -2630,6 +2630,7 @@ public class ServerGamePacketListenerImpl
+         if (!this.chatSpamThrottler.isIncrementAndUnderThreshold()
+             // CraftBukkit end
+             && !this.server.getPlayerList().isOp(this.player.getGameProfile())
++            && !this.server.getPlayerList().getPlayer(this.player.getUUID()).getBukkitEntity().hasPermission("minecraft.spam.bypass")
+             && !this.server.isSingleplayerOwner(this.player.getGameProfile())) {
+             this.disconnectAsync(Component.translatable("disconnect.spam"), org.bukkit.event.player.PlayerKickEvent.Cause.SPAM); // Paper - kick event cause & add proper async disconnect
+         }

--- a/purpur-server/minecraft-patches/features/0021-Add-permission-nodes-for-movement-bypass.patch
+++ b/purpur-server/minecraft-patches/features/0021-Add-permission-nodes-for-movement-bypass.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Sun, 13 Jul 2025 02:26:42 -0400
+Subject: [PATCH] Add permission nodes for movement bypass
+
+
+diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index a63ade75461b68a780c56bfb5ff7c61f99f76744..ce21dd710b6309e8ad6afbd608b9b988133df1e4 100644
+--- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -609,6 +609,9 @@ public class ServerGamePacketListenerImpl
+                 // Paper end - Prevent moving into unloaded chunks
+                 if (d7 - d6 > Math.max(100.0, Mth.square(org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed)) && !this.isSingleplayerOwner()) {
+                     // CraftBukkit end
++                    if (this.player.getBukkitEntity().hasPermission("minecraft.movement.bypass.vehicle")) {
++                        return;
++                    }
+                     LOGGER.warn(
+                         "{} (vehicle of {}) moved too quickly! {},{},{}", rootVehicle.getName().getString(), this.player.getName().getString(), d3, d4, d5
+                     );
+@@ -638,6 +641,9 @@ public class ServerGamePacketListenerImpl
+                 d7 = d3 * d3 + d4 * d4 + d5 * d5;
+                 boolean flag1 = false;
+                 if (d7 > org.spigotmc.SpigotConfig.movedWronglyThreshold) { // Spigot
++                    if (this.player.getBukkitEntity().hasPermission("minecraft.movement.bypass.vehicle")) {
++                        return;
++                    }
+                     flag1 = true; // Paper - diff on change, this should be moved wrongly
+                     LOGGER.warn("{} (vehicle of {}) moved wrongly! {}", rootVehicle.getName().getString(), this.player.getName().getString(), Math.sqrt(d7));
+                 }
+@@ -1555,6 +1561,9 @@ public class ServerGamePacketListenerImpl
+                                         float f2 = isFallFlying ? 300.0F : 100.0F;
+                                         if (d7 - d6 > Math.max(f2, Mth.square(org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed))) {
+                                             // CraftBukkit end
++                                            if (this.player.getBukkitEntity().hasPermission("minecraft.movement.bypass.client")) {
++                                                return;
++                                            }
+                                             // Paper start - Add fail move event
+                                             io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_TOO_QUICKLY,
+                                                     toX, toY, toZ, toYaw, toPitch, true);
+@@ -1631,7 +1640,8 @@ public class ServerGamePacketListenerImpl
+                                     && d7 > org.spigotmc.SpigotConfig.movedWronglyThreshold // Spigot
+                                     && !this.player.isSleeping()
+                                     && !this.player.isCreative()
+-                                    && !this.player.isSpectator()) {
++                                    && !this.player.isSpectator()
++                                    && !this.player.getBukkitEntity().hasPermission("minecraft.movement.bypass.client")) {
+                                     // Paper start - Add fail move event
+                                     io.papermc.paper.event.player.PlayerFailMoveEvent event = fireFailMove(io.papermc.paper.event.player.PlayerFailMoveEvent.FailReason.MOVED_WRONGLY,
+                                             toX, toY, toZ, toYaw, toPitch, true);

--- a/purpur-server/minecraft-patches/features/0022-Add-bypass-permission-for-Elytra-movement-check.patch
+++ b/purpur-server/minecraft-patches/features/0022-Add-bypass-permission-for-Elytra-movement-check.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Mon, 14 Jul 2025 14:54:29 -0400
+Subject: [PATCH] Add bypass permission for Elytra movement check
+
+
+diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index a63ade75461b68a780c56bfb5ff7c61f99f76744..c6860babd7f48aa41ef91bc8c483b7f4cafd24ee 100644
+--- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1801,6 +1801,8 @@ public class ServerGamePacketListenerImpl
+             return false;
+         } else if (this.player.isChangingDimension()) {
+             return false;
++        } else if (this.player.getBukkitEntity().hasPermission("minecraft.movement.bypass.elytra")) {
++            return false;
+         } else {
+             GameRules gameRules = this.player.level().getGameRules();
+             return !gameRules.getBoolean(GameRules.RULE_DISABLE_PLAYER_MOVEMENT_CHECK)

--- a/purpur-server/minecraft-patches/features/0022-Add-permission-nodes-for-flight-bypass.patch
+++ b/purpur-server/minecraft-patches/features/0022-Add-permission-nodes-for-flight-bypass.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Sun, 13 Jul 2025 01:19:15 -0400
+Subject: [PATCH] Add permission nodes for flight bypass
+
+
+diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 0e01fdca875e2d0ef079c5e24cffed39fcf6c89b..e33a5062b2cdfb5aa1c8bc9973287e9928bf41eb 100644
+--- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -722,6 +722,7 @@ public class ServerGamePacketListenerImpl
+                 this.clientVehicleIsFloating = verticalDelta >= -0.03125
+                     && !flag
+                     && !this.server.isFlightAllowed()
++                    && !this.player.getBukkitEntity().hasPermission("minecraft.flight.bypass.vehicle")
+                     && !rootVehicle.isFlyingVehicle()
+                     && !rootVehicle.isNoGravity()
+                     && this.noBlocksAround(rootVehicle);
+@@ -1740,6 +1741,7 @@ public class ServerGamePacketListenerImpl
+                                         && !this.server.isFlightAllowed()
+                                         && !this.player.getAbilities().mayfly
+                                         && !this.player.hasEffect(MobEffects.LEVITATION)
++                                        && !this.player.getBukkitEntity().hasPermission("minecraft.flight.bypass.client")
+                                         && !isFallFlying
+                                         && !isAutoSpinAttack
+                                         && this.noBlocksAround(this.player);

--- a/purpur-server/minecraft-patches/features/0022-Permission-nodes-for-more-gamemaster-blocks.patch
+++ b/purpur-server/minecraft-patches/features/0022-Permission-nodes-for-more-gamemaster-blocks.patch
@@ -1,0 +1,133 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Sat, 12 Jul 2025 12:08:29 -0400
+Subject: [PATCH] Permission nodes for more gamemaster blocks
+
+
+diff --git a/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index a63ade75461b68a780c56bfb5ff7c61f99f76744..f6688fc752b47ef15c3baafcc73a91d48f9bf922 100644
+--- a/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -1128,7 +1128,7 @@ public class ServerGamePacketListenerImpl
+     @Override
+     public void handleSetStructureBlock(ServerboundSetStructureBlockPacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
+-        if (this.player.canUseGameMasterBlocks()) {
++        if (this.player.canUseGameMasterBlocks() || this.player.getBukkitEntity().hasPermission("minecraft.structureblock")) {
+             BlockPos pos = packet.getPos();
+             BlockState blockState = this.player.level().getBlockState(pos);
+             if (this.player.level().getBlockEntity(pos) instanceof StructureBlockEntity structureBlockEntity) {
+@@ -1181,7 +1181,7 @@ public class ServerGamePacketListenerImpl
+     @Override
+     public void handleSetTestBlock(ServerboundSetTestBlockPacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
+-        if (this.player.canUseGameMasterBlocks()) {
++        if (this.player.canUseGameMasterBlocks() || this.player.getBukkitEntity().hasPermission("minecraft.testblock")) {
+             BlockPos blockPos = packet.position();
+             BlockState blockState = this.player.level().getBlockState(blockPos);
+             if (this.player.level().getBlockEntity(blockPos) instanceof TestBlockEntity testBlockEntity) {
+@@ -1197,7 +1197,7 @@ public class ServerGamePacketListenerImpl
+     public void handleTestInstanceBlockAction(ServerboundTestInstanceBlockActionPacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
+         BlockPos blockPos = packet.pos();
+-        if (this.player.canUseGameMasterBlocks() && this.player.level().getBlockEntity(blockPos) instanceof TestInstanceBlockEntity testInstanceBlockEntity) {
++        if ((this.player.canUseGameMasterBlocks() || this.player.getBukkitEntity().hasPermission("minecraft.testinstanceblock")) && this.player.level().getBlockEntity(blockPos) instanceof TestInstanceBlockEntity testInstanceBlockEntity) {
+             if (packet.action() != ServerboundTestInstanceBlockActionPacket.Action.QUERY
+                 && packet.action() != ServerboundTestInstanceBlockActionPacket.Action.INIT) {
+                 testInstanceBlockEntity.set(packet.data());
+@@ -1240,7 +1240,7 @@ public class ServerGamePacketListenerImpl
+     @Override
+     public void handleSetJigsawBlock(ServerboundSetJigsawBlockPacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
+-        if (this.player.canUseGameMasterBlocks()) {
++        if (this.player.canUseGameMasterBlocks() || this.player.getBukkitEntity().hasPermission("minecraft.jigsawblock")) {
+             BlockPos pos = packet.getPos();
+             BlockState blockState = this.player.level().getBlockState(pos);
+             if (this.player.level().getBlockEntity(pos) instanceof JigsawBlockEntity jigsawBlockEntity) {
+@@ -1260,7 +1260,7 @@ public class ServerGamePacketListenerImpl
+     @Override
+     public void handleJigsawGenerate(ServerboundJigsawGeneratePacket packet) {
+         PacketUtils.ensureRunningOnSameThread(packet, this, this.player.level());
+-        if (this.player.canUseGameMasterBlocks()) {
++        if (this.player.canUseGameMasterBlocks() || this.player.getBukkitEntity().hasPermission("minecraft.jigsawblock")) {
+             BlockPos pos = packet.getPos();
+             if (this.player.level().getBlockEntity(pos) instanceof JigsawBlockEntity jigsawBlockEntity) {
+                 jigsawBlockEntity.generate(this.player.level(), packet.levels(), packet.keepJigsaws());
+diff --git a/net/minecraft/world/level/block/JigsawBlock.java b/net/minecraft/world/level/block/JigsawBlock.java
+index 5b5b0ba3d132be18403fb763039ccc723e2b7b46..31e17b20aa2eacf7ae40607a49fa01542ce65d05 100644
+--- a/net/minecraft/world/level/block/JigsawBlock.java
++++ b/net/minecraft/world/level/block/JigsawBlock.java
+@@ -68,7 +68,7 @@ public class JigsawBlock extends Block implements EntityBlock, GameMasterBlock {
+     @Override
+     protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
+         BlockEntity blockEntity = level.getBlockEntity(pos);
+-        if (blockEntity instanceof JigsawBlockEntity && player.canUseGameMasterBlocks()) {
++        if (blockEntity instanceof JigsawBlockEntity && player.canUseGameMasterBlocks()  || (player.isCreative() && player.getBukkitEntity().hasPermission("minecraft.jigsawblock"))) {
+             player.openJigsawBlock((JigsawBlockEntity)blockEntity);
+             return InteractionResult.SUCCESS;
+         } else {
+diff --git a/net/minecraft/world/level/block/LecternBlock.java b/net/minecraft/world/level/block/LecternBlock.java
+index 5a9b601b7bf7e80b04ebd8f5c8b7d121031132c7..9fce9dc9e2350f16ed7d191b45b61de893e32dd0 100644
+--- a/net/minecraft/world/level/block/LecternBlock.java
++++ b/net/minecraft/world/level/block/LecternBlock.java
+@@ -82,7 +82,7 @@ public class LecternBlock extends BaseEntityBlock {
+         ItemStack itemInHand = context.getItemInHand();
+         Player player = context.getPlayer();
+         boolean flag = false;
+-        if (!level.isClientSide && player != null && player.canUseGameMasterBlocks()) {
++        if (!level.isClientSide && player != null && player.canUseGameMasterBlocks() || player.getBukkitEntity().hasPermission("minecraft.lecternblock")) {
+             CustomData customData = itemInHand.getOrDefault(DataComponents.BLOCK_ENTITY_DATA, CustomData.EMPTY);
+             if (customData.contains("Book")) {
+                 flag = true;
+diff --git a/net/minecraft/world/level/block/LightBlock.java b/net/minecraft/world/level/block/LightBlock.java
+index 4e2c0383eda3e81bbc40a724263b49151a342746..902a0ee5f6d82d55a440440b22b60e6941630c2e 100644
+--- a/net/minecraft/world/level/block/LightBlock.java
++++ b/net/minecraft/world/level/block/LightBlock.java
+@@ -59,7 +59,7 @@ public class LightBlock extends Block implements SimpleWaterloggedBlock {
+ 
+     @Override
+     protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
+-        if (!level.isClientSide && player.canUseGameMasterBlocks()) {
++        if (!level.isClientSide && player.canUseGameMasterBlocks() || (player.isCreative() && player.getBukkitEntity().hasPermission("minecraft.lightblock"))) {
+             level.setBlock(pos, state.cycle(LEVEL), 2);
+             return InteractionResult.SUCCESS_SERVER;
+         } else {
+diff --git a/net/minecraft/world/level/block/TestBlock.java b/net/minecraft/world/level/block/TestBlock.java
+index fdcc98da158af9d93431ce5dac127e1017c1dcfb..ec21cd7c18f0808daf769e557a61544fcf6e5de8 100644
+--- a/net/minecraft/world/level/block/TestBlock.java
++++ b/net/minecraft/world/level/block/TestBlock.java
+@@ -62,7 +62,7 @@ public class TestBlock extends BaseEntityBlock implements GameMasterBlock {
+     @Override
+     protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
+         if (level.getBlockEntity(pos) instanceof TestBlockEntity testBlockEntity) {
+-            if (!player.canUseGameMasterBlocks()) {
++            if (!player.canUseGameMasterBlocks() && !player.getBukkitEntity().hasPermission("minecraft.testblock")) {
+                 return InteractionResult.PASS;
+             } else {
+                 if (level.isClientSide) {
+diff --git a/net/minecraft/world/level/block/TestInstanceBlock.java b/net/minecraft/world/level/block/TestInstanceBlock.java
+index 3f586d506090db3cad7ff30c23ef0db9b83e3042..7168d664936d607260dbd42deb034aa3b4690f34 100644
+--- a/net/minecraft/world/level/block/TestInstanceBlock.java
++++ b/net/minecraft/world/level/block/TestInstanceBlock.java
+@@ -28,7 +28,7 @@ public class TestInstanceBlock extends BaseEntityBlock implements GameMasterBloc
+     @Override
+     protected InteractionResult useWithoutItem(BlockState state, Level level, BlockPos pos, Player player, BlockHitResult hitResult) {
+         if (level.getBlockEntity(pos) instanceof TestInstanceBlockEntity testInstanceBlockEntity) {
+-            if (!player.canUseGameMasterBlocks()) {
++            if (!player.canUseGameMasterBlocks() && !player.getBukkitEntity().hasPermission("minecraft.testinstanceblock")) {
+                 return InteractionResult.PASS;
+             } else {
+                 if (player.level().isClientSide) {
+diff --git a/net/minecraft/world/level/block/entity/StructureBlockEntity.java b/net/minecraft/world/level/block/entity/StructureBlockEntity.java
+index c2c0915dc1458bb5755ee5591872da51c998582d..303baacd5cf5343eea6c71f48631aeaf985deb4a 100644
+--- a/net/minecraft/world/level/block/entity/StructureBlockEntity.java
++++ b/net/minecraft/world/level/block/entity/StructureBlockEntity.java
+@@ -147,7 +147,7 @@ public class StructureBlockEntity extends BlockEntity implements BoundingBoxRend
+     }
+ 
+     public boolean usedBy(Player player) {
+-        if (!player.canUseGameMasterBlocks()) {
++        if (!player.canUseGameMasterBlocks() || !(player.isCreative() && player.getBukkitEntity().hasPermission("minecraft.structureblock"))) {
+             return false;
+         } else {
+             if (player.level().isClientSide) {

--- a/purpur-server/paper-patches/features/0006-Add-bypass-permission-in-Bukkit-for-spawn-protection.patch
+++ b/purpur-server/paper-patches/features/0006-Add-bypass-permission-in-Bukkit-for-spawn-protection.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Sun, 13 Jul 2025 22:29:59 -0400
+Subject: [PATCH] Add bypass permission in Bukkit for spawn protection
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 658385b2887d6debec7fc941c28621da5d263411..d511cd839be7de82302bbd08ab6b195377d120bf 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -272,6 +272,7 @@ public class CraftEventFactory {
+         if (spawnSize <= 0) return true;
+         if (((CraftServer) Bukkit.getServer()).getHandle().getOps().isEmpty()) return true;
+         if (player.isOp()) return true;
++        if (player.hasPermission("minecraft.spawn-protection.bypass")) return true;
+ 
+         BlockPos spawnPos = world.getSharedSpawnPos();
+ 


### PR DESCRIPTION
This patch adds permission nodes for more gamemaster blocks. This allows users to access some functionalities of these blocks, similar to how "minecraft.commandblock" grants access to Command Blocks/Minecarts.

The following blocks now have a permission node:

- Structure Block ("minecraft.structureblock")

- Jigsaw Block ("minecraft.jigsawblock")

- Light Block ("minecraft.lightblock")
_Note: This controls whether or not players can change the light level by interacting with a Light Block with one in their hand._

- Lectern Block ("minecraft.lecternblock")
_Note: This permission node controls whether or not a lectern with NBT can be placed. Regular players can still place the block with no NBT._

- Test Block ("minecraft.testblock")

- Test Instance Block ("minecraft.testinstanceblock")

The other patches also adds bypass permission nodes for built-in vanilla features:

- Force Gamemode ("minecraft.force-gamemode.bypass")

- Spawn Protection ("minecraft.spawn-protection.bypass")

- Anti-spam ("minecraft.spam.bypass")

- Movement ("minecraft.movement.bypass.vehicle", "minecraft.movement.bypass.client", "minecraft.movement.bypass.elytra")

- Flight ("minecraft.flight.bypass.vehicle" and "minecraft.flight.bypass.client")