### PR TITLE
Fix fireball griefing not overriding gamerule - Fix #1702

### DIFF
--- a/purpur-server/minecraft-patches/features/0015-Add-mobGriefing-override-to-everything-affected.patch
+++ b/purpur-server/minecraft-patches/features/0015-Add-mobGriefing-override-to-everything-affected.patch
@@ -240,10 +240,10 @@ index 19211c0d78113da7827a071fd510b4f36e63a9f2..4e1a7b6caf8c0a3721a3a799261d7b63
  
      protected boolean canReplaceCurrentItem(ItemStack candidate) {
 diff --git a/net/minecraft/world/entity/projectile/LargeFireball.java b/net/minecraft/world/entity/projectile/LargeFireball.java
-index b782957c118313fcaa80d127291e5b6d614da98a..f92ea082aca3aa75839e8ce0001b0f272d3235ce 100644
+index b782957c118313fcaa80d127291e5b6d614da98a..bb5be4a4027256dee9a28546a8994578d95df2de 100644
 --- a/net/minecraft/world/entity/projectile/LargeFireball.java
 +++ b/net/minecraft/world/entity/projectile/LargeFireball.java
-@@ -20,20 +20,20 @@ public class LargeFireball extends Fireball {
+@@ -20,24 +20,24 @@ public class LargeFireball extends Fireball {
  
      public LargeFireball(EntityType<? extends LargeFireball> type, Level level) {
          super(type, level);
@@ -267,6 +267,11 @@ index b782957c118313fcaa80d127291e5b6d614da98a..f92ea082aca3aa75839e8ce0001b0f27
              // CraftBukkit start - fire ExplosionPrimeEvent
              org.bukkit.event.entity.ExplosionPrimeEvent event = new org.bukkit.event.entity.ExplosionPrimeEvent((org.bukkit.entity.Explosive) this.getBukkitEntity());
              if (event.callEvent()) {
+-                this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), Level.ExplosionInteraction.MOB);
++                this.level().explode(this, this.getX(), this.getY(), this.getZ(), event.getRadius(), event.getFire(), _boolean ? Level.ExplosionInteraction.BLOCK : Level.ExplosionInteraction.NONE); // Purpur - Add mobGriefing override to everything affected
+             }
+             // CraftBukkit end - fire ExplosionPrimeEvent
+             this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.HIT); // CraftBukkit - add Bukkit remove cause
 diff --git a/net/minecraft/world/entity/projectile/Projectile.java b/net/minecraft/world/entity/projectile/Projectile.java
 index cdb73cab0a64f51d65a7420fdac44455c6c77a48..74f5478c9eb8d0a01a7634980b6003198b8ea50c 100644
 --- a/net/minecraft/world/entity/projectile/Projectile.java


### PR DESCRIPTION
This fixes issue #1702

- The issue was even if in the config ```fireballs-mob-griefing-override``` is set to true or false, the gamerule will still override it, since the check was never used (Variable ```_boolean```) . and ```Level.ExplosionInteraction.MOB``` will still check the gamerule, therefore override the config.

- I was able to make the check directly with the use of ```_boolean``` to see if it will grief the blocks.

Tested with every config ```default/true/false``` and works amazing!