### PR TITLE
Fix copper golems not able to open barrels

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
@@ -15,8 +15,8 @@
      private boolean isTargetBlocked(Level level, TransportItemsBetweenContainers.TransportItemTarget target) {
 -        return ChestBlock.isChestBlockedAt(level, target.pos);
 +        // Purpur start - copper golem can place items in barrels or shulkers option
-+        boolean isBarrelBlocked = level.purpurConfig.copperGolemCanOpenBarrel && target.state.is(net.minecraft.world.level.block.Blocks.BARREL);
-+        boolean isShulkerBlocked = level.purpurConfig.copperGolemCanOpenShulker && target.blockEntity instanceof net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity shulkerBoxBlockEntity && !net.minecraft.world.level.block.ShulkerBoxBlock.canOpen(target.state, level, target.pos, shulkerBoxBlockEntity);
++        boolean isBarrelBlocked = !level.purpurConfig.copperGolemCanOpenBarrel && target.state.is(net.minecraft.world.level.block.Blocks.BARREL);
++        boolean isShulkerBlocked = !level.purpurConfig.copperGolemCanOpenShulker && target.blockEntity instanceof net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity shulkerBoxBlockEntity && !net.minecraft.world.level.block.ShulkerBoxBlock.canOpen(target.state, level, target.pos, shulkerBoxBlockEntity);
 +        return isBarrelBlocked || isShulkerBlocked || net.minecraft.world.level.block.ChestBlock.isChestBlockedAt(level, target.pos);
 +        // Purpur end - copper golem can place items in barrels or shulkers option
      }


### PR DESCRIPTION
The issue here was that `isBarrelBlocked` and also `isShulkerBlocked` were not handled correctly.

What I mean, if `level.purpurConfig.copperGolemCanOpenBarrel` is true, here it incorrectly means the barrel is blocked.

So adding `!` to both of these mean if `level.purpurConfig.copperGolemCanOpenBarrel` is true, then `isBarrelBlocked` is false, so the golem can open it.

(Same with shulker boxes, even though they also worked before, just because `!canOpen` is mostly false, so if we can make that true, they won't work either)

This is pretty well tested and it works fine as always.

Fixes #1730 