### PR TITLE
Update foojay-resolver-container to 1.0.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 if (!file(".git").exists()) {


### PR DESCRIPTION
Running the ```./gradlew runDevServer -d``` produces an error:

```
2025-10-04T21:27:05.448+0100 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] * What went wrong:
2025-10-04T21:27:05.448+0100 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] Could not initialize class org.gradle.toolchains.foojay.DistributionsKt
2025-10-04T21:27:05.448+0100 [ERROR] [org.gradle.internal.buildevents.BuildExceptionReporter] > Exception java.lang.NoSuchFieldError: Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU' [in thread "Daemon worker Thread 2"]
```

This was fixed by updating ```foojay-resolver-container plugin``` to 1.0.0 in ```settings.gradle.kts``` to match Paper settings.