### PR TITLE
Fix lagging threshold causing to slow the server

### DIFF
--- a/purpur-server/minecraft-patches/features/0001-Ridables.patch
+++ b/purpur-server/minecraft-patches/features/0001-Ridables.patch
@@ -18,10 +18,10 @@ index 6c452f195055afb489f828bfac9f23217ba7653d..7261bb8b2728b6e4ff519874375ef42f
              public boolean isClientAuthoritative() {
                  return false;
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index e35fb4f48a16780d8728ac1c7bb0fc64e2ded4e7..2c7039281854cc9b21e2badb62389522a5c1728e 100644
+index 32b531fa405fdadef5b767783d2c77bed8ef0657..69a41be9b96a3b38a49f27f2825f5bdfd6a48cea 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -1824,6 +1824,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1832,6 +1832,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              serverLevel.hasEntityMoveEvent = io.papermc.paper.event.entity.EntityMoveEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper - Add EntityMoveEvent
              serverLevel.updateLagCompensationTick(); // Paper - lag compensation
              net.minecraft.world.level.block.entity.HopperBlockEntity.skipHopperEvents = serverLevel.paperConfig().hopper.disableMoveEvent || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0; // Paper - Perf: Optimize Hoppers

--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -67,7 +67,7 @@
              while (this.running) {
                  final long tickStart = System.nanoTime(); // Paper - improve tick loop
                  long l; // Paper - improve tick loop - diff on change, expect this to be tick interval
-@@ -1306,8 +_,10 @@
+@@ -1306,8 +_,13 @@
                      final long ticksBehind = Math.max(1L, this.tickSchedule.getPeriodsAhead(l, tickStart));
                      final long catchup = (long)Math.max(
                          1,
@@ -75,7 +75,10 @@
 +                        org.purpurmc.purpur.PurpurConfig.tpsCatchup ? 5 : 1 //ConfigHolder.getConfig().tickLoop.catchupTicks.getOrDefault(MoonriseConfig.TickLoop.DEFAULT_CATCHUP_TICKS).intValue() // Purpur - Configurable TPS Catchup
                      );
 +
-+                    lagging = getTPS(this.tickTimes5s, this.tickRateManager().nanosecondsPerTick()) < org.purpurmc.purpur.PurpurConfig.laggingThreshold; // Purpur - Lagging threshold
++                    synchronized (this.statsLock) {
++                        lagging = getTPS(this.tickTimes5s, this.tickRateManager().nanosecondsPerTick()) < org.purpurmc.purpur.PurpurConfig.laggingThreshold; // Purpur - Lagging threshold
++
++                    }
  
                      // adjust ticksBehind so that it is not greater-than catchup
                      if (ticksBehind > catchup) {

--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -17,6 +17,21 @@
      // Paper start - improve tick loop
      public final ca.spottedleaf.moonrise.common.time.TickData tickTimes1s  = new ca.spottedleaf.moonrise.common.time.TickData(java.util.concurrent.TimeUnit.SECONDS.toNanos(1L));
      public final ca.spottedleaf.moonrise.common.time.TickData tickTimes5s  = new ca.spottedleaf.moonrise.common.time.TickData(java.util.concurrent.TimeUnit.SECONDS.toNanos(5L));
+@@ -358,6 +_,14 @@
+         }
+     }
+ 
++    // Purpur start - Lagging threshold
++    public double getTPS5s() {
++        synchronized (this.statsLock) {
++            return getTPS(this.tickTimes5s, this.tickRateManager().nanosecondsPerTick());
++        }
++    }
++    // Purpur end - Lagging threshold
++
+     public @Nullable ca.spottedleaf.moonrise.common.time.TickData.MSPTData getMSPTData5s() {
+         synchronized (this.statsLock) {
+             if (this.msptData5s == null) {
 @@ -370,6 +_,7 @@
      public double[] computeTPS() {
          final long interval = this.tickRateManager().nanosecondsPerTick();
@@ -67,7 +82,7 @@
              while (this.running) {
                  final long tickStart = System.nanoTime(); // Paper - improve tick loop
                  long l; // Paper - improve tick loop - diff on change, expect this to be tick interval
-@@ -1306,8 +_,13 @@
+@@ -1306,8 +_,10 @@
                      final long ticksBehind = Math.max(1L, this.tickSchedule.getPeriodsAhead(l, tickStart));
                      final long catchup = (long)Math.max(
                          1,
@@ -75,10 +90,7 @@
 +                        org.purpurmc.purpur.PurpurConfig.tpsCatchup ? 5 : 1 //ConfigHolder.getConfig().tickLoop.catchupTicks.getOrDefault(MoonriseConfig.TickLoop.DEFAULT_CATCHUP_TICKS).intValue() // Purpur - Configurable TPS Catchup
                      );
 +
-+                    synchronized (this.statsLock) {
-+                        lagging = getTPS(this.tickTimes5s, this.tickRateManager().nanosecondsPerTick()) < org.purpurmc.purpur.PurpurConfig.laggingThreshold; // Purpur - Lagging threshold
-+
-+                    }
++                    lagging = getTPS5s() < org.purpurmc.purpur.PurpurConfig.laggingThreshold; // Purpur - Lagging threshold
  
                      // adjust ticksBehind so that it is not greater-than catchup
                      if (ticksBehind > catchup) {

--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -75,7 +75,7 @@
 +                        org.purpurmc.purpur.PurpurConfig.tpsCatchup ? 5 : 1 //ConfigHolder.getConfig().tickLoop.catchupTicks.getOrDefault(MoonriseConfig.TickLoop.DEFAULT_CATCHUP_TICKS).intValue() // Purpur - Configurable TPS Catchup
                      );
 +
-+                    lagging = getTPS()[0] < org.purpurmc.purpur.PurpurConfig.laggingThreshold; // Purpur - Lagging threshold
++                    lagging = getTPS(this.tickTimes5s, this.tickRateManager().nanosecondsPerTick()) < org.purpurmc.purpur.PurpurConfig.laggingThreshold; // Purpur - Lagging threshold
  
                      // adjust ticksBehind so that it is not greater-than catchup
                      if (ticksBehind > catchup) {

--- a/purpur-server/src/main/java/org/purpurmc/purpur/task/TPSBarTask.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/task/TPSBarTask.java
@@ -4,6 +4,7 @@ import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.minecraft.server.MinecraftServer;
 import org.purpurmc.purpur.PurpurConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -44,7 +45,7 @@ public class TPSBarTask extends BossBarTask {
         }
         tick = 0;
 
-        this.tps = Math.max(Math.min(Bukkit.getTPS()[0], 20.0D), 0.0D);
+        this.tps = Math.max(Math.min(MinecraftServer.getServer().getTPS5s(), 20.0D), 0.0D);
         this.mspt = Bukkit.getAverageTickTime();
 
         super.run();


### PR DESCRIPTION
Calling `getTPS()` will cause to calculate the tps 4 times (Since it uses `computeTPS()` which calls `getTPS(params..)` 4 times to return a double[]).

- Since we only need the first value, then we'll avoid the `getTPS()` and instead calculate only that value (Instead of 4).

- i also added it to the tps bar

Spark: https://spark.lucko.me/v552TtyFyC

Spark with me inside the world and tpsbar enabled: https://spark.lucko.me/vUA85z47lI

I think it can a permanent or temporary fix based on paper changes (idk lol)