### PR TITLE
Make beacons not apply effects when covered or base destroyed while using "allow-effects-with-tinted-glass"

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BeaconBlockEntity.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BeaconBlockEntity.java.patch
@@ -25,14 +25,23 @@
          if (blockEntity.lastCheckY < y) {
              blockPos = pos;
              blockEntity.checkingBeamSections = Lists.newArrayList();
-@@ -195,6 +_,7 @@
+@@ -195,11 +_,15 @@
                      }
                  }
              } else {
+-                if (section == null || blockState.getLightBlock() >= 15 && !blockState.is(Blocks.BEDROCK)) {
 +                if (level.purpurConfig.beaconAllowEffectsWithTintedGlass && blockState.getBlock().equals(Blocks.TINTED_GLASS)) {isTintedGlass = true;} // Purpur - allow beacon effects when covered by tinted glass
-                 if (section == null || blockState.getLightBlock() >= 15 && !blockState.is(Blocks.BEDROCK)) {
++                // Purpur start - fix effects being applied when tinted glass is covered
++                if (section == null || blockState.getLightBlock() >= 15 && !blockState.is(Blocks.BEDROCK) && !blockState.getBlock().equals(Blocks.TINTED_GLASS)) {
                      blockEntity.checkingBeamSections.clear();
                      blockEntity.lastCheckY = height;
++                    isTintedGlass = false;
+                     break;
+                 }
++                // Purpur end - fix effects being applied when tinted glass is covered
+ 
+                 section.increaseHeight();
+             }
 @@ -210,11 +_,11 @@
  
          int i = blockEntity.levels; final int originalLevels = i; // Paper - OBFHELPER

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BeaconBlockEntity.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BeaconBlockEntity.java.patch
@@ -32,7 +32,7 @@
 -                if (section == null || blockState.getLightBlock() >= 15 && !blockState.is(Blocks.BEDROCK)) {
 +                if (level.purpurConfig.beaconAllowEffectsWithTintedGlass && blockState.getBlock().equals(Blocks.TINTED_GLASS)) {isTintedGlass = true;} // Purpur - allow beacon effects when covered by tinted glass
 +                // Purpur start - fix effects being applied when tinted glass is covered
-+                if (section == null || blockState.getLightBlock() >= 15 && !blockState.is(Blocks.BEDROCK) && !blockState.getBlock().equals(Blocks.TINTED_GLASS)) {
++                if (section == null || blockState.getLightBlock() >= 15 && !blockState.is(Blocks.BEDROCK) && !(blockState.getBlock().equals(Blocks.TINTED_GLASS) && level.purpurConfig.beaconAllowEffectsWithTintedGlass)) {
                      blockEntity.checkingBeamSections.clear();
                      blockEntity.lastCheckY = height;
 +                    isTintedGlass = false;

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BeaconBlockEntity.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BeaconBlockEntity.java.patch
@@ -33,7 +33,12 @@
                  if (section == null || blockState.getLightBlock() >= 15 && !blockState.is(Blocks.BEDROCK)) {
                      blockEntity.checkingBeamSections.clear();
                      blockEntity.lastCheckY = height;
-@@ -214,7 +_,7 @@
+@@ -210,11 +_,11 @@
+ 
+         int i = blockEntity.levels; final int originalLevels = i; // Paper - OBFHELPER
+         if (level.getGameTime() % 80L == 0L) {
+-            if (!blockEntity.beamSections.isEmpty()) {
++            if (!blockEntity.beamSections.isEmpty() || (level.purpurConfig.beaconAllowEffectsWithTintedGlass && isTintedGlass)) { // Purpur - fix beacon effects persisting with broken base while tinted glass is used
                  blockEntity.levels = updateBase(level, x, y, z);
              }
  


### PR DESCRIPTION
Resolves #1741 which reported unexpected beacon behavior while using tinted glass and "allow-effects-with-tinted-glass".

The problem with the base not updating was that with tinted glass being an opaque block it would still cause `blockEntity.beamSections` to be empty causing the below code to not check if the base of the beacon has changed.
```java
if (!blockEntity.beamSections.isEmpty()) { 
    blockEntity.levels = updateBase(level, x, y, z);
}
```

The problem with the opaque block check failing above tinted glass was that `isTintedGlass` served as an override to the condition before applying the effects. To fix it I just set `isTintedGlass` to false if the block is opaque and not tinted glass.