### PR TITLE
Fix stonecutter damage not checking for trapdoors on top

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/StonecutterBlock.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/StonecutterBlock.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/block/StonecutterBlock.java
 +++ b/net/minecraft/world/level/block/StonecutterBlock.java
-@@ -93,4 +_,14 @@
+@@ -93,4 +_,17 @@
      protected boolean isPathfindable(BlockState state, PathComputationType pathComputationType) {
          return false;
      }
@@ -9,7 +9,10 @@
 +    @Override
 +    public void stepOn(Level level, BlockPos pos, BlockState state, net.minecraft.world.entity.Entity entity) {
 +        if (level.purpurConfig.stonecutterDamage > 0.0F && entity instanceof net.minecraft.world.entity.LivingEntity) {
-+            entity.hurtServer((net.minecraft.server.level.ServerLevel) level, entity.damageSources().stonecutter().eventBlockDamager(level, pos), level.purpurConfig.stonecutterDamage);
++            BlockState stateAbove = level.getBlockState(pos.above());
++            if (!(stateAbove.getBlock() instanceof TrapDoorBlock) || stateAbove.getValue(net.minecraft.world.level.block.TrapDoorBlock.OPEN)) {
++                entity.hurtServer((net.minecraft.server.level.ServerLevel) level, entity.damageSources().stonecutter().eventBlockDamager(level, pos), level.purpurConfig.stonecutterDamage);
++            }
 +        }
 +        super.stepOn(level, pos, state, entity);
 +    }


### PR DESCRIPTION
This adds a check to see if there is an open trapdoor on top of the **stonecutter** when **stonecutter damage** is enabled.

If the trapdoor is closed, it won't damage you.

I tested it with all trapdoors (open and close) and without trapdoors and it works great!

Fixes #1720 