### PR TITLE
Fix Shift + right click with mending gives mass xp- Fixes #1694

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayerGameMode.java.patch
@@ -36,7 +36,7 @@
 +            int points = Math.min(this.player.totalExperience, this.player.level().purpurConfig.shiftRightClickRepairsMendingPoints);
 +            if (points > 0 && itemstack.isDamaged() && net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.MENDING, itemstack) > 0) {
 +                this.player.giveExperiencePoints(itemstack.getDamageValue() == 1 ? -2 : -points);
-+                this.player.level().addFreshEntity(new net.minecraft.world.entity.ExperienceOrb(this.player.level(), this.player.getX(), this.player.getY(), this.player.getZ(), points, org.bukkit.entity.ExperienceOrb.SpawnReason.UNKNOWN, this.player, this.player));
++                this.player.level().addFreshEntity(new net.minecraft.world.entity.ExperienceOrb(this.player.level(), this.player.getX(), this.player.getY(), this.player.getZ(), itemstack.getDamageValue() == 1 ? 1 : points, org.bukkit.entity.ExperienceOrb.SpawnReason.UNKNOWN, this.player, this.player));
 +                return true;
 +            }
 +        }


### PR DESCRIPTION
Issue is well explained here. See [#1694](https://github.com/PurpurMC/Purpur/issues/1694)

### Minecraft Mending

As explained in the wiki:
- Experience in the orb is deducted by one point for every two durability points repaired. For example, one durability point repaired doesn't take any experience away from the orb.
- I tested this and I found out that it's correct, my item does get repaired when its damage equals 1 without any xp.

### What the patch does

- If the item ***damage*** equals ```1```, it removes ```2 exp```, else the ```points``` value.
- But the issue, is that it spawns an exp orb of ```points``` value.
- This results in, if you ```shift + right click``` when the ***damage*** is ```1```, you get the item repaired and you also get ```points``` to your xp (This explains why in the issue, it would give you mass xp when the item is not damaged).

### My solution

- If the ***damage*** is ```1```, we remove ```2 xp points``` as the patch did (Still the same)
- But instead of creating an exp orb of ```points``` value when ***damage*** is ```1```, we make it an exp orb of ```1``` point.
- This will resolve into the player losing ```1 point``` to repair the ***1 damage***.

- If it's more than ***1 damage***, it's the same as the patch did.

(I didn't make an exp orb of ```2 points```, because this would mean, ***you won't lose any xp to repair your item***, which people can use as an exploit to have an unbreakable item ```e.g. Mining blocks with shift + right click + left click```

- If this is not well explained enough, put a comment here.
- I tested all this and it works as intended.