### PR TITLE
Fix multiple bugs for 26.1 release readiness

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -38,7 +38,7 @@
      // Paper start - EAR 2
      public final boolean defaultActivationState;
      public long activatedTick = Integer.MIN_VALUE;
-@@ -443,10 +_,22 @@
+@@ -443,10 +_,26 @@
      }
      // Paper end
  
@@ -52,7 +52,11 @@
          this.type = type;
          this.level = level;
          this.dimensions = type.getDimensions();
-+        this.maxAirTicks = level == null ? Entity.TOTAL_AIR_SUPPLY : this.level.purpurConfig.drowningAirTicks; // Purpur - Drowning Settings
++        // Purpur start - Drowning Settings; only override entities with default air supply to fix axolotl/dolphin/nautilus suffocation
++        if (level != null && this.getDefaultMaxAirSupply() == Entity.TOTAL_AIR_SUPPLY) {
++            this.maxAirTicks = this.level.purpurConfig.drowningAirTicks;
++        }
++        // Purpur end - Drowning Settings
 +        // Purpur start - Add toggle for RNG manipulation
 +        this.random = level == null || level.purpurConfig.entitySharedRandom ? SHARED_RANDOM : RandomSource.create();
 +        this.uuid = Mth.createInsecureUUID(this.random);

--- a/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/PurpurConfig.java
@@ -62,7 +62,8 @@ public class PurpurConfig {
         config = new YamlConfiguration();
         try {
             config.load(CONFIG_FILE);
-        } catch (IOException ignore) {
+        } catch (IOException ex) {
+            Bukkit.getLogger().log(Level.SEVERE, "Could not load purpur.yml", ex);
         } catch (InvalidConfigurationException ex) {
             Bukkit.getLogger().log(Level.SEVERE, "Could not load purpur.yml, please correct your syntax errors", ex);
             throw Throwables.propagate(ex);

--- a/purpur-server/src/main/java/org/purpurmc/purpur/controller/FlyingMoveControllerWASD.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/controller/FlyingMoveControllerWASD.java
@@ -53,8 +53,8 @@ public class FlyingMoveControllerWASD extends MoveControllerWASD {
         setSpeedModifier(entity.getAttributeValue(Attributes.MOVEMENT_SPEED));
         float speed = (float) getSpeedModifier();
 
-        if (entity.onGround) {
-            speed *= groundSpeedModifier; // TODO = fix this!
+        if (entity.onGround()) {
+            speed *= groundSpeedModifier;
         } else {
             speed *= flyingSpeedModifier;
         }

--- a/purpur-server/src/main/java/org/purpurmc/purpur/controller/FlyingWithSpacebarMoveControllerWASD.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/controller/FlyingWithSpacebarMoveControllerWASD.java
@@ -30,7 +30,7 @@ public class FlyingWithSpacebarMoveControllerWASD extends FlyingMoveControllerWA
 
         float speed = (float) entity.getAttributeValue(Attributes.MOVEMENT_SPEED);
 
-        if (entity.onGround) {
+        if (entity.onGround()) {
             speed *= groundSpeedModifier;
         }
 

--- a/purpur-server/src/main/java/org/purpurmc/purpur/controller/LookControllerWASD.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/controller/LookControllerWASD.java
@@ -48,7 +48,7 @@ public class LookControllerWASD extends LookControl {
             (short) 0, (short) 0, (short) 0,
             (byte) Mth.floor(entity.getYRot() * 256.0F / 360.0F),
             (byte) Mth.floor(entity.getXRot() * 256.0F / 360.0F),
-            entity.onGround
+            entity.onGround()
         );
         ((ServerLevel) entity.level()).getChunkSource().sendToTrackingPlayers(entity, entityPacket);
     }

--- a/purpur-server/src/main/java/org/purpurmc/purpur/controller/MoveControllerWASD.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/controller/MoveControllerWASD.java
@@ -69,7 +69,7 @@ public class MoveControllerWASD extends MoveControl {
 
         ((LookControllerWASD) entity.getLookControl()).setOffsets(yawOffset, 0);
 
-        if (lastClientInput.jump() && spacebarEvent(entity) && !entity.onSpacebar() && entity.onGround) {
+        if (lastClientInput.jump() && spacebarEvent(entity) && !entity.onSpacebar() && entity.onGround()) {
             entity.jumpFromGround();
         }
 

--- a/purpur-server/src/main/java/org/purpurmc/purpur/controller/WaterMoveControllerWASD.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/controller/WaterMoveControllerWASD.java
@@ -36,7 +36,7 @@ public class WaterMoveControllerWASD extends MoveControllerWASD {
             vertical = 0.0F;
         }
 
-        if (rider.jumping && spacebarEvent(entity)) {
+        if (lastClientInput.jump() && spacebarEvent(entity)) {
             entity.onSpacebar();
         }
 

--- a/purpur-server/src/main/java/org/purpurmc/purpur/entity/PurpurStoredBee.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/entity/PurpurStoredBee.java
@@ -106,11 +106,12 @@ public class PurpurStoredBee implements StoredEntity<Bee> {
 
     @Override
     public void update() {
-        handle.occupant.entityData().copyTagWithEntityId().put("BukkitValues", this.persistentDataContainer.toTagCompound());
-        if(customName == null) {
-            handle.occupant.entityData().copyTagWithEntityId().remove("CustomName");
+        CompoundTag tag = handle.occupant.entityData().getUnsafe();
+        tag.put("BukkitValues", this.persistentDataContainer.toTagCompound());
+        if (customName == null) {
+            tag.remove("CustomName");
         } else {
-            handle.occupant.entityData().copyTagWithEntityId().putString("CustomName", CraftChatMessage.toJSON(PaperAdventure.asVanilla(customName)));
+            tag.putString("CustomName", CraftChatMessage.toJSON(PaperAdventure.asVanilla(customName)));
         }
     }
 }

--- a/purpur-server/src/main/java/org/purpurmc/purpur/entity/projectile/DolphinSpit.java
+++ b/purpur-server/src/main/java/org/purpurmc/purpur/entity/projectile/DolphinSpit.java
@@ -87,9 +87,11 @@ public class DolphinSpit extends LlamaSpit {
 
     @Override
     protected void onHitEntity(EntityHitResult entityHitResult) {
-        Entity shooter = this.getOwner();
-        if (shooter instanceof LivingEntity) {
-            entityHitResult.getEntity().hurt(entityHitResult.getEntity().damageSources().mobProjectile(this, (LivingEntity) shooter), level().purpurConfig.dolphinSpitDamage);
+        if (this.level() instanceof ServerLevel serverLevel) {
+            Entity shooter = this.getOwner();
+            if (shooter instanceof LivingEntity livingShooter) {
+                entityHitResult.getEntity().hurtServer(serverLevel, entityHitResult.getEntity().damageSources().mobProjectile(this, livingShooter), serverLevel.purpurConfig.dolphinSpitDamage);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- **Fix drowning air ticks overriding entity-specific values** — the `drowningAirTicks` config was blindly applied to all entities, causing axolotls to suffocate in 15 seconds instead of 5 minutes. Now only overrides entities with default air supply. Fixes #1763
- **Fix stored bee data modifications being silently discarded** — `update()` was calling `copyTagWithEntityId()` three times, writing to throwaway copies. Uses `getUnsafe()` to modify the actual underlying tag.
- **Fix DolphinSpit using wrong damage method** — `onHitEntity` was calling `hurt()` instead of `hurtServer()` with a `ServerLevel` check, matching the pattern used by `PhantomFlames`.
- **Fix WaterMoveControllerWASD using wrong jump input source** — was reading `rider.jumping` field directly instead of `getLastClientInput().jump()` like every other controller.
- **Use `onGround()` method instead of deprecated field in controllers** — updated `FlyingMoveControllerWASD`, `FlyingWithSpacebarMoveControllerWASD`, `MoveControllerWASD`, and `LookControllerWASD`.
- **Log IOException instead of silently swallowing it in PurpurConfig** — filesystem errors when loading `purpur.yml` are now logged instead of ignored.

## Test plan

- [ ] Verify axolotls survive out of water for ~5 minutes (6000 ticks) with default config
- [ ] Verify dolphins/nautiluses retain their custom air supply values
- [ ] Verify `drowningAirTicks` config still works for normal entities
- [ ] Place bees in a beehive, modify stored bee custom name/persistent data, verify changes persist
- [ ] Test dolphin spit damage on entities while riding a dolphin
- [ ] Test ridable water mobs (spacebar/jump input)
- [ ] Test ridable flying mobs (ground vs air speed)
- [ ] Corrupt or remove purpur.yml and verify error is logged on startup