### PR TITLE
Fix fireball mobgriefing override not working

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -201,7 +201,7 @@
              case NONE -> Explosion.BlockInteraction.KEEP;
              case BLOCK -> this.getDestroyType(GameRules.RULE_BLOCK_EXPLOSION_DROP_DECAY);
 -            case MOB -> this.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)
-+            case MOB -> (source instanceof net.minecraft.world.entity.projectile.LargeFireball && this.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, this.purpurConfig.fireballsMobGriefingOverride)) || this.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING) // Purpur - Add mobGriefing override to everything affected
++            case MOB -> ((source instanceof net.minecraft.world.entity.projectile.LargeFireball) ? this.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, this.purpurConfig.fireballsMobGriefingOverride) : this.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) // Purpur - Add mobGriefing override to everything affected
                  ? this.getDestroyType(GameRules.RULE_MOB_EXPLOSION_DROP_DECAY)
                  : Explosion.BlockInteraction.KEEP;
              case TNT -> this.getDestroyType(GameRules.RULE_TNT_EXPLOSION_DROP_DECAY);


### PR DESCRIPTION
The existing does so if the game rule `this.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)` is true, then the whole condition is true, which is why blocks still get destroyed even when the config is set to **false**.

The fix is to check if the **source** is a `fireball`, it will check the purpur config in `this.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING, this.purpurConfig.fireballsMobGriefingOverride)`.

Else it will use the default one `this.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)`.

This is tested with every value and it works.

Fixes #1722 