### PR TITLE
Fix stonecutter doing damage even when trapdoor is on top

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/StonecutterBlock.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/StonecutterBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/StonecutterBlock.java
 +++ b/net/minecraft/world/level/block/StonecutterBlock.java
-@@ -93,4 +_,14 @@
+@@ -93,4 +_,18 @@
      protected boolean isPathfindable(BlockState state, PathComputationType pathComputationType) {
          return false;
      }
@@ -9,7 +9,11 @@
 +    @Override
 +    public void stepOn(Level level, BlockPos pos, BlockState state, net.minecraft.world.entity.Entity entity) {
 +        if (level.purpurConfig.stonecutterDamage > 0.0F && entity instanceof net.minecraft.world.entity.LivingEntity) {
-+            entity.hurtServer((net.minecraft.server.level.ServerLevel) level, entity.damageSources().stonecutter().eventBlockDamager(level, pos), level.purpurConfig.stonecutterDamage);
++            BlockPos blockAbove = pos.above();
++            BlockState blockAboveState = level.getBlockState(blockAbove);
++            if (!(blockAboveState.getBlock() instanceof TrapDoorBlock && !blockAboveState.getValue(net.minecraft.world.level.block.TrapDoorBlock.OPEN))) {
++                entity.hurtServer((net.minecraft.server.level.ServerLevel) level, entity.damageSources().stonecutter().eventBlockDamager(level, pos), level.purpurConfig.stonecutterDamage);
++            }
 +        }
 +        super.stepOn(level, pos, state, entity);
 +    }


### PR DESCRIPTION
I just added a check for the block on top if it's an open trapdoor or not.

Tested with various trapdoors and it works well.

Fixes #1720 