### PR TITLE
Fix hardcoded obsidian check when igniting a portal

### DIFF
--- a/build-data/purpur.at
+++ b/build-data/purpur.at
@@ -7,5 +7,6 @@ public net.minecraft.world.entity.monster.Shulker MAX_SCALE
 public net.minecraft.world.entity.player.Player canGlide()Z
 public net.minecraft.world.level.block.ShulkerBoxBlock canOpen(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/world/level/Level;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/entity/ShulkerBoxBlockEntity;)Z
 public net.minecraft.world.level.block.entity.FuelValues values
+public net.minecraft.world.level.portal.PortalShape FRAME
 public-f net.minecraft.world.entity.EntityType dimensions
 public-f net.minecraft.world.level.block.state.BlockBehaviour explosionResistance

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/BaseFireBlock.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/block/BaseFireBlock.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/block/BaseFireBlock.java
++++ b/net/minecraft/world/level/block/BaseFireBlock.java
+@@ -208,7 +_,7 @@
+             boolean flag = false;
+ 
+             for (Direction direction1 : Direction.values()) {
+-                if (level.getBlockState(mutableBlockPos.set(pos).move(direction1)).is(Blocks.OBSIDIAN)) {
++                if (PortalShape.FRAME.test(level.getBlockState(mutableBlockPos.set(pos).move(direction1)), level, mutableBlockPos)) { // Purpur - Crying obsidian valid for portal frames
+                     flag = true;
+                     break;
+                 }

--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/level/portal/PortalShape.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/level/portal/PortalShape.java.patch
@@ -4,8 +4,8 @@
      public static final int MAX_WIDTH = 21;
      private static final int MIN_HEIGHT = 3;
      public static final int MAX_HEIGHT = 21;
--    private static final BlockBehaviour.StatePredicate FRAME = (state, level, pos) -> state.is(Blocks.OBSIDIAN);
-+    private static final BlockBehaviour.StatePredicate FRAME = (state, level, pos) -> state.is(Blocks.OBSIDIAN) || (org.purpurmc.purpur.PurpurConfig.cryingObsidianValidForPortalFrame && state.is(Blocks.CRYING_OBSIDIAN)); // Purpur - Crying obsidian valid for portal frames
+-    public static final BlockBehaviour.StatePredicate FRAME = (state, level, pos) -> state.is(Blocks.OBSIDIAN);
++    public static final BlockBehaviour.StatePredicate FRAME = (state, level, pos) -> state.is(Blocks.OBSIDIAN) || (org.purpurmc.purpur.PurpurConfig.cryingObsidianValidForPortalFrame && state.is(Blocks.CRYING_OBSIDIAN)); // Purpur - Crying obsidian valid for portal frames
      private static final float SAFE_TRAVEL_MAX_ENTITY_XY = 4.0F;
      private static final double SAFE_TRAVEL_MAX_VERTICAL_DELTA = 1.0;
      private final Direction.Axis axis;


### PR DESCRIPTION
BaseFireBlock.isPortal currently has a hardcoded check for a neighbouring Obsidian block, which prevents portals including Crying Obsidian from being ignited if the targeted block has no neighbouring Obsidian. 

This PR replaces the check with testing against PortalShape.FRAME which respects the Crying Obsidian setting.

Before:
https://github.com/user-attachments/assets/fa2083be-35aa-484c-afca-814483aa1de2

After:
https://github.com/user-attachments/assets/94069a85-d332-4c1d-831c-8b67b1f18b92