### PR TITLE
Fix Copper Golems can't open barrels if there is a block on top

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
@@ -17,7 +17,7 @@
 +        // Purpur start - copper golem can place items in barrels or shulkers option
 +        boolean isBarrelBlocked = !level.purpurConfig.copperGolemCanOpenBarrel && target.state.is(net.minecraft.world.level.block.Blocks.BARREL);
 +        boolean isShulkerBlocked = !level.purpurConfig.copperGolemCanOpenShulker && target.blockEntity instanceof net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity shulkerBoxBlockEntity && !net.minecraft.world.level.block.ShulkerBoxBlock.canOpen(target.state, level, target.pos, shulkerBoxBlockEntity);
-+        return isBarrelBlocked || isShulkerBlocked || net.minecraft.world.level.block.ChestBlock.isChestBlockedAt(level, target.pos);
++        return target.state.is(net.minecraft.world.level.block.Blocks.BARREL) ? isBarrelBlocked : isShulkerBlocked || net.minecraft.world.level.block.ChestBlock.isChestBlockedAt(level, target.pos);
 +        // Purpur end - copper golem can place items in barrels or shulkers option
      }
  


### PR DESCRIPTION
Barrels should be able to open even if there a block on top.

The fix would be to check if there is a barrel (So that we won't check if there a block on top)

Fixes #1735 