### PR TITLE
fix copper golems putting shulkers into shulkers while using "can-open-shulker"

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/TransportItemsBetweenContainers.java.patch
@@ -9,6 +9,20 @@
                          double d1 = chestBlockEntity.getBlockPos().distToCenterSqr(mob.position());
                          if (d1 < d) {
                              TransportItemsBetweenContainers.TransportItemTarget transportItemTarget1 = this.isTargetValidToPick(
+@@ -324,6 +_,13 @@
+                     && !this.isContainerLocked(transportItemTarget)
+                     && org.bukkit.craftbukkit.event.CraftEventFactory.callTransporterValidateTarget(mob, level, transportItemTarget.pos);
+                     // Paper end - ItemTransportingEntityValidateTargetEvent
++                // Purpur start - fix copper golems putting shulkers into shulkers
++                if (level.purpurConfig.copperGolemCanOpenShulker) {
++                    net.minecraft.world.level.block.Block heldBlock = net.minecraft.world.level.block.Block.byItem(mob.getMainHandItem().getItem());
++                    boolean isHoldingShulker = heldBlock instanceof net.minecraft.world.level.block.ShulkerBoxBlock;
++                    if (transportItemTarget.blockEntity instanceof net.minecraft.world.level.block.entity.ShulkerBoxBlockEntity && isHoldingShulker) return null;
++                }
++                // Purpur end - fix copper golems putting shulkers into shulkers
+                 return flag1 ? transportItemTarget : null;
+             }
+         }
 @@ -369,7 +_,11 @@
      }
  


### PR DESCRIPTION
Resolves #1752 by adding a check to see if the held item and the targeted block is a shulker.