### PR TITLE
Update LlamaJoinCaravanEvent arguments

### DIFF
--- a/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/animal/equine/Llama.java.patch
+++ b/purpur-server/minecraft-patches/sources/net/minecraft/world/entity/animal/equine/Llama.java.patch
@@ -36,7 +36,7 @@
      }
  
      public void joinCaravan(final Llama tail) {
-+        if (!this.level().purpurConfig.llamaJoinCaravans || !shouldJoinCaravan || !new org.purpurmc.purpur.event.entity.LlamaJoinCaravanEvent((org.bukkit.entity.Llama) getBukkitEntity(), (org.bukkit.entity.Llama) caravanHead.getBukkitEntity()).callEvent()) return; // Purpur - Llama API // Purpur - Config to disable Llama caravans
++        if (!this.level().purpurConfig.llamaJoinCaravans || !shouldJoinCaravan || !new org.purpurmc.purpur.event.entity.LlamaJoinCaravanEvent((org.bukkit.entity.Llama) getBukkitEntity(), (org.bukkit.entity.Llama) tail.getBukkitEntity()).callEvent()) return; // Purpur - Llama API // Purpur - Config to disable Llama caravans
          this.caravanHead = tail;
          this.caravanHead.caravanTail = this;
      }


### PR DESCRIPTION
`caravanHead` was renamed to `tail` in 26.1

Without the fix in this PR, this exception is thrown:
```
[21:13:07 ERROR]: Entity threw exception at world:197.0565253594869,71.0,352.56243817392556
java.lang.NullPointerException: Cannot invoke "net.minecraft.world.entity.animal.equine.Llama.getBukkitEntity()" because "this.caravanHead" is null
	at net.minecraft.world.entity.animal.equine.Llama.joinCaravan(Llama.java:492)
```