### PR TITLE
Add "/afk" command.

### DIFF
--- a/purpur-server/minecraft-patches/features/0021-Add-afk-command.patch
+++ b/purpur-server/minecraft-patches/features/0021-Add-afk-command.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mickey42302 <bgoodwin423@gmail.com>
+Date: Sun, 23 Nov 2025 22:23:35 -0500
+Subject: [PATCH] Add afk command
+
+
+diff --git a/net/minecraft/commands/Commands.java b/net/minecraft/commands/Commands.java
+index 9aa09e11032f539952edeeed119f7705c330db0a..5c70ceafca093175a98eca3340bd4d1a6527fb59 100644
+--- a/net/minecraft/commands/Commands.java
++++ b/net/minecraft/commands/Commands.java
+@@ -295,6 +295,7 @@ public class Commands {
+             org.purpurmc.purpur.command.CompassCommand.register(this.dispatcher); // Purpur - Add compass command
+             org.purpurmc.purpur.command.RamBarCommand.register(this.dispatcher); // Purpur - Add rambar command
+             org.purpurmc.purpur.command.RamCommand.register(this.dispatcher); // Purpur - Add ram command
++            org.purpurmc.purpur.command.AFKCommand.register(this.dispatcher); // Purpur - Add afk command
+         }
+ 
+         if (selection.includeIntegrated) {

--- a/purpur-server/src/main/java/org/purpurmc/purpur/command/AFKCommand.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/command/AFKCommand.java
@@ -1,0 +1,33 @@
+package org.purpurmc.purpur.command;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public class AFKCommand {
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("afk")
+            .requires((listener) -> listener.hasPermission(2, "bukkit.command.afk"))
+            .executes((context) -> execute(context.getSource(), Collections.singleton(context.getSource().getPlayerOrException())))
+            .then(Commands.argument("targets", EntityArgument.players())
+                .requires(listener -> listener.hasPermission(2, "bukkit.command.afk.other"))
+                .executes((context) -> execute(context.getSource(), EntityArgument.getPlayers(context, "targets")))
+            )
+        );
+    }
+
+    private static int execute(CommandSourceStack sender, Collection<ServerPlayer> targets) {
+        for (ServerPlayer player : targets) {
+            boolean afk = player.isAfk();
+
+            if (afk) player.setAfk(true);
+        }
+
+        return targets.size();
+    }
+}


### PR DESCRIPTION
I would like to suggest the addition of an "/afk" command. This is designed to be used with the AFK system that is built into Purpur.

Permission nodes: "bukkit.command.afk", "bukkit.command.afk.other"