### PR TITLE
Add hostile mobs to not spawn in blue and packed ice - Fix #1701

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Ghast.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Ghast.java.patch
@@ -1,15 +1,12 @@
 --- a/net/minecraft/world/entity/monster/Ghast.java
 +++ b/net/minecraft/world/entity/monster/Ghast.java
-@@ -155,6 +_,14 @@
+@@ -155,6 +_,11 @@
      public static boolean checkGhastSpawnRules(
          EntityType<Ghast> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (net.minecraft.world.entity.monster.Monster.canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          return level.getDifficulty() != Difficulty.PEACEFUL && random.nextInt(20) == 0 && checkMobSpawnRules(entityType, level, spawnReason, pos, random);

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Ghast.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Ghast.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/entity/monster/Ghast.java
++++ b/net/minecraft/world/entity/monster/Ghast.java
+@@ -155,6 +_,14 @@
+     public static boolean checkGhastSpawnRules(
+         EntityType<Ghast> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
++        // Purpur start - Config to disable hostile mob spawn on ice
++        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
++            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
++                return false;
++            }
++        }
++        // Purpur end - Config to disable hostile mob spawn on ice
+         return level.getDifficulty() != Difficulty.PEACEFUL && random.nextInt(20) == 0 && checkMobSpawnRules(entityType, level, spawnReason, pos, random);
+     }
+ 

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Guardian.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Guardian.java.patch
@@ -1,15 +1,12 @@
 --- a/net/minecraft/world/entity/monster/Guardian.java
 +++ b/net/minecraft/world/entity/monster/Guardian.java
-@@ -314,6 +_,14 @@
+@@ -314,6 +_,11 @@
      public static boolean checkGuardianSpawnRules(
          EntityType<? extends Guardian> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          return (random.nextInt(20) == 0 || !level.canSeeSkyFromBelowWater(pos))

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Guardian.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Guardian.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/entity/monster/Guardian.java
++++ b/net/minecraft/world/entity/monster/Guardian.java
+@@ -314,6 +_,14 @@
+     public static boolean checkGuardianSpawnRules(
+         EntityType<? extends Guardian> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
++        // Purpur start - Config to disable hostile mob spawn on ice
++        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
++            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
++                return false;
++            }
++        }
++        // Purpur end - Config to disable hostile mob spawn on ice
+         return (random.nextInt(20) == 0 || !level.canSeeSkyFromBelowWater(pos))
+             && level.getDifficulty() != Difficulty.PEACEFUL
+             && (EntitySpawnReason.isSpawner(spawnReason) || level.getFluidState(pos).is(FluidTags.WATER))

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/MagmaCube.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/MagmaCube.java.patch
@@ -1,15 +1,12 @@
 --- a/net/minecraft/world/entity/monster/MagmaCube.java
 +++ b/net/minecraft/world/entity/monster/MagmaCube.java
-@@ -31,6 +_,14 @@
+@@ -31,6 +_,11 @@
      public static boolean checkMagmaCubeSpawnRules(
          EntityType<MagmaCube> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (net.minecraft.world.entity.monster.Monster.canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          return level.getDifficulty() != Difficulty.PEACEFUL;

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/MagmaCube.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/MagmaCube.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/entity/monster/MagmaCube.java
++++ b/net/minecraft/world/entity/monster/MagmaCube.java
+@@ -31,6 +_,14 @@
+     public static boolean checkMagmaCubeSpawnRules(
+         EntityType<MagmaCube> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
++        // Purpur start - Config to disable hostile mob spawn on ice
++        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
++            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
++                return false;
++            }
++        }
++        // Purpur end - Config to disable hostile mob spawn on ice
+         return level.getDifficulty() != Difficulty.PEACEFUL;
+     }
+ 

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Monster.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Monster.java.patch
@@ -1,32 +1,39 @@
 --- a/net/minecraft/world/entity/monster/Monster.java
 +++ b/net/minecraft/world/entity/monster/Monster.java
-@@ -84,6 +_,14 @@
+@@ -84,6 +_,11 @@
      }
  
      public static boolean isDarkEnoughToSpawn(ServerLevelAccessor level, BlockPos pos, RandomSource random) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          if (level.getBrightness(LightLayer.SKY, pos) > random.nextInt(32)) {
              return false;
          } else {
-@@ -109,6 +_,14 @@
+@@ -109,6 +_,11 @@
      public static boolean checkAnyLightMonsterSpawnRules(
          EntityType<? extends Monster> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          return level.getDifficulty() != Difficulty.PEACEFUL && checkMobSpawnRules(entityType, level, spawnReason, pos, random);
      }
  
+@@ -140,4 +_,12 @@
+             return ItemStack.EMPTY;
+         }
+     }
++
++    // Purpur start - Config to disable hostile mob spawn on ice
++    public static boolean canSpawnInBlueAndPackedIce(LevelAccessor level, BlockPos pos) {
++        net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++
++        return (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE));
++    }
++    // Purpur end - Config to disable hostile mob spawn on ice
+ }

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Monster.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Monster.java.patch
@@ -15,3 +15,18 @@
          if (level.getBrightness(LightLayer.SKY, pos) > random.nextInt(32)) {
              return false;
          } else {
+@@ -109,6 +_,14 @@
+     public static boolean checkAnyLightMonsterSpawnRules(
+         EntityType<? extends Monster> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
++        // Purpur start - Config to disable hostile mob spawn on ice
++        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
++            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
++                return false;
++            }
++        }
++        // Purpur end - Config to disable hostile mob spawn on ice
+         return level.getDifficulty() != Difficulty.PEACEFUL && checkMobSpawnRules(entityType, level, spawnReason, pos, random);
+     }
+ 

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/entity/monster/Slime.java
++++ b/net/minecraft/world/entity/monster/Slime.java
+@@ -301,6 +_,14 @@
+     public static boolean checkSlimeSpawnRules(
+         EntityType<Slime> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
++        // Purpur start - Config to disable hostile mob spawn on ice
++        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
++            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
++                return false;
++            }
++        }
++        // Purpur end - Config to disable hostile mob spawn on ice
+         if (level.getDifficulty() != Difficulty.PEACEFUL) {
+             if (EntitySpawnReason.isSpawner(spawnReason)) {
+                 return checkMobSpawnRules(entityType, level, spawnReason, pos, random);

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/Slime.java.patch
@@ -1,15 +1,12 @@
 --- a/net/minecraft/world/entity/monster/Slime.java
 +++ b/net/minecraft/world/entity/monster/Slime.java
-@@ -301,6 +_,14 @@
+@@ -301,6 +_,11 @@
      public static boolean checkSlimeSpawnRules(
          EntityType<Slime> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (net.minecraft.world.entity.monster.Monster.canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          if (level.getDifficulty() != Difficulty.PEACEFUL) {

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/ZombifiedPiglin.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/ZombifiedPiglin.java.patch
@@ -13,16 +13,31 @@
          super.customServerAiStep(level);
      }
  
-@@ -159,6 +_,12 @@
-             this.playFirstAngerSoundIn = FIRST_ANGER_SOUND_DELAY.sample(this.random);
+@@ -160,6 +_,12 @@
              this.ticksUntilNextAlert = ALERT_INTERVAL.sample(this.random);
          }
-+
+ 
 +        // Purpur start - Toggle for Zombified Piglin death always counting as player kill when angry
 +        if (target instanceof Player player && this.level().purpurConfig.zombifiedPiglinCountAsPlayerKillWhenAngry) {
 +            this.setLastHurtByPlayer(player, this.tickCount);
 +        }
 +        // Purpur end - Toggle for Zombified Piglin death always counting as player kill when angry
- 
++
          return super.setTarget(target, reason); // CraftBukkit
      }
+ 
+@@ -180,6 +_,14 @@
+     public static boolean checkZombifiedPiglinSpawnRules(
+         EntityType<ZombifiedPiglin> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
++        // Purpur start - Config to disable hostile mob spawn on ice
++        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
++            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
++                return false;
++            }
++        }
++        // Purpur end - Config to disable hostile mob spawn on ice
+         return level.getDifficulty() != Difficulty.PEACEFUL && !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);
+     }
+ 

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/ZombifiedPiglin.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/ZombifiedPiglin.java.patch
@@ -26,16 +26,13 @@
          return super.setTarget(target, reason); // CraftBukkit
      }
  
-@@ -180,6 +_,14 @@
+@@ -180,6 +_,11 @@
      public static boolean checkZombifiedPiglinSpawnRules(
          EntityType<ZombifiedPiglin> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          return level.getDifficulty() != Difficulty.PEACEFUL && !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/hoglin/Hoglin.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/hoglin/Hoglin.java.patch
@@ -1,15 +1,12 @@
 --- a/net/minecraft/world/entity/monster/hoglin/Hoglin.java
 +++ b/net/minecraft/world/entity/monster/hoglin/Hoglin.java
-@@ -200,6 +_,14 @@
+@@ -200,6 +_,11 @@
      public static boolean checkHoglinSpawnRules(
          EntityType<Hoglin> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (net.minecraft.world.entity.monster.Monster.canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          return !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/hoglin/Hoglin.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/hoglin/Hoglin.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/entity/monster/hoglin/Hoglin.java
++++ b/net/minecraft/world/entity/monster/hoglin/Hoglin.java
+@@ -200,6 +_,14 @@
+     public static boolean checkHoglinSpawnRules(
+         EntityType<Hoglin> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
++        // Purpur start - Config to disable hostile mob spawn on ice
++        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
++            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
++                return false;
++            }
++        }
++        // Purpur end - Config to disable hostile mob spawn on ice
+         return !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);
+     }
+ 

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
@@ -1,0 +1,17 @@
+--- a/net/minecraft/world/entity/monster/piglin/Piglin.java
++++ b/net/minecraft/world/entity/monster/piglin/Piglin.java
+@@ -203,6 +_,14 @@
+     public static boolean checkPiglinSpawnRules(
+         EntityType<Piglin> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
+     ) {
++        // Purpur start - Config to disable hostile mob spawn on ice
++        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
++            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
++            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
++                return false;
++            }
++        }
++        // Purpur end - Config to disable hostile mob spawn on ice
+         return !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);
+     }
+ 

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/monster/piglin/Piglin.java.patch
@@ -1,15 +1,12 @@
 --- a/net/minecraft/world/entity/monster/piglin/Piglin.java
 +++ b/net/minecraft/world/entity/monster/piglin/Piglin.java
-@@ -203,6 +_,14 @@
+@@ -203,6 +_,11 @@
      public static boolean checkPiglinSpawnRules(
          EntityType<Piglin> entityType, LevelAccessor level, EntitySpawnReason spawnReason, BlockPos pos, RandomSource random
      ) {
 +        // Purpur start - Config to disable hostile mob spawn on ice
-+        if (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce || !level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce) {
-+            net.minecraft.world.level.block.state.BlockState spawnBlock = level.getBlockState(pos.below());
-+            if ((!level.getMinecraftWorld().purpurConfig.mobsSpawnOnPackedIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.PACKED_ICE)) || (!level.getMinecraftWorld().purpurConfig.mobsSpawnOnBlueIce && spawnBlock.is(net.minecraft.world.level.block.Blocks.BLUE_ICE))) {
-+                return false;
-+            }
++        if (canSpawnInBlueAndPackedIce(level, pos)) {
++            return false;
 +        }
 +        // Purpur end - Config to disable hostile mob spawn on ice
          return !level.getBlockState(pos.below()).is(Blocks.NETHER_WART_BLOCK);


### PR DESCRIPTION
This adds the hostile mobs that wasn't working to not be spawned on blue and packed ice.